### PR TITLE
Refactor: Extract Spotify Controls into `useSpotifyControls` Hook

### DIFF
--- a/app/client/control/components/TimerControls.tsx
+++ b/app/client/control/components/TimerControls.tsx
@@ -1,10 +1,11 @@
 // File: app/client/control/components/TimerControls.tsx
 'use client'
+// File: app/client/control/components/TimerControls.tsx
+'use client'
 import { useDebounce } from '@/hooks/useDebounce'
+import { useSpotifyControls } from '@/hooks/useSpotifyControls'
 import { useWebSocket } from '@/context/WebSocketContext'
-import { resolveSpotifyDeviceId } from '@/lib/spotify/device'
 import {
-  SpotifyCommandMessage,
   TimerCommandMessage,
   TimerConfigMessage,
   TimerModeCommandMessage,
@@ -19,7 +20,7 @@ import Card from '@mui/material/Card'
 import CardContent from '@mui/material/CardContent'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
-import { useCallback, useEffect, useState, useMemo } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { motion } from 'framer-motion'
 import DurationStepper from './DurationStepper'
 
@@ -50,6 +51,7 @@ const stopButtonSx = {
 
 const TimerControls = () => {
   const { timerData, sendData, connectionStatus } = useWebSocket()
+  const { sendSpotifyCommand } = useSpotifyControls()
   const [workTime, setWorkTime] = useState(20)
   const [restTime, setRestTime] = useState(10)
   const [optimisticAction, setOptimisticAction] = useState<
@@ -101,25 +103,6 @@ const TimerControls = () => {
     }
     sendData(message)
   }, [debouncedWorkTime, debouncedRestTime, sendData, connectionStatus])
-
-  const { spotifyData } = useWebSocket()
-  const spotifyDeviceId = useMemo(
-    () => resolveSpotifyDeviceId(spotifyData.devices || []),
-    [spotifyData.devices]
-  )
-
-  const sendSpotifyCommand = useCallback(
-    (command: 'NEXT' | 'PAUSE') => {
-      const deviceId = spotifyDeviceId || null
-      const message: SpotifyCommandMessage = {
-        type: 'SPOTIFY_COMMAND',
-        command,
-        ...(deviceId ? { deviceId } : {}),
-      }
-      sendData(message)
-    },
-    [sendData, spotifyDeviceId]
-  )
 
   const sendTimerCommand = useCallback(
     (command: 'START' | 'STOP') => {

--- a/hooks/useSpotifyControls.test.ts
+++ b/hooks/useSpotifyControls.test.ts
@@ -40,7 +40,9 @@ describe('useSpotifyControls', () => {
     ;(resolveSpotifyDeviceId as jest.Mock).mockReturnValue(mockDeviceId)
     mockUseWebSocket.mockReturnValue({
       sendData: mockSendData,
-      spotifyData: { devices: [{ id: mockDeviceId, is_active: true, name: 'Test Device' }] },
+      spotifyData: {
+        devices: [{ id: mockDeviceId, is_active: true, name: 'Test Device' }],
+      },
     })
     const { result } = renderHook(() => useSpotifyControls())
     result.current.sendSpotifyCommand('NEXT')

--- a/hooks/useSpotifyControls.test.ts
+++ b/hooks/useSpotifyControls.test.ts
@@ -1,0 +1,54 @@
+// hooks/useSpotifyControls.test.ts
+import { renderHook } from '@testing-library/react'
+import { useWebSocket } from '@/context/WebSocketContext'
+import { useSpotifyControls } from './useSpotifyControls'
+import { resolveSpotifyDeviceId } from '@/lib/spotify/device'
+
+jest.mock('@/context/WebSocketContext', () => ({
+  useWebSocket: jest.fn(),
+}))
+
+jest.mock('@/lib/spotify/device', () => ({
+  resolveSpotifyDeviceId: jest.fn(),
+}))
+
+describe('useSpotifyControls', () => {
+  const mockSendData = jest.fn()
+  const mockUseWebSocket = useWebSocket as jest.Mock
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseWebSocket.mockReturnValue({
+      sendData: mockSendData,
+      spotifyData: { devices: [] },
+    })
+  })
+
+  it('should send a PAUSE command without a device ID when no devices are available', () => {
+    ;(resolveSpotifyDeviceId as jest.Mock).mockReturnValue('')
+    const { result } = renderHook(() => useSpotifyControls())
+    result.current.sendSpotifyCommand('PAUSE')
+
+    expect(mockSendData).toHaveBeenCalledWith({
+      type: 'SPOTIFY_COMMAND',
+      command: 'PAUSE',
+    })
+  })
+
+  it('should send a NEXT command with a device ID when a device is available', () => {
+    const mockDeviceId = 'test-device-id'
+    ;(resolveSpotifyDeviceId as jest.Mock).mockReturnValue(mockDeviceId)
+    mockUseWebSocket.mockReturnValue({
+      sendData: mockSendData,
+      spotifyData: { devices: [{ id: mockDeviceId, is_active: true, name: 'Test Device' }] },
+    })
+    const { result } = renderHook(() => useSpotifyControls())
+    result.current.sendSpotifyCommand('NEXT')
+
+    expect(mockSendData).toHaveBeenCalledWith({
+      type: 'SPOTIFY_COMMAND',
+      command: 'NEXT',
+      deviceId: mockDeviceId,
+    })
+  })
+})

--- a/hooks/useSpotifyControls.ts
+++ b/hooks/useSpotifyControls.ts
@@ -1,0 +1,39 @@
+// hooks/useSpotifyControls.ts
+'use client'
+
+import { useCallback, useMemo } from 'react'
+import { useWebSocket } from '@/context/WebSocketContext'
+import { resolveSpotifyDeviceId } from '@/lib/spotify/device'
+import { SpotifyCommandMessage } from '@/types/websocket'
+
+/**
+ * Custom hook to encapsulate Spotify control logic.
+ *
+ * This hook provides a centralized way to manage Spotify commands,
+ * abstracting the WebSocket communication and device ID resolution.
+ *
+ * @returns An object containing the `sendSpotifyCommand` function.
+ */
+export const useSpotifyControls = () => {
+  const { spotifyData, sendData } = useWebSocket()
+
+  const spotifyDeviceId = useMemo(
+    () => resolveSpotifyDeviceId(spotifyData.devices || []),
+    [spotifyData.devices]
+  )
+
+  const sendSpotifyCommand = useCallback(
+    (command: 'NEXT' | 'PAUSE') => {
+      const deviceId = spotifyDeviceId || null
+      const message: SpotifyCommandMessage = {
+        type: 'SPOTIFY_COMMAND',
+        command,
+        ...(deviceId ? { deviceId } : {}),
+      }
+      sendData(message)
+    },
+    [sendData, spotifyDeviceId]
+  )
+
+  return { sendSpotifyCommand }
+}


### PR DESCRIPTION
## Description

This pull request extracts the Spotify command sending logic and device management from the `TimerControls.tsx` component into a dedicated custom React hook, `useSpotifyControls`. This change improves the encapsulation of Spotify-specific concerns, enhances the readability of the `TimerControls` component, and makes the Spotify interaction logic more reusable and testable. A new test file with unit tests for the `useSpotifyControls` hook has also been added.

Fixes #4306

## Change Type: 🏗️ Refactoring (code change that neither fixes bug nor adds feature)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [x] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [x] **Tests** are added/updated for new functionality
- [x] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

This pull request extracts the Spotify command sending logic and device management from the `TimerControls.tsx` component into a dedicated custom React hook, `useSpotifyControls`. This change improves the encapsulation of Spotify-specific concerns, enhances the readability of the `TimerControls` component, and makes the Spotify interaction logic more reusable and testable. A new test file with unit tests for the `useSpotifyControls` hook has also been added.

Fixes #4306

---
*PR created automatically by Jules for task [506344227661929412](https://jules.google.com/task/506344227661929412) started by @arii*
</details>