### PR TITLE
Revert "feat(small): [BUG] Main Dashboard: Default to 'HRM Web Player' when no active device"

### DIFF
--- a/components/SpotifyDisplay.tsx
+++ b/components/SpotifyDisplay.tsx
@@ -234,49 +234,19 @@ const SpotifyDisplay = () => {
     ) {
       dispatch({ type: 'SELECT_DEVICE', payload: activeDevice?.id ?? '' })
     }
-  }, [spotifyData.devices, selectedDeviceId, dispatch])
+  }, [spotifyData.devices, selectedDeviceId])
 
-  // Effect to auto-select the Web Player if available and no other device is active
-  useEffect(() => {
-    const devices = spotifyData.devices || []
-    const hasActiveDevice = devices.some((d) => d.is_active)
-
-    // If the SDK is ready, we have its deviceId, there's no selected device yet,
-    // and no other device is active, then select the web player.
-    if (isReady && deviceId && !selectedDeviceId && !hasActiveDevice) {
-      dispatch({ type: 'SELECT_DEVICE', payload: deviceId })
+  const sendSpotifyCommand = (
+    command: 'PLAY' | 'PAUSE' | 'NEXT' | 'PREVIOUS' | 'TRANSFER_PLAYBACK',
+    targetDeviceId?: string
+  ) => {
+    const message: SpotifyCommandMessage = {
+      type: 'SPOTIFY_COMMAND',
+      command,
+      ...(targetDeviceId && { deviceId: targetDeviceId }),
     }
-  }, [spotifyData.devices, selectedDeviceId, isReady, deviceId, dispatch]) // Re-run when devices or SDK status changes
-
-  const sendSpotifyCommand = useCallback(
-    (
-      command: 'PLAY' | 'PAUSE' | 'NEXT' | 'PREVIOUS' | 'TRANSFER_PLAYBACK',
-      // Allow overriding the device ID, e.g., for transferring playback
-      overriddenDeviceId?: string
-    ) => {
-      const targetDeviceId =
-        overriddenDeviceId ??
-        selectedDeviceId ??
-        spotifyData.devices?.find((device) => device.is_active)?.id
-
-      // For transfer, a deviceId is mandatory.
-      if (command === 'TRANSFER_PLAYBACK' && !targetDeviceId) {
-        console.error(
-          '[SpotifyDisplay] Transfer playback requires a target device.'
-        )
-        return
-      }
-
-      const finalDeviceId = targetDeviceId || undefined
-      const message: SpotifyCommandMessage = {
-        type: 'SPOTIFY_COMMAND',
-        command,
-        ...(finalDeviceId && { deviceId: finalDeviceId }),
-      }
-      sendData(message)
-    },
-    [sendData, selectedDeviceId, spotifyData.devices]
-  )
+    sendData(message)
+  }
 
   const handlePlayPauseToggle = () => {
     const command = spotifyData.isPlaying ? 'PAUSE' : 'PLAY'

--- a/tests/unit/components/SpotifyDisplay.test.tsx
+++ b/tests/unit/components/SpotifyDisplay.test.tsx
@@ -22,21 +22,6 @@ jest.mock('@/components/Spotify/CurrentSpotifyItemDisplay', () => ({
   __esModule: true,
   default: () => <div data-testid="current-spotify-item-display" />,
 }))
-jest.mock('@/components/SpotifyDeviceSelectorWrapper', () => ({
-  __esModule: true,
-  default: ({
-    onDeviceSelect,
-  }: {
-    onDeviceSelect: (deviceId: string) => void
-  }) => (
-    <button
-      data-testid="spotify-device-selector"
-      onClick={() => onDeviceSelect('mock-device-id')}
-    >
-      Select Device
-    </button>
-  ),
-}))
 jest.mock('@/context/WebSocketContext')
 jest.mock('next-auth/react', () => ({
   ...jest.requireActual('next-auth/react'), // Keep original functionality
@@ -217,106 +202,6 @@ describe('SpotifyDisplay', () => {
       })
       rerender(<SpotifyDisplay />)
       expect(slider).toHaveValue('25')
-    })
-  })
-
-  describe('Auto-selection and Command Sending', () => {
-    let mockSendData: jest.Mock
-    let initialSpotifyData: SpotifyData
-    const hrmWebPlayerDeviceId = 'hrm-web-player-device-id'
-
-    beforeEach(() => {
-      jest.useFakeTimers()
-      mockSendData = jest.fn()
-      initialSpotifyData = {
-        trackName: 'Test Track',
-        artist: 'Test Artist',
-        albumName: 'Test Album',
-        albumArtUrl: '',
-        isPlaying: true,
-        volume: 50,
-        isMuted: false,
-        devices: [
-          {
-            id: 'some-other-device',
-            name: 'Some Other Device',
-            is_active: false,
-          },
-        ],
-      }
-
-      mockedUseSession.mockReturnValue({
-        data: { accessToken: 'fake-token' },
-        status: 'authenticated',
-      })
-
-      mockedUseWebSocket.mockReturnValue({
-        spotifyData: initialSpotifyData,
-        sendData: mockSendData,
-        connectionStatus: 'Connected',
-        spotifyServiceInitialized: true,
-      })
-    })
-
-    afterEach(() => {
-      jest.useRealTimers()
-    })
-
-    it('defaults to HRM Web Player when SDK is ready and no active device', async () => {
-      mockedUseSpotifyWebPlayback.mockReturnValue({
-        isReady: true,
-        deviceId: hrmWebPlayerDeviceId,
-        player: null,
-        isAuthenticated: true,
-      })
-
-      // Ensure the web player device is part of the mocked devices for correct display logic
-      mockedUseWebSocket.mockReturnValue({
-        ...mockedUseWebSocket(),
-        spotifyData: {
-          ...initialSpotifyData,
-          devices: [
-            ...initialSpotifyData.devices,
-            {
-              id: hrmWebPlayerDeviceId,
-              name: 'HRM Web Player',
-              is_active: false,
-            },
-          ],
-        },
-      })
-
-      await act(async () => {
-        renderWithProviders(<SpotifyDisplay />)
-      })
-
-      expect(
-        await screen.findByText('🎵 Browser Player Active')
-      ).toBeInTheDocument()
-    })
-
-    it('sends command to the active device when no device is explicitly selected', () => {
-      // Set the device to active in the mock data
-      const updatedSpotifyData = {
-        ...initialSpotifyData,
-        devices: [{ ...initialSpotifyData.devices[0], is_active: true }],
-      }
-      mockedUseWebSocket.mockReturnValue({
-        ...mockedUseWebSocket(),
-        spotifyData: updatedSpotifyData,
-      })
-
-      renderWithProviders(<SpotifyDisplay />)
-      const nextButton = screen.getByRole('button', { name: /next track/i })
-      act(() => {
-        fireEvent.click(nextButton)
-      })
-      expect(mockSendData).toHaveBeenCalledWith(
-        expect.objectContaining({
-          command: 'NEXT',
-          deviceId: 'some-other-device',
-        })
-      )
     })
   })
 })


### PR DESCRIPTION
## Description

This pull request reverts the changes introduced in PR arii/hrm#3160.
The original PR, titled "feat(small): [BUG] Main Dashboard: Default to 'HRM Web Player' when no active device", is being reverted. This action likely addresses issues, unintended side effects, or a change in requirements related to the original implementation. The revert aims to restore the system to its state prior to PR arii/hrm#3160.

Fixes # (issue) - This revert addresses issues potentially introduced by, or undesirable behavior resulting from, arii/hrm#3160.

## Change Type: 🐛 Bug fix (non-breaking change fixing an issue)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [x] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [x] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

Reverts arii/hrm#3160
</details>