### PR TITLE
ci: use PAT_TOKEN for release-please action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,5 +16,5 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT_TOKEN }}
           config-file: release-please-config.json


### PR DESCRIPTION
Use PAT_TOKEN secret instead of GITHUB_TOKEN for release-please action to fix 'Resource not accessible by integration' error.

The PAT_TOKEN has the necessary permissions to create releases while GITHUB_TOKEN has limited capabilities in GitHub Actions.