### PR TITLE
docs(small): fix: update tech debt prompt

### DIFF
--- a/prompts/tech-debt-analysis.md
+++ b/prompts/tech-debt-analysis.md
@@ -1,4 +1,14 @@
-You are an expert at identifying technical debt in code. Analyze the following code diff and identify any technical debt.
+You are an expert at identifying technical debt in code. Analyze the following code diff and identify any **existing technical debt in the codebase** that is revealed or highlighted by these changes.
+
+**Important:** Focus ONLY on existing issues, not on problems introduced in this PR itself. This review is designed to surface pre-existing technical debt that the current changes touch or expose.
+
+**Guidance for Analysis:**
+
+- Identify deprecated patterns, outdated approaches, or problematic code structures that existed BEFORE this PR
+- Look for code smells, maintainability issues, or architectural problems in the files being modified
+- Note anti-patterns or suboptimal implementations that this PR interacts with
+- Suggest improvements to existing code, not critiques of the new changes
+- Ignore any issues that are direct results of code changes in this PR
 
 **Output Format (JSON only):**
 Respond with a JSON object containing a list of technical debt issues. Each issue should have the following structure:
@@ -7,8 +17,8 @@ Respond with a JSON object containing a list of technical debt issues. Each issu
 {
   "issues": [
     {
-      "title": "Technical Debt: [A concise, descriptive title of the debt]",
-      "description": "[A detailed explanation of the technical debt, including why it's a problem and potential solutions. Use Markdown for formatting.]",
+      "title": "Technical Debt: [A concise, descriptive title of the pre-existing debt]",
+      "description": "[A detailed explanation of the existing technical debt, including why it's a problem and potential solutions. Use Markdown for formatting. Reference the affected code location.]",
       "fingerprint": "[A unique, stable identifier for this specific piece of technical debt. This could be a combination of the file path and a key part of the code, like a function name or a specific line.]"
     }
   ]


### PR DESCRIPTION
## Description

This pull request addresses an update to the "tech debt prompt". The change is intended to fix or improve the existing prompt, enhancing its effectiveness or correctness. The primary impact is within documentation-related areas, suggesting the prompt might be used for generating or analyzing documentation for technical debt.

Fixes #

## Change Type: 🐛 Bug fix (non-breaking change fixing an issue)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [ ] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [ ] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [ ] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [ ] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [ ] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [ ] Changes are **backward compatible** (or breaking changes are documented)
- [ ] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>


</details>