### PR TITLE
feat: refactor playlist selector and display details

### DIFF
--- a/app/api/spotify/playlists/[playlistId]/route.ts
+++ b/app/api/spotify/playlists/[playlistId]/route.ts
@@ -40,6 +40,8 @@ async function getPlaylistDetails(_req: Request, ...args: unknown[]) {
         duration: item.track.duration_ms,
       }
     })
+    // The map operation above can return null for non-track items,
+    // so we filter them out here.
     .filter(Boolean)
 
   return NextResponse.json({
@@ -47,7 +49,7 @@ async function getPlaylistDetails(_req: Request, ...args: unknown[]) {
     description: playlist.description,
     imageUrl:
       playlist.images && playlist.images.length > 0
-        ? playlist.images[0]?.url ?? ''
+        ? (playlist.images[0]?.url ?? '')
         : '',
     tracks,
   })

--- a/app/api/spotify/playlists/[playlistId]/route.ts
+++ b/app/api/spotify/playlists/[playlistId]/route.ts
@@ -28,16 +28,28 @@ async function getPlaylistDetails(_req: Request, ...args: unknown[]) {
     throw new ApiError(404, 'Playlist not found.')
   }
 
+  const tracks = playlist.tracks.items
+    .map((item) => {
+      if (!item.track || item.track.type !== 'track') {
+        return null
+      }
+      return {
+        uri: item.track.uri,
+        name: item.track.name,
+        artist: item.track.artists.map((artist) => artist.name).join(', '),
+        duration: item.track.duration_ms,
+      }
+    })
+    .filter(Boolean)
+
   return NextResponse.json({
-    id: playlist.id,
     name: playlist.name,
     description: playlist.description,
     imageUrl:
       playlist.images && playlist.images.length > 0
-        ? (playlist.images[0]?.url ?? null)
-        : null,
-    owner: playlist.owner?.display_name ?? null,
-    trackCount: playlist.tracks?.total ?? 0,
+        ? playlist.images[0]?.url ?? ''
+        : '',
+    tracks,
   })
 }
 

--- a/app/client/spotify-selection/page.tsx
+++ b/app/client/spotify-selection/page.tsx
@@ -8,6 +8,7 @@ import Container from '@mui/material/Container'
 import Skeleton from '@mui/material/Skeleton'
 import Typography from '@mui/material/Typography'
 import dynamic from 'next/dynamic'
+import { Suspense } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useWebSocket } from '@/context/WebSocketContext'
 import { SpotifyCommandMessage } from '@/types/websocket'
@@ -112,4 +113,10 @@ const SpotifySelectionPage = () => {
   )
 }
 
-export default SpotifySelectionPage
+const SpotifySelectionPageWithSuspense = () => (
+  <Suspense fallback={<Skeleton variant="rectangular" height={600} />}>
+    <SpotifySelectionPage />
+  </Suspense>
+)
+
+export default SpotifySelectionPageWithSuspense

--- a/app/client/spotify-selection/page.tsx
+++ b/app/client/spotify-selection/page.tsx
@@ -8,8 +8,9 @@ import Container from '@mui/material/Container'
 import Skeleton from '@mui/material/Skeleton'
 import Typography from '@mui/material/Typography'
 import dynamic from 'next/dynamic'
-import { useRouter } from 'next/navigation'
+import { useState } from 'react'
 import { useWebSocket } from '@/context/WebSocketContext'
+import { SpotifyCommandMessage } from '@/types/websocket'
 
 const PlaylistSelector = dynamic(
   () => import('../../../components/Spotify/PlaylistSelector'),
@@ -19,33 +20,39 @@ const PlaylistSelector = dynamic(
   }
 )
 
+const PlaylistDetails = dynamic(
+  () => import('../../../components/Spotify/PlaylistDetails'),
+  {
+    ssr: false,
+    loading: () => <Skeleton variant="rectangular" height={400} />,
+  }
+)
+
 const SpotifySelectionPage = () => {
   const { spotifyData, sendData } = useWebSocket()
-  const router = useRouter()
+  const [selectedPlaylistUri, setSelectedPlaylistUri] = useState<string | null>(
+    null
+  )
 
   const handlePlaylistSelected = (uri: string) => {
-    const playlistId = uri.split(':').pop()
-    if (playlistId) {
-      router.push(`/spotify/playlist/${playlistId}`)
-    }
+    setSelectedPlaylistUri(uri)
   }
 
-  const handlePlaylistPlay = (uri: string) => {
+  const handlePlaylistPlay = (uri: string, trackUri?: string) => {
     const activeDevice = spotifyData.devices?.find((device) => device.is_active)
-    if (activeDevice) {
-      sendData({
-        type: 'SPOTIFY_COMMAND',
-        command: 'PLAY',
-        playlistUri: uri,
-        deviceId: activeDevice.id,
-      })
-    } else {
-      sendData({
-        type: 'SPOTIFY_COMMAND',
-        command: 'PLAY',
-        playlistUri: uri,
-      })
+    const command: SpotifyCommandMessage = {
+      type: 'SPOTIFY_COMMAND',
+      command: 'PLAY',
     }
+    if (trackUri) {
+      command.uri = trackUri
+    } else {
+      command.contextUri = uri
+    }
+    if (activeDevice) {
+      command.deviceId = activeDevice.id
+    }
+    sendData(command)
   }
 
   return (
@@ -75,13 +82,24 @@ const SpotifySelectionPage = () => {
 
       <Card sx={{ mt: 2 }}>
         <CardContent>
-          <Typography variant="h6" gutterBottom>
-            Select a Playlist to view its tracks
-          </Typography>
-          <PlaylistSelector
-            onPlaylistSelected={handlePlaylistSelected}
-            onPlaylistPlay={handlePlaylistPlay}
-          />
+          {selectedPlaylistUri ? (
+            <PlaylistDetails
+              key={selectedPlaylistUri}
+              playlistUri={selectedPlaylistUri}
+              onBack={() => setSelectedPlaylistUri(null)}
+              onPlaylistPlay={handlePlaylistPlay}
+            />
+          ) : (
+            <>
+              <Typography variant="h6" gutterBottom>
+                Select a Playlist to view its tracks
+              </Typography>
+              <PlaylistSelector
+                onPlaylistSelected={handlePlaylistSelected}
+                onPlaylistPlay={handlePlaylistPlay}
+              />
+            </>
+          )}
         </CardContent>
       </Card>
     </Container>

--- a/app/client/spotify-selection/page.tsx
+++ b/app/client/spotify-selection/page.tsx
@@ -8,7 +8,7 @@ import Container from '@mui/material/Container'
 import Skeleton from '@mui/material/Skeleton'
 import Typography from '@mui/material/Typography'
 import dynamic from 'next/dynamic'
-import { useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { useWebSocket } from '@/context/WebSocketContext'
 import { SpotifyCommandMessage } from '@/types/websocket'
 
@@ -30,12 +30,18 @@ const PlaylistDetails = dynamic(
 
 const SpotifySelectionPage = () => {
   const { spotifyData, sendData } = useWebSocket()
-  const [selectedPlaylistUri, setSelectedPlaylistUri] = useState<string | null>(
-    null
-  )
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const selectedPlaylistUri = searchParams.get('playlist')
 
   const handlePlaylistSelected = (uri: string) => {
-    setSelectedPlaylistUri(uri)
+    const params = new URLSearchParams(searchParams.toString())
+    params.set('playlist', uri)
+    router.push(`?${params.toString()}`)
+  }
+
+  const handleBack = () => {
+    router.back()
   }
 
   const handlePlaylistPlay = (uri: string, trackUri?: string) => {
@@ -86,7 +92,7 @@ const SpotifySelectionPage = () => {
             <PlaylistDetails
               key={selectedPlaylistUri}
               playlistUri={selectedPlaylistUri}
-              onBack={() => setSelectedPlaylistUri(null)}
+              onBack={handleBack}
               onPlaylistPlay={handlePlaylistPlay}
             />
           ) : (

--- a/components/Spotify/PlaylistDetails.tsx
+++ b/components/Spotify/PlaylistDetails.tsx
@@ -13,6 +13,7 @@ import Typography from '@mui/material/Typography'
 import Skeleton from '@mui/material/Skeleton'
 import Image from 'next/image'
 import { useEffect, useState } from 'react'
+import { formatDuration } from '@/utils/formatters'
 
 interface Track {
   uri: string
@@ -154,21 +155,27 @@ const PlaylistDetails: React.FC<PlaylistDetailsProps> = ({
         </Box>
       </Box>
       <List>
-        {details.tracks.map((track, index) => (
-          <ListItem key={`${track.uri}-${index}`} divider>
-            <ListItemText
-              primary={`${index + 1}. ${track.name}`}
-              secondary={`${track.artist} • ${formatDuration(track.duration)}`}
-            />
-            <IconButton
-              edge="end"
-              aria-label={`Play ${track.name}`}
-              onClick={() => handlePlayTrack(track.uri)}
-            >
-              <PlayArrow />
-            </IconButton>
+        {details.tracks && details.tracks.length > 0 ? (
+          details.tracks.map((track, index) => (
+            <ListItem key={`${track.uri}-${index}`} divider>
+              <ListItemText
+                primary={`${index + 1}. ${track.name}`}
+                secondary={`${track.artist} • ${formatDuration(track.duration)}`}
+              />
+              <IconButton
+                edge="end"
+                aria-label={`Play ${track.name}`}
+                onClick={() => handlePlayTrack(track.uri)}
+              >
+                <PlayArrow />
+              </IconButton>
+            </ListItem>
+          ))
+        ) : (
+          <ListItem>
+            <ListItemText primary="This playlist is empty." />
           </ListItem>
-        ))}
+        )}
       </List>
     </Box>
   )

--- a/components/Spotify/PlaylistDetails.tsx
+++ b/components/Spotify/PlaylistDetails.tsx
@@ -13,13 +13,12 @@ import Typography from '@mui/material/Typography'
 import Skeleton from '@mui/material/Skeleton'
 import Image from 'next/image'
 import { useEffect, useState } from 'react'
-import { useDebounce } from '../../hooks/useDebounce'
 
 interface Track {
   uri: string
   name: string
   artist: string
-  duration: string
+  duration: number
 }
 
 interface PlaylistDetailsData {
@@ -44,16 +43,15 @@ const PlaylistDetails: React.FC<PlaylistDetailsProps> = ({
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [imageLoading, setImageLoading] = useState(true)
-  const debouncedPlaylistUri = useDebounce(playlistUri, 300)
 
   useEffect(() => {
-    if (!debouncedPlaylistUri) return
+    if (!playlistUri) return
 
     const fetchDetails = async () => {
       setLoading(true)
       setError(null)
       try {
-        const playlistId = debouncedPlaylistUri.split(':').pop()
+        const playlistId = playlistUri.split(':').pop()
         const response = await fetch(`/api/spotify/playlists/${playlistId}`)
         if (!response.ok) {
           if (response.status === 404) {
@@ -79,10 +77,10 @@ const PlaylistDetails: React.FC<PlaylistDetailsProps> = ({
     }
 
     fetchDetails()
-  }, [debouncedPlaylistUri])
+  }, [playlistUri])
 
   const handlePlayTrack = (trackUri: string) => {
-    onPlaylistPlay(debouncedPlaylistUri, trackUri)
+    onPlaylistPlay(playlistUri, trackUri)
   }
 
   if (loading) {
@@ -157,10 +155,10 @@ const PlaylistDetails: React.FC<PlaylistDetailsProps> = ({
       </Box>
       <List>
         {details.tracks.map((track, index) => (
-          <ListItem key={track.uri} divider>
+          <ListItem key={`${track.uri}-${index}`} divider>
             <ListItemText
               primary={`${index + 1}. ${track.name}`}
-              secondary={`${track.artist} • ${track.duration}`}
+              secondary={`${track.artist} • ${formatDuration(track.duration)}`}
             />
             <IconButton
               edge="end"
@@ -174,6 +172,13 @@ const PlaylistDetails: React.FC<PlaylistDetailsProps> = ({
       </List>
     </Box>
   )
+}
+
+const formatDuration = (ms: number) => {
+  const totalSeconds = Math.floor(ms / 1000)
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`
 }
 
 export default PlaylistDetails

--- a/components/Spotify/PlaylistDetails.tsx
+++ b/components/Spotify/PlaylistDetails.tsx
@@ -1,0 +1,179 @@
+// components/Spotify/PlaylistDetails.tsx
+import BackIcon from '@mui/icons-material/ArrowBack'
+import PlayArrow from '@mui/icons-material/PlayArrow'
+import Alert from '@mui/material/Alert'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import CircularProgress from '@mui/material/CircularProgress'
+import IconButton from '@mui/material/IconButton'
+import List from '@mui/material/List'
+import ListItem from '@mui/material/ListItem'
+import ListItemText from '@mui/material/ListItemText'
+import Typography from '@mui/material/Typography'
+import Skeleton from '@mui/material/Skeleton'
+import Image from 'next/image'
+import { useEffect, useState } from 'react'
+import { useDebounce } from '../../hooks/useDebounce'
+
+interface Track {
+  uri: string
+  name: string
+  artist: string
+  duration: string
+}
+
+interface PlaylistDetailsData {
+  name: string
+  description: string
+  imageUrl: string
+  tracks: Track[]
+}
+
+interface PlaylistDetailsProps {
+  playlistUri: string
+  onBack: () => void
+  onPlaylistPlay: (uri: string, trackUri?: string) => void
+}
+
+const PlaylistDetails: React.FC<PlaylistDetailsProps> = ({
+  playlistUri,
+  onBack,
+  onPlaylistPlay,
+}) => {
+  const [details, setDetails] = useState<PlaylistDetailsData | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [imageLoading, setImageLoading] = useState(true)
+  const debouncedPlaylistUri = useDebounce(playlistUri, 300)
+
+  useEffect(() => {
+    if (!debouncedPlaylistUri) return
+
+    const fetchDetails = async () => {
+      setLoading(true)
+      setError(null)
+      try {
+        const playlistId = debouncedPlaylistUri.split(':').pop()
+        const response = await fetch(`/api/spotify/playlists/${playlistId}`)
+        if (!response.ok) {
+          if (response.status === 404) {
+            throw new Error(
+              'Playlist not found. It might be private or deleted.'
+            )
+          } else {
+            throw new Error(
+              `Failed to fetch playlist details, status: ${response.status}`
+            )
+          }
+        }
+        const data = await response.json()
+        setDetails(data)
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : 'An unknown error occurred'
+        setError(message)
+        console.error('Error fetching playlist details:', err)
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchDetails()
+  }, [debouncedPlaylistUri])
+
+  const handlePlayTrack = (trackUri: string) => {
+    onPlaylistPlay(debouncedPlaylistUri, trackUri)
+  }
+
+  if (loading) {
+    return (
+      <Box sx={{ textAlign: 'center', py: 5 }}>
+        <CircularProgress />
+        <Typography sx={{ mt: 2 }}>Loading playlist...</Typography>
+      </Box>
+    )
+  }
+
+  if (error) {
+    return (
+      <Box>
+        <Button startIcon={<BackIcon />} onClick={onBack} sx={{ mb: 2 }}>
+          Back to Playlists
+        </Button>
+        <Alert severity="error">{error}</Alert>
+      </Box>
+    )
+  }
+
+  if (!details) {
+    return (
+      <Box>
+        <Button startIcon={<BackIcon />} onClick={onBack} sx={{ mb: 2 }}>
+          Back to Playlists
+        </Button>
+        <Typography>No details found for this playlist.</Typography>
+      </Box>
+    )
+  }
+
+  return (
+    <Box>
+      <Button startIcon={<BackIcon />} onClick={onBack} sx={{ mb: 2 }}>
+        Back to Playlists
+      </Button>
+      <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
+        {details.imageUrl && (
+          <>
+            {imageLoading && (
+              <Skeleton
+                variant="rectangular"
+                width={100}
+                height={100}
+                sx={{ borderRadius: 1, mr: 2 }}
+              />
+            )}
+            <Image
+              src={details.imageUrl}
+              alt={details.name}
+              width={100}
+              height={100}
+              style={{
+                borderRadius: 8,
+                marginRight: 16,
+                display: imageLoading ? 'none' : 'block',
+              }}
+              onLoad={() => setImageLoading(false)}
+            />
+          </>
+        )}
+        <Box>
+          <Typography variant="h5" component="h2">
+            {details.name}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {details.description}
+          </Typography>
+        </Box>
+      </Box>
+      <List>
+        {details.tracks.map((track, index) => (
+          <ListItem key={track.uri} divider>
+            <ListItemText
+              primary={`${index + 1}. ${track.name}`}
+              secondary={`${track.artist} • ${track.duration}`}
+            />
+            <IconButton
+              edge="end"
+              aria-label={`Play ${track.name}`}
+              onClick={() => handlePlayTrack(track.uri)}
+            >
+              <PlayArrow />
+            </IconButton>
+          </ListItem>
+        ))}
+      </List>
+    </Box>
+  )
+}
+
+export default PlaylistDetails

--- a/components/Spotify/PlaylistSelector.tsx
+++ b/components/Spotify/PlaylistSelector.tsx
@@ -1,8 +1,6 @@
 // components/Spotify/PlaylistSelector.tsx
-import ClearIcon from '@mui/icons-material/Clear'
 import MusicNote from '@mui/icons-material/MusicNote'
 import PlayArrow from '@mui/icons-material/PlayArrow'
-import Search from '@mui/icons-material/Search'
 import Alert from '@mui/material/Alert'
 import Autocomplete from '@mui/material/Autocomplete'
 import Box from '@mui/material/Box'
@@ -45,8 +43,8 @@ const PlaylistItemContent: React.FC<PlaylistItemProps> = ({
         playlist.trackCount !== undefined
           ? `${playlist.trackCount} tracks${playlist.owner ? ` • ${playlist.owner}` : ''}`
           : playlist.owner
-          ? playlist.owner
-          : undefined
+            ? playlist.owner
+            : undefined
       }
     />
     {playlist.isPreset && (
@@ -276,14 +274,12 @@ const PlaylistSelector: React.FC<PlaylistSelectorProps> = ({
             }}
           />
         )}
-        renderOption={(props, option) => {
-          const { key, ...optionProps } = props
-          return (
-            <ListItem {...optionProps} key={key} divider>
-              <div
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
+        renderOption={(props, option) => (
+          <ListItem {...props} divider>
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
                 width: '100%',
               }}
             >

--- a/components/Spotify/PlaylistSelector.tsx
+++ b/components/Spotify/PlaylistSelector.tsx
@@ -8,109 +8,14 @@ import Autocomplete from '@mui/material/Autocomplete'
 import Box from '@mui/material/Box'
 import Chip from '@mui/material/Chip'
 import CircularProgress from '@mui/material/CircularProgress'
-import Divider from '@mui/material/Divider'
 import IconButton from '@mui/material/IconButton'
-import List from '@mui/material/List'
 import ListItem from '@mui/material/ListItem'
-import ListItemButton from '@mui/material/ListItemButton'
 import ListItemText from '@mui/material/ListItemText'
-import Paper from '@mui/material/Paper'
-import Link from 'next/link'
 import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
 import React, { useEffect, useMemo, useState } from 'react'
 import { useDebounce } from '../../hooks/useDebounce'
 import { API_SPOTIFY_PLAYLISTS } from '../../constants/apiEndpoints'
-
-interface PlaylistItemProps {
-  playlist: Playlist
-  selected: boolean
-  onClick: () => void
-  onPlay: (event: React.MouseEvent<HTMLElement>) => void
-}
-
-const PlaylistItem: React.FC<PlaylistItemProps> = ({
-  playlist,
-  selected,
-  onClick,
-  onPlay,
-}) => (
-  <ListItem
-    key={playlist.uri}
-    divider
-    sx={{ display: 'flex', justifyContent: 'space-between' }}
-  >
-    <Link href={`/spotify/playlist/${playlist.id}`} passHref legacyBehavior>
-      <ListItemButton
-        selected={selected}
-        onClick={onClick}
-        sx={{
-          flexGrow: 1,
-          '&:hover': {
-            backgroundColor: 'action.hover',
-          },
-        }}
-      >
-        {playlist.imageUrl ? (
-          <Box
-            component="img"
-            src={playlist.imageUrl}
-            alt={playlist.name}
-            sx={{
-              width: 48,
-              height: 48,
-              borderRadius: 1,
-              mr: 1.5,
-              objectFit: 'cover',
-            }}
-          />
-        ) : (
-          <MusicNote sx={{ mr: 1.5, color: 'text.secondary', fontSize: 24 }} />
-        )}
-        <ListItemText
-          primary={playlist.name}
-          secondary={
-            playlist.trackCount !== undefined
-              ? `${playlist.trackCount} tracks${playlist.owner ? ` • ${playlist.owner}` : ''}`
-              : playlist.owner
-                ? playlist.owner
-                : undefined
-          }
-        />
-        {playlist.isPreset && (
-          <Chip
-            label="Preset"
-            size="small"
-            sx={{ height: 20, fontSize: '0.7rem', ml: 1 }}
-          />
-        )}
-        {playlist.isSearchResult && !playlist.isPreset && (
-          <Chip
-            label="Spotify"
-            size="small"
-            color="success"
-            sx={{ height: 20, fontSize: '0.7rem', ml: 1 }}
-          />
-        )}
-      </ListItemButton>
-    </Link>
-    <Box sx={{ pl: 1 }}>
-      <IconButton
-        edge="end"
-        aria-label="play"
-        onClick={onPlay}
-        sx={{
-          '&:hover': {
-            backgroundColor: 'action.hover',
-            transform: 'scale(1.1)',
-          },
-        }}
-      >
-        <PlayArrow />
-      </IconButton>
-    </Box>
-  </ListItem>
-)
 
 interface Playlist {
   name: string
@@ -123,6 +28,59 @@ interface Playlist {
   trackCount?: number
   owner?: string
 }
+
+interface PlaylistItemProps {
+  playlist: Playlist
+  onPlay: (event: React.MouseEvent<HTMLElement>) => void
+}
+
+const PlaylistItemContent: React.FC<PlaylistItemProps> = ({
+  playlist,
+  onPlay,
+}) => (
+  <>
+    <ListItemText
+      primary={playlist.name}
+      secondary={
+        playlist.trackCount !== undefined
+          ? `${playlist.trackCount} tracks${playlist.owner ? ` • ${playlist.owner}` : ''}`
+          : playlist.owner
+          ? playlist.owner
+          : undefined
+      }
+    />
+    {playlist.isPreset && (
+      <Chip
+        label="Preset"
+        size="small"
+        sx={{ height: 20, fontSize: '0.7rem', ml: 1 }}
+      />
+    )}
+    {playlist.isSearchResult && !playlist.isPreset && (
+      <Chip
+        label="Spotify"
+        size="small"
+        color="success"
+        sx={{ height: 20, fontSize: '0.7rem', ml: 1 }}
+      />
+    )}
+    <Box sx={{ pl: 1 }}>
+      <IconButton
+        edge="end"
+        aria-label={`Play ${playlist.name}`}
+        onClick={onPlay}
+        sx={{
+          '&:hover': {
+            backgroundColor: 'action.hover',
+            transform: 'scale(1.1)',
+          },
+        }}
+      >
+        <PlayArrow />
+      </IconButton>
+    </Box>
+  </>
+)
 
 interface PlaylistSelectorProps {
   onPlaylistSelected: (uri: string) => void
@@ -137,7 +95,6 @@ const PlaylistSelector: React.FC<PlaylistSelectorProps> = ({
   const [userPlaylists, setUserPlaylists] = useState<Playlist[]>([])
   const [searchResults, setSearchResults] = useState<Playlist[]>([])
   const [loading, setLoading] = useState(true)
-  const [searchLoading, setSearchLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [searchQuery, setSearchQuery] = useState('')
   const [selectedPlaylist, setSelectedPlaylist] = useState<Playlist | null>(
@@ -187,7 +144,6 @@ const PlaylistSelector: React.FC<PlaylistSelectorProps> = ({
     }
 
     const fetchSearchResults = async () => {
-      setSearchLoading(true)
       try {
         const response = await fetch(
           `/api/spotify/playlists/search?q=${encodeURIComponent(debouncedSearch)}`
@@ -200,8 +156,6 @@ const PlaylistSelector: React.FC<PlaylistSelectorProps> = ({
       } catch (error) {
         console.error('Error searching playlists:', error)
         setSearchResults([])
-      } finally {
-        setSearchLoading(false)
       }
     }
 
@@ -269,19 +223,29 @@ const PlaylistSelector: React.FC<PlaylistSelectorProps> = ({
 
   return (
     <Box>
+      {/*
+        This Autocomplete component is used to display the playlist selector.
+        It was chosen to fix a "squished UI" issue that occurred with a
+        previous implementation that used a separate input and list.
+      */}
       <Autocomplete
         options={filteredPlaylists}
         getOptionLabel={(option) => option.name}
+        groupBy={(option) =>
+          option.isPreset
+            ? 'Preset Playlists'
+            : option.isSearchResult
+              ? 'Spotify Search Results'
+              : 'Your Playlists'
+        }
         value={selectedPlaylist}
         onChange={(_, newValue) => handlePlaylistSelect(newValue)}
         inputValue={searchQuery}
         onInputChange={(_, newInputValue) => setSearchQuery(newInputValue)}
         renderInput={(params) => (
           <TextField
-            id={params.id}
-            disabled={params.disabled}
-            fullWidth={params.fullWidth}
             inputProps={params.inputProps}
+            InputProps={params.InputProps}
             placeholder="Search or browse playlists..."
             sx={{
               '& .MuiOutlinedInput-root': {
@@ -294,157 +258,59 @@ const PlaylistSelector: React.FC<PlaylistSelectorProps> = ({
                 },
               },
             }}
-            InputProps={{
-              ref: params.InputProps.ref,
-              className: params.InputProps.className,
-              startAdornment: (
-                <Search sx={{ color: 'text.secondary', mr: 1 }} />
-              ),
-              endAdornment: (
-                <>
-                  {searchLoading ? (
-                    <CircularProgress size={20} sx={{ mr: 1 }} />
-                  ) : searchQuery ? (
-                    <IconButton
-                      size="small"
-                      onClick={() => setSearchQuery('')}
-                      aria-label="Clear search"
-                      sx={{ mr: 1 }}
-                    >
-                      <ClearIcon fontSize="small" />
-                    </IconButton>
-                  ) : null}
-                  {params.InputProps.endAdornment}
-                </>
-              ),
-            }}
           />
         )}
-        renderOption={(_props, option) => (
-          <PlaylistItem
-            key={option.uri}
-            playlist={option}
-            selected={selectedPlaylist?.uri === option.uri}
-            onClick={() => handlePlaylistSelect(option)}
-            onPlay={(e) => {
-              e.stopPropagation()
-              onPlaylistPlay(option.uri)
-            }}
-          />
+        renderOption={(props, option) => (
+          <ListItem {...props} key={option.uri} divider>
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                width: '100%',
+              }}
+            >
+              {option.imageUrl ? (
+                <Box
+                  component="img"
+                  src={option.imageUrl}
+                  alt={option.name}
+                  sx={{
+                    width: 48,
+                    height: 48,
+                    borderRadius: 1,
+                    mr: 1.5,
+                    objectFit: 'cover',
+                  }}
+                />
+              ) : (
+                <MusicNote
+                  sx={{ mr: 1.5, color: 'text.secondary', fontSize: 24 }}
+                />
+              )}
+              <PlaylistItemContent
+                playlist={option}
+                onPlay={(e) => {
+                  e.stopPropagation()
+                  onPlaylistPlay(option.uri)
+                }}
+              />
+            </div>
+          </ListItem>
         )}
         noOptionsText={
           debouncedSearch ? (
-            // eslint-disable-next-line react/no-unescaped-entities
-            <>No playlists found matching "{debouncedSearch}"</>
+            <>No playlists found matching &quot;{debouncedSearch}&quot;</>
           ) : (
             'No playlists available'
           )
         }
         sx={{ mb: 2 }}
+        ListboxProps={{
+          style: {
+            maxHeight: '40vh',
+          },
+        }}
       />
-
-      {!searchQuery && (
-        <Paper variant="outlined" sx={{ maxHeight: 300, overflow: 'auto' }}>
-          <List dense>
-            {presetPlaylists.length > 0 && (
-              <>
-                <ListItem>
-                  <ListItemText
-                    primary={
-                      <Typography variant="overline" color="text.secondary">
-                        Preset Playlists
-                      </Typography>
-                    }
-                  />
-                </ListItem>
-                {presetPlaylists.map((playlist) => (
-                  <PlaylistItem
-                    key={playlist.uri}
-                    playlist={playlist}
-                    selected={selectedPlaylist?.uri === playlist.uri}
-                    onClick={() => handlePlaylistSelect(playlist)}
-                    onPlay={(e) => {
-                      e.stopPropagation()
-                      onPlaylistPlay(playlist.uri)
-                    }}
-                  />
-                ))}
-                {userPlaylists.length > 0 && <Divider sx={{ my: 1 }} />}
-              </>
-            )}
-            {userPlaylists.length > 0 && (
-              <>
-                <ListItem>
-                  <ListItemText
-                    primary={
-                      <Typography variant="overline" color="text.secondary">
-                        Your Playlists ({userPlaylists.length})
-                      </Typography>
-                    }
-                  />
-                </ListItem>
-                {userPlaylists.map((playlist) => (
-                  <PlaylistItem
-                    key={playlist.uri}
-                    playlist={playlist}
-                    selected={selectedPlaylist?.uri === playlist.uri}
-                    onClick={() => handlePlaylistSelect(playlist)}
-                    onPlay={(e) => {
-                      e.stopPropagation()
-                      onPlaylistPlay(playlist.uri)
-                    }}
-                  />
-                ))}
-              </>
-            )}
-          </List>
-        </Paper>
-      )}
-
-      {searchQuery && (
-        <Paper
-          variant="outlined"
-          sx={{ maxHeight: 300, overflow: 'auto', mt: 1 }}
-        >
-          {searchLoading ? (
-            <Box
-              sx={{
-                display: 'flex',
-                justifyContent: 'center',
-                alignItems: 'center',
-                py: 3,
-              }}
-            >
-              <CircularProgress size={24} />
-              <Typography sx={{ ml: 2 }} variant="body2" color="text.secondary">
-                Searching Spotify...
-              </Typography>
-            </Box>
-          ) : filteredPlaylists.length > 0 ? (
-            <List dense>
-              {filteredPlaylists.map((playlist) => (
-                <PlaylistItem
-                  key={playlist.uri}
-                  playlist={playlist}
-                  selected={selectedPlaylist?.uri === playlist.uri}
-                  onClick={() => handlePlaylistSelect(playlist)}
-                  onPlay={(e) => {
-                    e.stopPropagation()
-                    onPlaylistPlay(playlist.uri)
-                  }}
-                />
-              ))}
-            </List>
-          ) : (
-            <Box sx={{ p: 3, textAlign: 'center' }}>
-              <Typography variant="body2" color="text.secondary">
-                {/* eslint-disable-next-line react/no-unescaped-entities */}
-                No playlists found matching "{searchQuery}"
-              </Typography>
-            </Box>
-          )}
-        </Paper>
-      )}
     </Box>
   )
 }

--- a/components/Spotify/PlaylistSelector.tsx
+++ b/components/Spotify/PlaylistSelector.tsx
@@ -97,6 +97,7 @@ const PlaylistSelector: React.FC<PlaylistSelectorProps> = ({
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [searchQuery, setSearchQuery] = useState('')
+  const [searchLoading, setSearchLoading] = useState(false)
   const [selectedPlaylist, setSelectedPlaylist] = useState<Playlist | null>(
     null
   )
@@ -144,6 +145,7 @@ const PlaylistSelector: React.FC<PlaylistSelectorProps> = ({
     }
 
     const fetchSearchResults = async () => {
+      setSearchLoading(true)
       try {
         const response = await fetch(
           `/api/spotify/playlists/search?q=${encodeURIComponent(debouncedSearch)}`
@@ -156,6 +158,8 @@ const PlaylistSelector: React.FC<PlaylistSelectorProps> = ({
       } catch (error) {
         console.error('Error searching playlists:', error)
         setSearchResults([])
+      } finally {
+        setSearchLoading(false)
       }
     }
 
@@ -231,6 +235,8 @@ const PlaylistSelector: React.FC<PlaylistSelectorProps> = ({
       <Autocomplete
         options={filteredPlaylists}
         getOptionLabel={(option) => option.name}
+        filterOptions={(x) => x}
+        loading={loading || searchLoading}
         groupBy={(option) =>
           option.isPreset
             ? 'Preset Playlists'
@@ -244,9 +250,19 @@ const PlaylistSelector: React.FC<PlaylistSelectorProps> = ({
         onInputChange={(_, newInputValue) => setSearchQuery(newInputValue)}
         renderInput={(params) => (
           <TextField
-            inputProps={params.inputProps}
-            InputProps={params.InputProps}
+            {...params}
             placeholder="Search or browse playlists..."
+            InputProps={{
+              ...params.InputProps,
+              endAdornment: (
+                <>
+                  {loading || searchLoading ? (
+                    <CircularProgress color="inherit" size={20} />
+                  ) : null}
+                  {params.InputProps.endAdornment}
+                </>
+              ),
+            }}
             sx={{
               '& .MuiOutlinedInput-root': {
                 '&:hover .MuiOutlinedInput-notchedOutline': {
@@ -260,12 +276,14 @@ const PlaylistSelector: React.FC<PlaylistSelectorProps> = ({
             }}
           />
         )}
-        renderOption={(props, option) => (
-          <ListItem {...props} key={option.uri} divider>
-            <div
-              style={{
-                display: 'flex',
-                alignItems: 'center',
+        renderOption={(props, option) => {
+          const { key, ...optionProps } = props
+          return (
+            <ListItem {...optionProps} key={key} divider>
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
                 width: '100%',
               }}
             >
@@ -296,7 +314,8 @@ const PlaylistSelector: React.FC<PlaylistSelectorProps> = ({
               />
             </div>
           </ListItem>
-        )}
+          )
+        }}
         noOptionsText={
           debouncedSearch ? (
             <>No playlists found matching &quot;{debouncedSearch}&quot;</>

--- a/tests/unit/app/api/spotify/playlists/[playlistId]/route.test.ts
+++ b/tests/unit/app/api/spotify/playlists/[playlistId]/route.test.ts
@@ -7,7 +7,7 @@ jest.mock('next-auth/next')
 jest.mock('@spotify/web-api-ts-sdk')
 
 describe('GET /api/spotify/playlists/[playlistId]', () => {
-  it('should return playlist details for a valid playlist ID', async () => {
+  it('should return playlist details and tracks for a valid playlist ID', async () => {
     // Arrange
     const mockSession = { accessToken: 'test-token' }
     ;(getServerSession as jest.Mock).mockResolvedValue(mockSession)
@@ -18,7 +18,28 @@ describe('GET /api/spotify/playlists/[playlistId]', () => {
       description: 'A test playlist',
       images: [{ url: 'http://example.com/image.jpg' }],
       owner: { display_name: 'Test User' },
-      tracks: { total: 10 },
+      tracks: {
+        items: [
+          {
+            track: {
+              type: 'track',
+              uri: 'spotify:track:1',
+              name: 'Track 1',
+              artists: [{ name: 'Artist 1' }],
+              duration_ms: 180000,
+            },
+          },
+          {
+            track: {
+              type: 'track',
+              uri: 'spotify:track:2',
+              name: 'Track 2',
+              artists: [{ name: 'Artist 2' }],
+              duration_ms: 240000,
+            },
+          },
+        ],
+      },
     }
     const mockGetPlaylist = jest.fn().mockResolvedValue(mockPlaylist)
     ;(SpotifyApi.withAccessToken as jest.Mock).mockReturnValue({
@@ -35,12 +56,23 @@ describe('GET /api/spotify/playlists/[playlistId]', () => {
     // Assert
     expect(response.status).toBe(200)
     expect(data).toEqual({
-      id: '123',
       name: 'Test Playlist',
       description: 'A test playlist',
       imageUrl: 'http://example.com/image.jpg',
-      owner: 'Test User',
-      trackCount: 10,
+      tracks: [
+        {
+          uri: 'spotify:track:1',
+          name: 'Track 1',
+          artist: 'Artist 1',
+          duration: 180000,
+        },
+        {
+          uri: 'spotify:track:2',
+          name: 'Track 2',
+          artist: 'Artist 2',
+          duration: 240000,
+        },
+      ],
     })
   })
 })

--- a/tests/unit/components/Spotify/PlaylistDetails.test.tsx
+++ b/tests/unit/components/Spotify/PlaylistDetails.test.tsx
@@ -1,0 +1,128 @@
+/** @jest-environment jsdom */
+
+import PlaylistDetails from '@/components/Spotify/PlaylistDetails'
+import '@testing-library/jest-dom'
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+const mockPlaylistDetails = {
+  name: 'Rock Classics',
+  description: 'Legendary rock anthems.',
+  imageUrl: 'https://i.scdn.co/image/ab67706f0000000278b4745cb9ce8ec3a8157074',
+  tracks: [
+    {
+      uri: 'spotify:track:1',
+      name: 'Bohemian Rhapsody',
+      artist: 'Queen',
+      duration: '5:55',
+    },
+    {
+      uri: 'spotify:track:2',
+      name: 'Stairway to Heaven',
+      artist: 'Led Zeppelin',
+      duration: '8:02',
+    },
+  ],
+}
+
+describe('PlaylistDetails', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(mockPlaylistDetails),
+      })
+    ) as jest.Mock
+  })
+
+  it('should display a loading state initially', () => {
+    render(
+      <PlaylistDetails
+        playlistUri="spotify:playlist:2"
+        onBack={jest.fn()}
+        onPlaylistPlay={jest.fn()}
+      />
+    )
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+  })
+
+  it('should display playlist details after a successful fetch', async () => {
+    render(
+      <PlaylistDetails
+        playlistUri="spotify:playlist:2"
+        onBack={jest.fn()}
+        onPlaylistPlay={jest.fn()}
+      />
+    )
+
+    expect(await screen.findByText('Rock Classics')).toBeInTheDocument()
+    expect(await screen.findByText(/Bohemian Rhapsody/)).toBeInTheDocument()
+    expect(await screen.findByText(/Stairway to Heaven/)).toBeInTheDocument()
+  })
+
+  it('should display an error message if the fetch fails', async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: false,
+        status: 404,
+      })
+    ) as jest.Mock
+
+    render(
+      <PlaylistDetails
+        playlistUri="spotify:playlist:2"
+        onBack={jest.fn()}
+        onPlaylistPlay={jest.fn()}
+      />
+    )
+
+    expect(
+      await screen.findByText(
+        'Playlist not found. It might be private or deleted.'
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('should call onBack when the back button is clicked', async () => {
+    const onBack = jest.fn()
+    render(
+      <PlaylistDetails
+        playlistUri="spotify:playlist:2"
+        onBack={onBack}
+        onPlaylistPlay={jest.fn()}
+      />
+    )
+    const user = userEvent.setup()
+
+    const backButton = await screen.findByRole('button', {
+      name: /Back to Playlists/i,
+    })
+    await user.click(backButton)
+    expect(onBack).toHaveBeenCalled()
+  })
+
+  it('should call onPlaylistPlay with the correct URI when a track play button is clicked', async () => {
+    const onPlaylistPlay = jest.fn()
+    render(
+      <PlaylistDetails
+        playlistUri="spotify:playlist:2"
+        onBack={jest.fn()}
+        onPlaylistPlay={onPlaylistPlay}
+      />
+    )
+    const user = userEvent.setup()
+
+    const bohemianRhapsodyItem = await screen.findByText(/Bohemian Rhapsody/)
+    const listItem = bohemianRhapsodyItem.closest('li')
+    if (!listItem) throw new Error('List item not found')
+    const playButton = within(listItem).getByRole('button', {
+      name: /Play Bohemian Rhapsody/i,
+    })
+    await user.click(playButton)
+
+    expect(onPlaylistPlay).toHaveBeenCalledWith(
+      'spotify:playlist:2',
+      'spotify:track:1'
+    )
+  })
+})

--- a/tests/unit/components/Spotify/PlaylistSelector.test.tsx
+++ b/tests/unit/components/Spotify/PlaylistSelector.test.tsx
@@ -23,19 +23,30 @@ describe('PlaylistSelector', () => {
     ) as jest.Mock
   })
 
-  it('should fetch and display playlists on render', async () => {
+  it('should fetch and display playlists on render after opening the dropdown', async () => {
     render(
       <PlaylistSelector
         onPlaylistSelected={jest.fn()}
         onPlaylistPlay={jest.fn()}
       />
     )
+    const user = userEvent.setup()
 
-    // Wait for the playlists to be fetched and rendered
+    // Click the autocomplete input to open the dropdown
+    const input = await screen.findByRole('combobox')
+    await user.click(input)
+
+    // Wait for the playlists to be fetched and rendered in the listbox
     await waitFor(() => {
-      expect(screen.getByText('Chill Hits')).toBeInTheDocument()
-      expect(screen.getByText('Rock Classics')).toBeInTheDocument()
-      expect(screen.getByText('Focus Flow')).toBeInTheDocument()
+      expect(
+        screen.getByRole('option', { name: /Chill Hits/i })
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole('option', { name: /Rock Classics/i })
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole('option', { name: /Focus Flow/i })
+      ).toBeInTheDocument()
     })
   })
 
@@ -49,8 +60,15 @@ describe('PlaylistSelector', () => {
     )
     const user = userEvent.setup()
 
-    const rockClassicsItem = await screen.findByText('Rock Classics')
-    await user.click(rockClassicsItem)
+    // Click the autocomplete input to open the dropdown
+    const input = await screen.findByRole('combobox')
+    await user.click(input)
+
+    // Click the "Rock Classics" option
+    const rockClassicsOption = await screen.findByRole('option', {
+      name: /Rock Classics/i,
+    })
+    await user.click(rockClassicsOption)
 
     // Verify the callback was called with the correct URI
     expect(onPlaylistSelected).toHaveBeenCalledWith('spotify:playlist:2')
@@ -66,12 +84,19 @@ describe('PlaylistSelector', () => {
     )
     const user = userEvent.setup()
 
-    const focusFlowItem = await screen.findByText('Focus Flow')
-    const listItem = focusFlowItem.closest('li')
-    if (!listItem) throw new Error('Playlist item not found')
+    // Click the autocomplete input to open the dropdown
+    const input = await screen.findByRole('combobox')
+    await user.click(input)
 
-    const playButton = within(listItem).getByRole('button', { name: /play/i })
+    // Find the option
+    const focusFlowOption = await screen.findByRole('option', {
+      name: /Focus Flow/i,
+    })
 
+    // Find the play button within that option and click it
+    const playButton = within(focusFlowOption).getByRole('button', {
+      name: /Play Focus Flow/i,
+    })
     await user.click(playButton)
 
     expect(onPlaylistPlay).toHaveBeenCalledWith('spotify:playlist:3')


### PR DESCRIPTION
Refactors the Spotify playlist selector to display playlist details on the same page instead of navigating to a new URL.

- The `PlaylistSelector` component is refactored to use the Material-UI `Autocomplete` component's built-in features for rendering options, which fixes the "squished" UI.
- The incorrect navigation is fixed by removing the `Link` component and using local state to conditionally render a new `PlaylistDetails` component.
- The `PlaylistDetails` component fetches and displays the tracks of the selected playlist.
- Unit tests for the `PlaylistSelector` are updated to reflect the new UI structure.
