### PR TITLE
Revert "feat(small): Add unit tests for Spotify JWT scope persistence"

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -23,7 +23,6 @@ declare module 'next-auth/jwt' {
     refreshToken?: string
     error?: string
     providerAccountId?: string
-    scope?: string
   }
 }
 
@@ -129,7 +128,6 @@ async function refreshAccessToken(token: JWT) {
       // Note: Spotify might or might not send a new refresh token.
       // If it does, use it. If not, keep the old one.
       refreshToken: refreshedTokens.refresh_token ?? token.refreshToken,
-      scope: refreshedTokens.scope ?? token.scope, // Persist the scope
     }
   } catch (error) {
     logger.error({ error }, 'Failed to refresh access token')
@@ -285,7 +283,6 @@ export const authOptions: AuthOptions = {
             Date.now() + (Number(account.expires_in) || 3600) * 1000,
           refreshToken: account.refresh_token,
           providerAccountId: account.providerAccountId, // Store ID for reference
-          scope: account.scope, // <-- ADD THIS LINE
         }
 
         // Sync on initial login

--- a/tests/unit/lib/auth.test.ts
+++ b/tests/unit/lib/auth.test.ts
@@ -40,14 +40,13 @@ describe('authOptions.callbacks.jwt', () => {
     jest.clearAllMocks()
   })
 
-  it('should handle initial sign-in correctly, including scope', async () => {
+  it('should handle initial sign-in correctly', async () => {
     const account = {
       provider: 'spotify',
       providerAccountId: 'spotify-user-id',
       access_token: 'initial-access-token',
       refresh_token: 'initial-refresh-token',
       expires_in: 3600,
-      scope: 'user-read-private user-read-email',
     }
     const token = { ...baseToken }
 
@@ -61,7 +60,6 @@ describe('authOptions.callbacks.jwt', () => {
     expect(result.accessToken).toBe(account.access_token)
     expect(result.refreshToken).toBe(account.refresh_token)
     expect(result.providerAccountId).toBe(account.providerAccountId)
-    expect(result.scope).toBe(account.scope)
     expect(fetch).toHaveBeenCalledWith(
       expect.stringContaining('internal/token-delivery'),
       expect.objectContaining({
@@ -84,20 +82,18 @@ describe('authOptions.callbacks.jwt', () => {
     expect(spotify.refreshSpotifyToken).not.toHaveBeenCalled()
   })
 
-  it('should refresh the token if it is expired and persist scope', async () => {
+  it('should refresh the token if it is expired', async () => {
     const token: JWT = {
       ...baseToken,
       accessToken: 'expired-access-token',
       refreshToken: 'current-refresh-token',
       accessTokenExpires: Date.now() - 1000, // Expired 1 second ago
       providerAccountId: 'spotify-user-id',
-      scope: 'user-read-private user-read-email',
     }
     const refreshedTokens = {
       access_token: 'refreshed-access-token',
       expires_in: 3600,
       refresh_token: 'new-refresh-token',
-      // No new scope returned from refresh
     }
 
     ;(spotify.refreshSpotifyToken as jest.Mock).mockResolvedValue(
@@ -112,7 +108,6 @@ describe('authOptions.callbacks.jwt', () => {
     expect(spotify.refreshSpotifyToken).toHaveBeenCalledWith(token.refreshToken)
     expect(result.accessToken).toBe(refreshedTokens.access_token)
     expect(result.refreshToken).toBe(refreshedTokens.refresh_token)
-    expect(result.scope).toBe(token.scope) // Ensure scope is carried over
     expect(fetch).toHaveBeenCalledWith(
       expect.stringContaining('internal/token-delivery'),
       expect.objectContaining({
@@ -138,35 +133,5 @@ describe('authOptions.callbacks.jwt', () => {
 
     expect(result.error).toBe('RefreshAccessTokenError')
     expect(fetch).not.toHaveBeenCalled()
-  })
-
-  it('should update scope if a new one is returned on refresh', async () => {
-    const token: JWT = {
-      ...baseToken,
-      accessToken: 'expired-access-token',
-      refreshToken: 'current-refresh-token',
-      accessTokenExpires: Date.now() - 1000,
-      scope: 'old-scope',
-    }
-    const refreshedTokens = {
-      access_token: 'refreshed-access-token',
-      expires_in: 3600,
-      scope: 'new-scope',
-    }
-
-    ;(spotify.refreshSpotifyToken as jest.Mock).mockResolvedValue(
-      refreshedTokens
-    )
-    ;(fetch as jest.Mock).mockResolvedValueOnce({ ok: true })
-
-    const result = await jwtCallback({ token, account: null })
-
-    expect(result.scope).toBe(refreshedTokens.scope)
-    expect(fetch).toHaveBeenCalledWith(
-      expect.stringContaining('internal/token-delivery'),
-      expect.objectContaining({
-        body: expect.stringContaining('"scope":"new-scope"'),
-      })
-    )
   })
 })


### PR DESCRIPTION
## Description

This pull request reverts the changes introduced in PR arii/hrm#3439, titled "feat(small): Add unit tests for Spotify JWT scope persistence".
The revert is performed to undo the previous changes.

Fixes # 

## Change Type: 🐛 Bug fix (non-breaking change fixing an issue)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [ ] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [ ] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

Reverts arii/hrm#3439
</details>