### PR TITLE
ci(small): chore: only post PR comment when quality checks fail

### DIFF
--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -1071,11 +1071,16 @@ jobs:
           # Write the final comment to a file
           echo -e "$COMMENT_BODY" > test-results/pr-comment.md
 
-          # Post comment to PR
-          gh pr comment "$PR_NUMBER" --body-file test-results/pr-comment.md || {
-            echo "::warning::Failed to post comment to PR"
-            exit 0
-          }
+          # Only post comment to PR if some checks failed
+          if [ "$KNIP_RESULT" != "success" ] || [ "$LINT_RESULT" != "success" ] || [ "$BUILD_RESULT" != "success" ] || \
+             [ "$INFRA_TESTS_OUTCOME" != "success" ] || [ "$UNIT_TESTS_OUTCOME" != "success" ] || [ "$PERF_TESTS_OUTCOME" != "success" ] || [ "$VISUAL_TESTS_OUTCOME" != "success" ]; then
+            gh pr comment "$PR_NUMBER" --body-file test-results/pr-comment.md || {
+              echo "::warning::Failed to post comment to PR"
+              exit 0
+            }
+          else
+            echo "All checks passed. Skipping PR comment to reduce spam."
+          fi
 
           # Check if all passed
           if [ "$KNIP_RESULT" = "success" ] && [ "$LINT_RESULT" = "success" ] && [ "$BUILD_RESULT" = "success" ] && \


### PR DESCRIPTION
<details>
<summary>Original PR Body</summary>


</details>

## Description

This pull request modifies the Continuous Integration (CI) workflow to only post a comment on the Pull Request when quality checks fail.

The motivation behind this change is to reduce noise in PR conversations. By ensuring that automated comments from quality checks are only posted when there are actual failures, developers can more easily identify issues that require attention. This streamlines the PR review process and improves the overall developer experience by providing more focused and actionable feedback.

Fixes # 

## Change Type (select one)

- [ ] 🐛 Bug fix (non-breaking change fixing an issue)
- [ ] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix/feature causing existing functionality to break)
- [x] 🏗️ Refactoring (code change that neither fixes bug nor adds feature)
- [ ] 📚 Documentation (changes only affecting documentation)
- [ ] 🎨 Styling (changes that do not affect functionality)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [x] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [ ] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes