### PR TITLE
Revert "test(small): Fix: Disconnected HR monitor tile remains visible on dashboard"

### DIFF
--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -30,7 +30,85 @@ export interface WebSocketContextType extends WebSocketState {
 
 export const WebSocketContext = createContext<WebSocketContextType | null>(null)
 
-import { reducer } from './webSocketReducer'
+// Unified State Object managed by a reducer
+export const reducer = (
+  state: WebSocketState,
+  message: ServerMessage | { type: 'RESET_STATE' }
+): WebSocketState => {
+  switch (message.type) {
+    case 'RESET_STATE':
+      return INITIAL_STATE
+    case 'INITIAL_STATE': {
+      // When the initial state is loaded, all users present in the hrmData have their
+      // connection status explicitly set to true. This ensures that the UI correctly
+      // reflects their status.
+      const hrmDataWithConnection =
+        message.payload.hrmData?.map((d) => ({ ...d, isConnected: true })) || []
+      return {
+        ...state,
+        ...message.payload,
+        hrmData: hrmDataWithConnection,
+      }
+    }
+    case 'HRM_UPDATE': {
+      const payload = message.payload as ServerHrmData[]
+      // Create a new state array by merging existing and new data
+      // The previous logic used a Set of incoming client IDs to determine who was connected,
+      // but this was flawed. By using the payload as the single source of truth, we ensure
+      // that only users who are actively sending data are marked as connected.
+      const mergedHrmData = state.hrmData.map((existingUser) => {
+        const updatedUser = payload.find(
+          (newUser) => newUser.clientId === existingUser.clientId
+        )
+        if (updatedUser) {
+          // CRITICAL FIX: The order of spread operators is essential.
+          // By spreading existingUser first, then updatedUser, we ensure
+          // that any fields NOT present in the (potentially partial) `updatedUser`
+          // payload are preserved from the existing state.
+          return {
+            ...existingUser,
+            ...updatedUser,
+            isConnected: true,
+          }
+        }
+        return { ...existingUser, isConnected: false }
+      })
+
+      // Add any brand-new users from the payload who were not in the previous state
+      payload.forEach((newUser) => {
+        if (
+          !state.hrmData.some(
+            (existingUser) => existingUser.clientId === newUser.clientId
+          )
+        ) {
+          mergedHrmData.push({ ...newUser, isConnected: true })
+        }
+      })
+
+      return { ...state, hrmData: mergedHrmData }
+    }
+    case 'TIMER_UPDATE':
+      return {
+        ...state,
+        timerData: { ...state.timerData, ...message.payload },
+      }
+    case 'SPOTIFY_UPDATE':
+      return {
+        ...state,
+        spotifyData: { ...state.spotifyData, ...message.payload },
+      }
+    case 'ACTIVE_ALERTS_UPDATE':
+      return { ...state, activeAlerts: message.payload }
+    case 'SPOTIFY_SERVICE_INIT_UPDATE':
+      return { ...state, spotifyServiceInitialized: message.payload }
+    case 'EXECUTE_SPOTIFY':
+      // This message type is handled by useSpotifyRemoteExecution hook
+      // We don't need to update state here, just pass it through
+      return state
+    default:
+      return state
+  }
+}
 
 export const WebSocketProvider = ({
   children,

--- a/context/webSocketReducer.ts
+++ b/context/webSocketReducer.ts
@@ -66,20 +66,42 @@ export const reducer = (
     }
     case 'HRM_UPDATE': {
       const payload = message.payload as ServerHrmData[]
+      // Create a map of incoming clientIds for efficient lookup
+      const incomingClients = new Set(payload.map((user) => user.clientId))
 
-      // Filter out disconnected clients and merge new data for active ones.
-      const newHrmData = payload.map((newUser) => {
-        const existingUser = state.hrmData.find(
-          (u) => u.clientId === newUser.clientId
-        )
-        return {
-          ...(existingUser || {}), // Preserve existing data if any
-          ...newUser, // Overwrite with the new data
-          isConnected: true,
+      // Create a new state array by merging existing and new data
+      const mergedHrmData = state.hrmData.map((existingUser) => {
+        if (incomingClients.has(existingUser.clientId)) {
+          const updatedUser = payload.find(
+            (newUser) => newUser.clientId === existingUser.clientId
+          )
+          // CRITICAL FIX: The order of spread operators is essential.
+          // By spreading existingUser first, then updatedUser, we ensure
+          // that any fields NOT present in the (potentially partial) `updatedUser`
+          // payload are preserved from the existing state.
+          return updatedUser
+            ? {
+                ...existingUser,
+                ...updatedUser,
+                isConnected: true,
+              }
+            : { ...existingUser, isConnected: true }
+        }
+        return { ...existingUser, isConnected: false }
+      })
+
+      // Add any brand-new users from the payload who were not in the previous state
+      payload.forEach((newUser) => {
+        if (
+          !state.hrmData.some(
+            (existingUser) => existingUser.clientId === newUser.clientId
+          )
+        ) {
+          mergedHrmData.push({ ...newUser, isConnected: true })
         }
       })
 
-      return { ...state, hrmData: newHrmData }
+      return { ...state, hrmData: mergedHrmData }
     }
     case 'TIMER_UPDATE':
       return {

--- a/tests/unit/context/webSocketReducer.test.ts
+++ b/tests/unit/context/webSocketReducer.test.ts
@@ -115,7 +115,7 @@ describe('webSocketReducer', () => {
       expect(state.hrmData[0].isConnected).toBe(true)
     })
 
-    it('should remove a user if they are not in the payload', () => {
+    it('should mark a user as disconnected if not in payload', () => {
       const user2 = { ...baseUser, clientId: '2', userName: 'User B' }
       const initialState: WebSocketState = {
         ...INITIAL_STATE,
@@ -129,12 +129,11 @@ describe('webSocketReducer', () => {
         payload: [baseUser], // Only user 1 is in the update
       }
       const state = reducer(initialState, action)
-      expect(state.hrmData).toHaveLength(1)
+      expect(state.hrmData).toHaveLength(2)
       const updatedUser1 = state.hrmData.find((u) => u.clientId === '1')
       const updatedUser2 = state.hrmData.find((u) => u.clientId === '2')
-      expect(updatedUser1).toBeDefined()
       expect(updatedUser1?.isConnected).toBe(true)
-      expect(updatedUser2).toBeUndefined()
+      expect(updatedUser2?.isConnected).toBe(false)
     })
   })
 


### PR DESCRIPTION
## Description

This pull request reverts `arii/hrm#3195`.

The previous PR introduced a dependency error where the dashboard needs to load first before connected clients can be processed, causing a regression. Reverting `arii/hrm#3195` resolves this dependency problem.

Fixes # (regression from arii/hrm#3195)

## Change Type: 🐛 Bug fix (non-breaking change fixing an issue)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [x] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [x] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

Reverts arii/hrm#3195


leads to dependency error --dashboard needs to load first before connected clients
</details>