### PR TITLE
Fix #308: Configure ESLint rule for trailing commas

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -25,6 +25,22 @@ export default defineConfig([
   // Apply recommended TypeScript ESLint rules
   ...tseslint.configs.recommended,
 
+  // Configure trailing comma rules for consistent code formatting
+  {
+    rules: {
+      '@typescript-eslint/comma-dangle': [
+        'error',
+        {
+          arrays: 'always-multiline',
+          objects: 'always-multiline',
+          imports: 'always-multiline',
+          exports: 'always-multiline',
+          functions: 'always-multiline',
+        },
+      ],
+    },
+  },
+
   // Next.js specific rules and configurations
   ...nextPlugin, // Extends the core-web-vitals configuration from eslint-config-next
   {


### PR DESCRIPTION
Adds ESLint rule configuration for consistent trailing comma style across the codebase.

## Changes
- ✅ Added @typescript-eslint/comma-dangle rule with 'always-multiline' setting
- ✅ Configures trailing comma enforcement for arrays, objects, imports, exports, and functions
- ✅ Only applies to multiline constructs (single-line remains unaffected)

## Benefits
- Enforces consistent code formatting standards
- Improves diff readability when adding/removing items
- Reduces merge conflicts in version control
- Aligns with modern JavaScript/TypeScript best practices

## Rule Configuration


Closes #308