### PR TITLE
Fix #305: Add Footer component with current year (2025) copyright notice

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import { Inter, Roboto_Mono } from 'next/font/google'
 import BottomNavBar from '../components/BottomNavBar' // Import the new component
+import Footer from '../components/Footer'
 import Providers from '../components/Providers'
 import ThemeRegistry from '../components/ThemeRegistry/ThemeRegistry'
 import ErrorBoundary from '../components/ErrorBoundary'
@@ -37,6 +38,7 @@ export default function RootLayout({
               <TimerSoundProvider>{children}</TimerSoundProvider>
             </ErrorBoundary>
           </Providers>
+          <Footer />
           <BottomNavBar />
         </ThemeRegistry>
       </body>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import { Box, Typography } from '@mui/material'
+
+export default function Footer() {
+  const currentYear = new Date().getFullYear()
+
+  return (
+    <Box
+      component="footer"
+      sx={{
+        mt: 'auto',
+        py: 2,
+        px: 2,
+        textAlign: 'center',
+        borderTop: '1px solid',
+        borderColor: 'divider',
+        backgroundColor: 'background.paper',
+      }}
+    >
+      <Typography variant="body2" color="text.secondary">
+        © {currentYear} HRM Dashboard. All rights reserved.
+      </Typography>
+    </Box>
+  )
+}


### PR DESCRIPTION
This PR addresses issue #305 by adding a footer component with the current copyright year.

## Changes
- Created a new  component with dynamic year calculation
- Added the footer to the app layout
- The footer displays '© 2025 HRM Dashboard. All rights reserved.'
- Uses Material-UI for consistent styling

## Testing
The footer will automatically update the year based on , ensuring it stays current.

Fixes #305