### PR TITLE
feat: add manual release workflow for local deployment

### DIFF
--- a/.github/workflows/manual-release-local.yml
+++ b/.github/workflows/manual-release-local.yml
@@ -1,0 +1,152 @@
+name: Manual Release (Local Deployment)
+
+on:
+  workflow_dispatch:
+    inputs:
+      deploy_dir:
+        description: 'Local deployment directory (default: ~/hrm-release)'
+        required: false
+        default: '~/hrm-release'
+        type: string
+      skip_verification:
+        description: 'Skip deployment verification'
+        required: false
+        default: false
+        type: boolean
+
+env:
+  NODE_VERSION: '20'
+
+jobs:
+  release-local:
+    runs-on: self-hosted
+
+    steps:
+      - name: 📋 Display Configuration
+        run: |
+          echo "🎯 Release Configuration:"
+          echo "  Deploy Directory: ${{ github.event.inputs.deploy_dir }}"
+          echo "  Skip Verification: ${{ github.event.inputs.skip_verification }}"
+
+      - uses: actions/checkout@v4
+
+      - name: 📦 Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+
+      - name: 🟢 Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+
+      - name: 📥 Install Dependencies
+        run: pnpm install
+
+      - name: 🏗️ Build Standalone Artifact
+        env:
+          NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET_BUILD_PLACEHOLDER }}
+          NEXTAUTH_URL: "http://localhost:3000"
+        run: |
+          echo "Building Next.js application..."
+          pnpm run build
+
+          echo "Packaging artifact..."
+          ./scripts/package.sh
+
+      - name: 📂 Prepare Local Deployment Directory
+        run: |
+          DEPLOY_DIR="${{ github.event.inputs.deploy_dir }}"
+          DEPLOY_DIR="${DEPLOY_DIR/#\~/$HOME}"
+          
+          echo "Creating deployment directory: $DEPLOY_DIR"
+          mkdir -p "$DEPLOY_DIR"
+          
+          # Backup existing deployment if it exists
+          if [ -d "$DEPLOY_DIR/.next" ]; then
+            echo "⚠️ Existing deployment found. Backing up to ${DEPLOY_DIR}.backup"
+            rm -rf "${DEPLOY_DIR}.backup"
+            mv "$DEPLOY_DIR" "${DEPLOY_DIR}.backup"
+            mkdir -p "$DEPLOY_DIR"
+          fi
+          
+          # Copy the release artifact
+          echo "Extracting release artifact..."
+          cp release.tar.gz "$DEPLOY_DIR/"
+          cd "$DEPLOY_DIR"
+          tar -xzf release.tar.gz --overwrite
+          rm release.tar.gz
+
+      - name: 📦 Install Production Dependencies
+        env:
+          DEPLOY_DIR: ${{ github.event.inputs.deploy_dir }}
+        run: |
+          DEPLOY_DIR="${DEPLOY_DIR/#\~/$HOME}"
+          cd "$DEPLOY_DIR"
+          
+          echo "Installing production dependencies..."
+          pnpm install --prod --ignore-scripts
+
+      - name: 🔄 Start/Reload Application (PM2)
+        env:
+          DEPLOY_DIR: ${{ github.event.inputs.deploy_dir }}
+        run: |
+          DEPLOY_DIR="${DEPLOY_DIR/#\~/$HOME}"
+          cd "$DEPLOY_DIR"
+          
+          echo "Starting/reloading application with PM2..."
+          if [ -f "ecosystem.config.cjs" ]; then
+            npx pm2 startOrReload ecosystem.config.cjs --env production --update-env
+          else
+            echo "⚠️ ecosystem.config.cjs not found. Skipping PM2 reload."
+          fi
+
+      - name: 🕵️ Verify Deployment
+        if: ${{ !github.event.inputs.skip_verification }}
+        env:
+          DEPLOY_DIR: ${{ github.event.inputs.deploy_dir }}
+        run: |
+          DEPLOY_DIR="${DEPLOY_DIR/#\~/$HOME}"
+          cd "$DEPLOY_DIR"
+          
+          if [ -f "scripts/verify-deployment.sh" ]; then
+            echo "Running deployment verification..."
+            chmod +x scripts/verify-deployment.sh
+            ./scripts/verify-deployment.sh
+          else
+            echo "⚠️ verify-deployment.sh not found. Skipping verification."
+          fi
+
+      - name: ✅ Deployment Summary
+        if: success()
+        env:
+          DEPLOY_DIR: ${{ github.event.inputs.deploy_dir }}
+        run: |
+          DEPLOY_DIR="${DEPLOY_DIR/#\~/$HOME}"
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          echo "✅ RELEASE DEPLOYMENT SUCCESSFUL"
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          echo "📂 Deployment Directory: $DEPLOY_DIR"
+          echo "🔗 Check application at configured URL"
+          echo ""
+          echo "📊 Active PM2 Processes:"
+          npx pm2 list || echo "PM2 not available"
+          echo ""
+          echo "To view logs, run:"
+          echo "  pm2 logs"
+          echo ""
+          echo "To rollback to previous deployment, run:"
+          echo "  rm -rf $DEPLOY_DIR && mv ${DEPLOY_DIR}.backup $DEPLOY_DIR"
+
+      - name: ❌ Deployment Failed
+        if: failure()
+        env:
+          DEPLOY_DIR: ${{ github.event.inputs.deploy_dir }}
+        run: |
+          DEPLOY_DIR="${DEPLOY_DIR/#\~/$HOME}"
+          echo "❌ Deployment failed!"
+          echo ""
+          echo "If you have a backup, you can restore with:"
+          echo "  rm -rf $DEPLOY_DIR && mv ${DEPLOY_DIR}.backup $DEPLOY_DIR"
+          exit 1


### PR DESCRIPTION
## Description
Adds a new GitHub Actions workflow for manual release deployment to local environments.

## Changes
- Created `.github/workflows/manual-release-local.yml` workflow
- Enables triggered local deployment without SSH/SCP
- Supports configurable deployment directory (default: ~/hrm-release)
- Includes automatic backups and rollback instructions
- Optional deployment verification

## Usage
1. Go to Actions → Manual Release (Local Deployment)
2. Click 'Run workflow'
3. Optionally customize deployment directory
4. Watch deployment progress in logs