### PR TITLE
chore: remove private domain from deploy.sh

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -9,7 +9,7 @@ echo "🚀 Starting HRM production deployment..."
 if [ ! -f ".env.production" ]; then
     echo "❌ Error: .env.production file not found!"
     echo "Please create .env.production with:"
-    echo "  NEXTAUTH_URL=https://onasafari.ddns.net"
+    echo "  NEXTAUTH_URL=https://your-domain.com"
     echo "  NEXTAUTH_SECRET=your-secret-here"
     echo "  SPOTIFY_CLIENT_ID=your-client-id"
     echo "  SPOTIFY_CLIENT_SECRET=your-client-secret"


### PR DESCRIPTION
Replaces hardcoded private domain with a generic placeholder to protect privacy. Users should replace 'your-domain.com' with their own domain in .env.production.