### PR TITLE
Require prod env file and auto-build before PM2 start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,11 +25,47 @@
 *.pem
 
 # debug
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
+.pnpm-debug.log*
 
+# env files (can opt-in for committing if needed)
+.env*
+logs/spotify_tokens.json
+
+# vercel
+.vercel
+
+# typescript
 # env files (can opt-in for committing if needed)
 .env*
 logs/spotify_tokens.json
@@ -82,6 +118,28 @@ next-env.d.ts
 .gemini/settings.json
 .vscode/*
 .github/*
+
+npm_run_dev.log
+
+# Ignore generated server JS (keep TypeScript source canonical)
+server.js
+/dist
+logs/*add
+~/.config
+running_notes.md.backup
+
+# Test results and recordings
+test-results/
+playwright-report/
+test-recordings/
+tests/playwright/screenshots/
+tests/playwright/*-actual.png
+tests/playwright/*-diff.png
+next-env.d.ts
+
+.gemini/*
+.gemini/settings.json
+.vscode/*
 
 *.js
 *.js.map

--- a/README.md
+++ b/README.md
@@ -48,15 +48,19 @@ The server will start with:
 ### Production Build
 
 ```bash
-# Build TypeScript server and Next.js app
+# Build TypeScript server and Next.js app (optional; npm run start auto-builds if needed)
 npm run build
 
-# Start with PM2
+# Start with PM2 (requires .env.production)
 npm run start
 
 # View logs
 npm run pm2:logs
 ```
+
+`npm run start` now checks for `.env.production` and verifies build artifacts. When `.next/` or
+`dist/server.mjs` are missing it runs `npm run build` before launching PM2, so manual builds are
+only required when you want to inspect the output ahead of time.
 
 ## Project Structure
 
@@ -89,7 +93,6 @@ npm run pm2:logs
 npm run dev                 # Start dev server (Next.js + WebSocket + services)
 npm run build               # Build for production
 npm run start               # Start production server with PM2
-npm run deploy              # Full deployment script (build + PM2 start)
 npm run lint                # Run ESLint
 npm run lint:fix            # Auto-fix lint issues
 npm run format              # Format codebase with Prettier
@@ -106,6 +109,9 @@ npm run verify:spotify      # Automated Spotify integration health check
 npm run kill-all            # Force-stop lingering Node/Chrome processes
 npm run mcp:chrome-devtools # Start Chrome DevTools MCP (isolated profile)
 ```
+
+For production, create `.env.production` alongside `.env.local`. The start script refuses to run
+without it so sensitive secrets are always loaded before PM2 boots.
 
 ### Navigation Shortcuts
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -14,7 +14,7 @@ This guide provides solutions for common issues encountered during development a
 
 ### Deployment Steps
 
-1.  **Build and Deploy**: Run `./deploy.sh` to build the application and start it with PM2.
+1.  **Build and Start**: Ensure `.env.production` exists, then run `npm run start`. The script verifies build artifacts and kicks off `npm run build` automatically when needed.
 2.  **Nginx Configuration**: Ensure Nginx is configured to proxy requests to port 3000 with WebSocket support.
 3.  **SSL Configuration**: Ensure SSL certificates are configured and renewed as needed.
 4.  **PM2 Startup**: Configure PM2 to start on boot with `pm2 startup`.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "build": "npm run build:server && next build",
     "build:server": "tsc -p tsconfig.build.json && cp dist/server.js dist/server.mjs",
     "start": "pm2 start ecosystem.config.cjs --env production",
-    "deploy": "./deploy.sh",
     "pm2:logs": "pm2 logs hrm-server",
     "pm2:stop": "pm2 stop hrm-server",
     "pm2:restart": "pm2 restart hrm-server",

--- a/start-production.sh
+++ b/start-production.sh
@@ -1,9 +1,25 @@
 #!/bin/bash
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
 export NODE_ENV=production
+
+if [ ! -f ".env.production" ]; then
+  echo "[start-production] Error: .env.production not found. Create it before running npm start." >&2
+  exit 1
+fi
 
 # Export all variables defined in .env.production to child processes
 set -a
 source .env.production
 set +a
+
+if [ ! -f "dist/server.mjs" ] || [ ! -d ".next" ]; then
+  echo "[start-production] Build artifacts missing. Running npm run build..."
+  npm run build
+fi
 
 exec node dist/server.mjs


### PR DESCRIPTION
## Summary
- harden start-production.sh to require .env.production and cd into the repo before boot
- auto-run npm run build when dist/server.mjs or .next artifacts are missing
- remove the obsolete deploy script hook from package.json
- update README, TROUBLESHOOTING, and .github/copilot-instructions to reflect the new workflow

## Testing
- npm run lint
- ./start-production.sh with and without prebuilt artifacts
