### PR TITLE
fix: Update kill-all script to only target isolated Chrome browsers

### DIFF
--- a/scripts/kill-all.sh
+++ b/scripts/kill-all.sh
@@ -24,9 +24,21 @@ pkill -f "chromium" 2>/dev/null || true
 echo "Killing Chrome DevTools MCP..."
 pkill -f "chrome-devtools-mcp" 2>/dev/null || true
 
-# Kill any remaining Chrome processes
-echo "Killing Chrome processes..."
-pkill -f "chrome" 2>/dev/null || true
+# Kill only isolated Chrome browsers on 127.0.0.1:9222 (remote debugging)
+echo "Killing isolated Chrome browsers (remote debugging on 127.0.0.1:9222)..."
+# Find Chrome processes listening on port 9222 specifically
+chrome_pids=$(lsof -ti:9222 2>/dev/null | grep -E '^[0-9]+$')
+if [ ! -z "$chrome_pids" ]; then
+    for pid in $chrome_pids; do
+        # Double-check this is a Chrome process with remote debugging
+        if ps -p $pid -o cmd= 2>/dev/null | grep -q "chrome.*--remote-debugging-port=9222"; then
+            echo "Killing Chrome remote debugging process (PID: $pid)"
+            kill -9 $pid >/dev/null 2>&1
+        fi
+    done
+else
+    echo "No Chrome remote debugging processes found on port 9222"
+fi
 
 # Wait for processes to terminate
 sleep 2
@@ -36,3 +48,6 @@ echo "Checking for processes on port 3000..."
 lsof -ti:3000 | xargs kill -9 2>/dev/null || true
 
 echo "✅ All processes stopped"
+echo ""
+echo "Note: Only killed isolated Chrome browsers (remote debugging on 127.0.0.1:9222)"
+echo "Your regular Chrome browser sessions remain untouched."


### PR DESCRIPTION
## Problem
The current `scripts/kill-all.sh` script kills ALL Chrome processes with `pkill -f "chrome"`, which closes users' regular Chrome browser sessions and tabs. This is disruptive when cleaning up development processes.

## Solution
Updated the script to only target isolated Chrome browsers running with remote debugging on `127.0.0.1:9222` (used for testing/automation), while preserving regular Chrome browser sessions.

### Key Changes:
- **Safer Chrome targeting**: Only kills Chrome processes with `--remote-debugging-port=9222`
- **Double verification**: Uses both `lsof` (port check) and `ps` (command verification)
- **Preserved functionality**: All other process cleanup remains unchanged (PM2, Node, Playwright, etc)
- **Better UX**: Clear messaging about what was preserved vs cleaned up

### Before:
```bash
# Killed ALL Chrome processes
pkill -f "chrome" 2>/dev/null || true
```

### After:
```bash
# Only kills isolated Chrome browsers on 127.0.0.1:9222
chrome_pids=$(lsof -ti:9222 2>/dev/null | grep -E '^[0-9]+$')
if [ ! -z "$chrome_pids" ]; then
    for pid in $chrome_pids; do
        if ps -p $pid -o cmd= 2>/dev/null | grep -q "chrome.*--remote-debugging-port=9222"; then
            kill -9 $pid >/dev/null 2>&1
        fi
    done
fi
```

## Testing
- ✅ Script syntax validated with `bash -n`
- ✅ Tested process identification logic
- ✅ Verified regular Chrome sessions are preserved
- ✅ Confirmed development cleanup still works

## Impact
- **Users**: No more accidentally closed Chrome browser sessions during development cleanup
- **Developers**: Can safely run `npm run kill-all` without losing their work
- **CI/Testing**: Properly cleans isolated Chrome instances used for automation

This change makes the kill-all script much safer for daily development use while maintaining its effectiveness for cleaning up test processes.