### PR TITLE
feat: Implement stable client IDs for persistent HRM data tracking

### DIFF
--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -71,14 +71,18 @@ export interface WebSocketContextType extends WebSocketState {
 export const WebSocketContext = createContext<WebSocketContextType | null>(null)
 
 // Helper for stable ID
-const generateUUID = () => {
-  // Native support check
-  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+const DEFAULT_UUID_FALLBACK = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'
+
+export const generateUUID = () => {
+  const isSecureContext =
+    typeof window !== 'undefined' && window.location.protocol === 'https:'
+  // Use native crypto.randomUUID only in secure contexts (HTTPS)
+  if (isSecureContext && typeof crypto !== 'undefined' && crypto.randomUUID) {
     return crypto.randomUUID()
   }
 
   // Fallback for insecure contexts or older browsers
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+  return DEFAULT_UUID_FALLBACK.replace(/[xy]/g, (c) => {
     const r = (Math.random() * 16) | 0
     const v = c === 'x' ? r : (r & 0x3) | 0x8
     return v.toString(16)

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -70,6 +70,21 @@ export interface WebSocketContextType extends WebSocketState {
 
 export const WebSocketContext = createContext<WebSocketContextType | null>(null)
 
+// Helper for stable ID
+const getClientId = () => {
+  // IMPORTANT: This client-side ID is for session persistence and UX ONLY.
+  // It is NOT a security feature. It is vulnerable to tampering and should not
+  // be used for authentication or authorization. For any sensitive operations,
+  // a proper server-side session with secure authentication (e.g., cookies, JWTs) is required.
+  if (typeof window === 'undefined') return ''
+  let id = localStorage.getItem('hrm_client_uuid')
+  if (!id) {
+    id = crypto.randomUUID() // Browser native UUID
+    localStorage.setItem('hrm_client_uuid', id)
+  }
+  return id
+}
+
 export const WebSocketProvider = ({
   children,
   serverUrl,
@@ -77,7 +92,6 @@ export const WebSocketProvider = ({
   children: ReactNode
   serverUrl?: string
 }) => {
-  const wsUrl = serverUrl || getWebSocketURL()
   const [connectionStatus, setConnectionStatus] = useState('Connecting...')
   const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const reconnectAttempts = useRef(0)
@@ -227,6 +241,14 @@ export const WebSocketProvider = ({
     }, 30000)
   }, [stopHeartbeat])
 
+  // Append clientId to query string
+  const getUrlWithId = useCallback(() => {
+    const base = serverUrl || getWebSocketURL()
+    const url = new URL(base)
+    url.searchParams.append('clientId', getClientId())
+    return url.toString()
+  }, [serverUrl])
+
   const connect = useCallback(() => {
     if (
       typeof window === 'undefined' ||
@@ -236,7 +258,7 @@ export const WebSocketProvider = ({
     }
 
     shouldReconnect.current = true
-    const ws = new WebSocket(wsUrl)
+    const ws = new WebSocket(getUrlWithId())
     wsRef.current = ws
 
     ws.onopen = () => {
@@ -360,7 +382,7 @@ export const WebSocketProvider = ({
         console.error('Failed to parse WebSocket message:', e)
       }
     }
-  }, [wsUrl, throttledDispatch, startHeartbeat, stopHeartbeat])
+  }, [getUrlWithId, throttledDispatch, startHeartbeat, stopHeartbeat])
 
   const disconnect = useCallback(() => {
     shouldReconnect.current = false

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -71,6 +71,20 @@ export interface WebSocketContextType extends WebSocketState {
 export const WebSocketContext = createContext<WebSocketContextType | null>(null)
 
 // Helper for stable ID
+const generateUUID = () => {
+  // Native support check
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID()
+  }
+
+  // Fallback for insecure contexts or older browsers
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0
+    const v = c === 'x' ? r : (r & 0x3) | 0x8
+    return v.toString(16)
+  })
+}
+
 const getClientId = () => {
   // IMPORTANT: This client-side ID is for session persistence and UX ONLY.
   // It is NOT a security feature. It is vulnerable to tampering and should not
@@ -79,7 +93,7 @@ const getClientId = () => {
   if (typeof window === 'undefined') return ''
   let id = localStorage.getItem('hrm_client_uuid')
   if (!id) {
-    id = crypto.randomUUID() // Browser native UUID
+    id = generateUUID()
     localStorage.setItem('hrm_client_uuid', id)
   }
   return id

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -23,6 +23,7 @@ const envSchema = z.object({
     .string()
     .default('10000')
     .transform(Number),
+  WEBSOCKET_GRACE_PERIOD_MS: z.string().default('5000').transform(Number),
 })
 
 export const env = envSchema.parse(process.env)

--- a/tests/unit/socketManager.test.ts
+++ b/tests/unit/socketManager.test.ts
@@ -86,6 +86,7 @@ class MockWebSocket extends EventEmitter {
   terminate = jest.fn()
   ping = jest.fn()
   send = jest.fn()
+  clientId?: string
 
   constructor() {
     super()
@@ -157,10 +158,6 @@ describe('WebSocket Manager', () => {
     })
 
     initSocketManager(mockWss, getSnapshot, mockServices)
-
-    mockWs = new MockWebSocket()
-    ;(mockWss.clients as Set<MockWebSocket>).add(mockWs)
-    mockWss.emit('connection', mockWs)
   })
 
   afterEach(() => {
@@ -180,13 +177,15 @@ describe('WebSocket Manager', () => {
 
     it('should set isAlive to true on new connection', () => {
       const newWs = new MockWebSocket() as ExtWebSocket
-      mockWss.emit('connection', newWs)
+      const mockReq = { url: '/', headers: { host: 'localhost' } }
+      mockWss.emit('connection', newWs, mockReq)
       expect(newWs.isAlive).toBe(true)
     })
 
     it('should set isAlive to true on pong', () => {
       const newWs = new MockWebSocket() as ExtWebSocket
-      mockWss.emit('connection', newWs)
+      const mockReq = { url: '/', headers: { host: 'localhost' } }
+      mockWss.emit('connection', newWs, mockReq)
       newWs.isAlive = false // Manually set to false
       newWs.emit('pong')
       expect(newWs.isAlive).toBe(true)
@@ -202,6 +201,14 @@ describe('WebSocket Manager', () => {
 
   describe('Calorie Calculation', () => {
     it('should accumulate calories correctly with small frequent updates', () => {
+      mockWs = new MockWebSocket()
+      ;(mockWss.clients as Set<MockWebSocket>).add(mockWs)
+      const mockReq = {
+        url: '/?clientId=11111111-1111-1111-1111-111111111111',
+        headers: { host: 'localhost' },
+      }
+      mockWss.emit('connection', mockWs, mockReq)
+
       const sendHrmInput = (hr: number) => {
         const message = JSON.stringify({
           type: 'HRM_INPUT',
@@ -239,6 +246,16 @@ describe('WebSocket Manager', () => {
   })
 
   describe('Message Handling', () => {
+    beforeEach(() => {
+      mockWs = new MockWebSocket()
+      ;(mockWss.clients as Set<MockWebSocket>).add(mockWs)
+      const mockReq = {
+        url: '/?clientId=11111111-1111-1111-1111-111111111111',
+        headers: { host: 'localhost' },
+      }
+      mockWss.emit('connection', mockWs, mockReq)
+    })
+
     it('should handle REGISTER_CLIENT message', () => {
       const message = JSON.stringify({
         type: 'REGISTER_CLIENT',
@@ -280,6 +297,10 @@ describe('WebSocket Manager', () => {
 
     it('should broadcast state on client disconnect', () => {
       mockWs.emit('close')
+
+      // Fast-forward timers to trigger the setTimeout in the close handler
+      jest.runOnlyPendingTimers()
+
       expect(broadcast).toHaveBeenCalledWith(
         mockWss,
         {
@@ -287,6 +308,57 @@ describe('WebSocket Manager', () => {
           payload: [],
         },
         'socketManager.broadcastState'
+      )
+    })
+
+    it('should not delete client data if they reconnect within the grace period', () => {
+      // 1. A client is connected
+      const clientId = '22222222-2222-2222-2222-222222222222'
+      const mockReq = {
+        url: `/?clientId=${clientId}`,
+        headers: { host: 'localhost' },
+      }
+      const firstWs = new MockWebSocket()
+      mockWss.emit('connection', firstWs, mockReq)
+
+      // Verify the user was added
+      let message = JSON.stringify({ type: 'GET_STATE' })
+      firstWs.emit('message', message)
+      const sentData = (sendWebSocketMessage as jest.Mock).mock.calls[0][1]
+      expect(sentData.payload.hrmData).toEqual(
+        expect.arrayContaining([expect.objectContaining({ clientId })])
+      )
+
+      // 2. The client disconnects
+      firstWs.emit('close')
+
+      // 3. Time advances, but less than the grace period
+      jest.advanceTimersByTime(3000) // 3 seconds
+
+      // 4. The client reconnects with the same ID
+      const secondWs = new MockWebSocket()
+      mockWss.emit('connection', secondWs, mockReq)
+
+      // 5. The original timer now fires
+      jest.runOnlyPendingTimers()
+
+      // 6. Verify the broadcast to delete the user was NOT called
+      //    (because a new socket for that client exists)
+      expect(broadcast).not.toHaveBeenCalledWith(
+        mockWss,
+        {
+          type: 'HRM_UPDATE',
+          payload: [], // This would be the payload on final deletion
+        },
+        'socketManager.broadcastState'
+      )
+
+      // 7. Verify the user's data still exists
+      message = JSON.stringify({ type: 'GET_STATE' })
+      secondWs.emit('message', message)
+      const finalSentData = (sendWebSocketMessage as jest.Mock).mock.calls[1][1]
+      expect(finalSentData.payload.hrmData).toEqual(
+        expect.arrayContaining([expect.objectContaining({ clientId })])
       )
     })
 
@@ -316,6 +388,7 @@ describe('WebSocket Manager', () => {
           deviceId: undefined,
           volume: undefined,
           playlistUri: undefined,
+          contextUri: undefined,
         }
       )
     })

--- a/tests/unit/socketManager.test.ts
+++ b/tests/unit/socketManager.test.ts
@@ -12,6 +12,7 @@ import {
 import {
   initSocketManager,
   resetSocketManager,
+  getRequestParams,
 } from '../../utils/socketManager'
 import { Server as WebSocketServer } from 'ws'
 import { EventEmitter } from 'events'
@@ -427,6 +428,53 @@ describe('WebSocket Manager', () => {
         expect.any(Object),
         'Unknown message type received'
       )
+    })
+  })
+  describe('getRequestParams', () => {
+    beforeEach(() => {
+      ;(logger.error as jest.Mock).mockClear()
+    })
+
+    it('should correctly parse clientId from a standard URL', () => {
+      const req = {
+        url: '/?clientId=abcdef-123456',
+        headers: { host: 'localhost:3000' },
+      }
+      const params = getRequestParams(req as any)
+      expect(params.get('clientId')).toBe('abcdef-123456')
+    })
+
+    it('should return empty params and log an error when URL is malformed', () => {
+      const req = {
+        url: 'a',
+        headers: { host: 'a:b:c' },
+      };
+      const params = getRequestParams(req as any);
+      expect(params.toString()).toBe('');
+      expect(logger.error).toHaveBeenCalled();
+    })
+
+    it('should handle missing host header by falling back to localhost', () => {
+      const req = { url: '/?foo=bar', headers: {} }
+      const params = getRequestParams(req as any)
+      expect(params.get('foo')).toBe('bar')
+    })
+
+    it('should handle missing URL by defaulting to "/"', () => {
+      const req = { headers: { host: 'testhost' } }
+      const params = getRequestParams(req as any)
+      expect(params.toString()).toBe('')
+    })
+
+    it('should handle multiple query parameters', () => {
+      const req = {
+        url: '/?clientId=123&user=test&mode=active',
+        headers: { host: 'localhost' },
+      }
+      const params = getRequestParams(req as any)
+      expect(params.get('clientId')).toBe('123')
+      expect(params.get('user')).toBe('test')
+      expect(params.get('mode')).toBe('active')
     })
   })
 })

--- a/utils/socketManager.ts
+++ b/utils/socketManager.ts
@@ -42,6 +42,7 @@ let services: AppServices
 // - clientSockets: Maps a clientId to their active WebSocket connection. Used to handle zombie connections and check for reconnections.
 // - clientSessionState: Holds internal server state for calculations (e.g., calorie accumulation), not sent to the client.
 const hrmDataRepository = new HrmDataRepository()
+const MAX_CLIENTS = 1000 // Prevent memory exhaustion
 
 // Track active sockets separately so we can handle "zombie" sockets during reconnects
 const clientSockets = new Map<string, WebSocket>()
@@ -51,6 +52,26 @@ const clientSessionState = new Map<
   string,
   { lastUpdate: number; accumulatedCalories: number }
 >()
+
+/**
+ * Safely parses the WebSocket request URL to extract search parameters.
+ * Handles cases where headers or URL might be malformed.
+ * @param req - The incoming HTTP request from the WebSocket upgrade.
+ * @returns URLSearchParams object, which will be empty if parsing fails.
+ */
+const getRequestParams = (req: IncomingMessage): URLSearchParams => {
+  try {
+    // Fallback to localhost if host header is missing, which can happen in some proxy/test setups
+    const host = req.headers.host || 'localhost'
+    const protocol = 'http' // WebSocket upgrades start as HTTP
+    const url = new URL(req.url || '/', `${protocol}://${host}`)
+    return url.searchParams
+  } catch (error) {
+    logger.error({ error }, 'Failed to parse WebSocket connection URL')
+    // Return empty params to prevent a crash on invalid URL
+    return new URLSearchParams()
+  }
+}
 
 /**
  * Initializes the WebSocket Server manager and registers the core services.
@@ -67,6 +88,12 @@ const initSocketManager = (
   connectionMonitor.start()
 
   wss.on('connection', (ws: WebSocket, req: IncomingMessage) => {
+    // Check limits before processing
+    if (clientSockets.size >= MAX_CLIENTS) {
+      logger.warn('Max connections reached. Rejecting client.')
+      ws.close(1013, 'Try again later')
+      return
+    }
     const extWs = ws as ExtWebSocket
     extWs.isAlive = true
     extWs.on('pong', () => {
@@ -74,11 +101,8 @@ const initSocketManager = (
     })
 
     // 1. EXTRACT OR GENERATE STABLE ID
-    const url = new URL(
-      req.url || '',
-      `http://${req.headers.host || 'localhost'}`
-    )
-    const requestedId = url.searchParams.get('clientId')
+    const searchParams = getRequestParams(req)
+    const requestedId = searchParams.get('clientId')
 
     // Validate requestedId to prevent injection/garbage
     const isValidId = requestedId && /^[0-9a-f-]{36}$/i.test(requestedId)

--- a/utils/socketManager.ts
+++ b/utils/socketManager.ts
@@ -4,6 +4,8 @@
  */
 import { WebSocket, Server as WebSocketServer } from 'ws'
 import { z } from 'zod' // Import z from zod
+import { IncomingMessage } from 'http'
+import { randomUUID } from 'crypto'
 import {
   ClientCommandMessageSchema,
   ClientRegistrationMessage,
@@ -25,6 +27,7 @@ import logger from './logger.js'
 import { estimateCaloriesBurned } from '../lib/calorie-estimation.js'
 import { HrmDataRepository } from '../lib/repositories/HrmDataRepository.js'
 import { AppServices } from '../lib/services.js'
+import { env } from '../lib/env.js'
 
 // Define service instances to be managed
 // New: Define a function to get the state snapshot
@@ -34,7 +37,15 @@ let wsServerInstance: WebSocketServer
 let connectionMonitor: ConnectionMonitor
 let services: AppServices
 
+// State Management:
+// - hrmDataRepository: Stores the live HRM data for each client (e.g., HR value, calories). This is the primary source of truth for broadcasted state.
+// - clientSockets: Maps a clientId to their active WebSocket connection. Used to handle zombie connections and check for reconnections.
+// - clientSessionState: Holds internal server state for calculations (e.g., calorie accumulation), not sent to the client.
 const hrmDataRepository = new HrmDataRepository()
+
+// Track active sockets separately so we can handle "zombie" sockets during reconnects
+const clientSockets = new Map<string, WebSocket>()
+
 // Track internal state for calculations (not sent to client)
 const clientSessionState = new Map<
   string,
@@ -55,39 +66,88 @@ const initSocketManager = (
   connectionMonitor = new ConnectionMonitor(wss)
   connectionMonitor.start()
 
-  wss.on('connection', (ws: WebSocket) => {
+  wss.on('connection', (ws: WebSocket, req: IncomingMessage) => {
     const extWs = ws as ExtWebSocket
     extWs.isAlive = true
     extWs.on('pong', () => {
       extWs.isAlive = true
     })
 
-    extWs.clientId = `user-${Math.random().toString(36).substring(2, 9)}`
-    logger.info({ clientId: extWs.clientId }, 'WebSocket client connected')
+    // 1. EXTRACT OR GENERATE STABLE ID
+    const url = new URL(
+      req.url || '',
+      `http://${req.headers.host || 'localhost'}`
+    )
+    const requestedId = url.searchParams.get('clientId')
 
-    // Initialize new client
-    const newClient: HrmStreamData = {
-      clientId: extWs.clientId,
-      value: 0,
-      maxHr: 185,
-      age: 30,
-      calories: 0, // Initialize to 0
+    // Validate requestedId to prevent injection/garbage
+    const isValidId = requestedId && /^[0-9a-f-]{36}$/i.test(requestedId)
+    if (requestedId && !isValidId) {
+      logger.warn(
+        { requestedId },
+        'Invalid clientId received. Generating new one.'
+      )
     }
-    hrmDataRepository.save(newClient)
-    clientSessionState.set(extWs.clientId, {
-      lastUpdate: Date.now(),
-      accumulatedCalories: 0,
-    })
+    const clientId = isValidId ? requestedId : randomUUID()
+    extWs.clientId = clientId // Keep it on the socket for logging/context
+
+    logger.info(
+      { clientId, isReconnection: !!isValidId },
+      'WebSocket client connected'
+    )
+
+    // 2. HANDLE CONFLICTS / ZOMBIES
+    if (clientSockets.has(clientId)) {
+      const oldWs = clientSockets.get(clientId)
+      if (oldWs && oldWs !== ws && oldWs.readyState === WebSocket.OPEN) {
+        logger.warn({ clientId }, 'Terminating zombie connection')
+        oldWs.terminate()
+      }
+    }
+    clientSockets.set(clientId, ws)
+
+    // 3. INITIALIZE OR RECOVER DATA
+    if (!hrmDataRepository.findById(clientId)) {
+      logger.info({ clientId }, 'Initializing new client session')
+      const newClient: HrmStreamData = {
+        clientId: clientId,
+        value: 0,
+        maxHr: 185,
+        age: 30,
+        calories: 0,
+      }
+      hrmDataRepository.save(newClient)
+      clientSessionState.set(clientId, {
+        lastUpdate: Date.now(),
+        accumulatedCalories: 0,
+      })
+    } else {
+      logger.info({ clientId }, 'Restored existing client session')
+    }
 
     extWs.on('message', (message) => {
-      handleIncomingMessage(extWs, message.toString(), extWs.clientId)
+      handleIncomingMessage(extWs, message.toString(), clientId)
     })
 
     extWs.on('close', () => {
-      logger.info({ clientId: extWs.clientId }, 'WebSocket client disconnected')
-      hrmDataRepository.deleteById(extWs.clientId)
-      clientSessionState.delete(extWs.clientId)
-      broadcastState()
+      logger.info({ clientId }, 'WebSocket client disconnected')
+
+      // CRITICAL: Do NOT immediately delete clientData.
+      // Wait a grace period (e.g., 5 seconds) to allow for page refresh.
+      // NOTE: In a high-traffic production environment, this could lead to
+      // memory pressure if many clients disconnect and don't reconnect.
+      // A more robust solution might involve a separate cleanup process
+      // or a maximum number of inactive sessions.
+      setTimeout(() => {
+        // Only delete if they haven't reconnected (i.e., the current socket is still this closed one)
+        if (clientSockets.get(clientId) === ws) {
+          logger.info({ clientId }, 'Session expired. Deleting data.')
+          hrmDataRepository.deleteById(clientId)
+          clientSessionState.delete(clientId)
+          clientSockets.delete(clientId)
+          broadcastState()
+        }
+      }, env.WEBSOCKET_GRACE_PERIOD_MS)
     })
   })
 

--- a/utils/socketManager.ts
+++ b/utils/socketManager.ts
@@ -367,4 +367,4 @@ const handleIncomingMessage = (
   }
 }
 
-export { initSocketManager }
+export { initSocketManager, getRequestParams }


### PR DESCRIPTION
This commit introduces a stable client ID strategy to ensure user session data persists across page refreshes.

On the client-side, a UUID is generated and stored in `localStorage`. This ID is now appended as a query parameter to the WebSocket connection URL.

On the server-side, the WebSocket manager now extracts the `clientId` from the URL, validates it, and uses it to manage the user's session. This includes:
- Re-hydrating user data on reconnection.
- Handling "zombie" connections by terminating old sockets.
- A 5-second grace period on disconnect to prevent data loss during page refreshes.

The unit tests for the WebSocket manager have been updated to accommodate these changes, including mocking the `IncomingMessage` object and handling the asynchronous nature of the disconnection logic.
