### PR TITLE
Enhance `resolveSpotifyDeviceId` for Robust Spotify Device Selection Logic

### DIFF
--- a/app/client/control/components/TimerControls.tsx
+++ b/app/client/control/components/TimerControls.tsx
@@ -104,7 +104,11 @@ const TimerControls = () => {
 
   const { spotifyData } = useWebSocket()
   const spotifyDeviceId = useMemo(
-    () => resolveSpotifyDeviceId(spotifyData.devices || []),
+    () =>
+      resolveSpotifyDeviceId(spotifyData.devices || [], [
+        'Computer',
+        'Speaker',
+      ]),
     [spotifyData.devices]
   )
 

--- a/lib/spotify/device.ts
+++ b/lib/spotify/device.ts
@@ -4,7 +4,28 @@ import type { SpotifyDevice } from '@/types/core'
  * Resolves the target device ID from a list of devices.
  * Returns the active device, or the first device if none are active.
  */
-export function resolveSpotifyDeviceId(devices: SpotifyDevice[]): string {
+export function resolveSpotifyDeviceId(
+  devices: SpotifyDevice[],
+  preferredDeviceTypes: string[] = [],
+): string {
+  if (!devices || devices.length === 0) {
+    return ''
+  }
+
+  // 1. Prioritize the active device
   const activeDevice = devices.find((d) => d.is_active)
-  return activeDevice?.id || devices[0]?.id || ''
+  if (activeDevice) {
+    return activeDevice.id
+  }
+
+  // 2. Prioritize preferred device types
+  for (const preferredType of preferredDeviceTypes) {
+    const preferredDevice = devices.find((d) => d.type === preferredType)
+    if (preferredDevice) {
+      return preferredDevice.id
+    }
+  }
+
+  // 3. Fallback to the first available device
+  return devices[0].id
 }

--- a/lib/spotify/device.ts
+++ b/lib/spotify/device.ts
@@ -6,7 +6,7 @@ import type { SpotifyDevice } from '@/types/core'
  */
 export function resolveSpotifyDeviceId(
   devices: SpotifyDevice[],
-  preferredDeviceTypes: string[] = [],
+  preferredDeviceTypes: string[] = []
 ): string {
   if (!devices || devices.length === 0) {
     return ''
@@ -27,5 +27,5 @@ export function resolveSpotifyDeviceId(
   }
 
   // 3. Fallback to the first available device
-  return devices[0].id
+  return devices[0]?.id || ''
 }

--- a/lib/spotify/device.ts
+++ b/lib/spotify/device.ts
@@ -1,8 +1,16 @@
 import type { SpotifyDevice } from '@/types/core'
 
 /**
- * Resolves the target device ID from a list of devices.
- * Returns the active device, or the first device if none are active.
+ * Resolves the target device ID from a list of available devices.
+ *
+ * The selection logic prioritizes devices in the following order:
+ * 1. The currently active device.
+ * 2. The first device matching a type from the `preferredDeviceTypes` list (case-insensitive).
+ * 3. The first device in the overall list as a fallback.
+ *
+ * @param devices - An array of available Spotify devices.
+ * @param preferredDeviceTypes - An optional array of device type strings to prioritize, e.g., ['Computer', 'Speaker'].
+ * @returns The ID of the resolved Spotify device, or an empty string if no device is found.
  */
 export function resolveSpotifyDeviceId(
   devices: SpotifyDevice[],

--- a/lib/spotify/device.ts
+++ b/lib/spotify/device.ts
@@ -18,9 +18,11 @@ export function resolveSpotifyDeviceId(
     return activeDevice.id
   }
 
-  // 2. Prioritize preferred device types
+  // 2. Prioritize preferred device types (case-insensitive)
   for (const preferredType of preferredDeviceTypes) {
-    const preferredDevice = devices.find((d) => d.type === preferredType)
+    const preferredDevice = devices.find(
+      (d) => d.type.toLowerCase() === preferredType.toLowerCase()
+    )
     if (preferredDevice) {
       return preferredDevice.id
     }

--- a/tests/unit/lib/spotify/device.spec.ts
+++ b/tests/unit/lib/spotify/device.spec.ts
@@ -42,19 +42,42 @@ describe('resolveSpotifyDeviceId', () => {
     expect(resolveSpotifyDeviceId([])).toBe('')
   })
 
-  it('should return the first device ID if no device is active', () => {
+  it('should return the first device ID if no device is active and no preferred types are provided', () => {
     expect(resolveSpotifyDeviceId(mockDevices)).toBe('MOCK_DEVICE_ID_1')
   })
 
   it('should return the active device ID if one is active', () => {
-    const devices = [...mockDevices]
+    const devices = JSON.parse(JSON.stringify(mockDevices))
     devices[1].is_active = true
     expect(resolveSpotifyDeviceId(devices)).toBe('MOCK_DEVICE_ID_2')
   })
 
-  it('should return the active device ID if multiple devices are present but only one is active', () => {
-    const devices = [...mockDevices]
+  it('should return the active device ID even if preferred types are provided', () => {
+    const devices = JSON.parse(JSON.stringify(mockDevices))
     devices[2].is_active = true
-    expect(resolveSpotifyDeviceId(devices)).toBe('MOCK_DEVICE_ID_3')
+    expect(resolveSpotifyDeviceId(devices, ['MOCK_DEVICE_TYPE_1'])).toBe(
+      'MOCK_DEVICE_ID_3',
+    )
+  })
+
+  it('should return the first preferred device type if no device is active', () => {
+    const preferredTypes = ['MOCK_DEVICE_TYPE_2', 'MOCK_DEVICE_TYPE_3']
+    expect(resolveSpotifyDeviceId(mockDevices, preferredTypes)).toBe(
+      'MOCK_DEVICE_ID_2',
+    )
+  })
+
+  it('should return the second preferred device type if the first is not available', () => {
+    const preferredTypes = ['NonExistentType', 'MOCK_DEVICE_TYPE_3']
+    expect(resolveSpotifyDeviceId(mockDevices, preferredTypes)).toBe(
+      'MOCK_DEVICE_ID_3',
+    )
+  })
+
+  it('should return the first device if no preferred types match and no device is active', () => {
+    const preferredTypes = ['NonExistentType1', 'NonExistentType2']
+    expect(resolveSpotifyDeviceId(mockDevices, preferredTypes)).toBe(
+      'MOCK_DEVICE_ID_1',
+    )
   })
 })

--- a/tests/unit/lib/spotify/device.spec.ts
+++ b/tests/unit/lib/spotify/device.spec.ts
@@ -80,4 +80,11 @@ describe('resolveSpotifyDeviceId', () => {
       'MOCK_DEVICE_ID_1'
     )
   })
+
+  it('should perform case-insensitive matching for preferred device types', () => {
+    const preferredTypes = ['mock_device_type_2']
+    expect(resolveSpotifyDeviceId(mockDevices, preferredTypes)).toBe(
+      'MOCK_DEVICE_ID_2'
+    )
+  })
 })

--- a/tests/unit/lib/spotify/device.spec.ts
+++ b/tests/unit/lib/spotify/device.spec.ts
@@ -56,28 +56,28 @@ describe('resolveSpotifyDeviceId', () => {
     const devices = JSON.parse(JSON.stringify(mockDevices))
     devices[2].is_active = true
     expect(resolveSpotifyDeviceId(devices, ['MOCK_DEVICE_TYPE_1'])).toBe(
-      'MOCK_DEVICE_ID_3',
+      'MOCK_DEVICE_ID_3'
     )
   })
 
   it('should return the first preferred device type if no device is active', () => {
     const preferredTypes = ['MOCK_DEVICE_TYPE_2', 'MOCK_DEVICE_TYPE_3']
     expect(resolveSpotifyDeviceId(mockDevices, preferredTypes)).toBe(
-      'MOCK_DEVICE_ID_2',
+      'MOCK_DEVICE_ID_2'
     )
   })
 
   it('should return the second preferred device type if the first is not available', () => {
     const preferredTypes = ['NonExistentType', 'MOCK_DEVICE_TYPE_3']
     expect(resolveSpotifyDeviceId(mockDevices, preferredTypes)).toBe(
-      'MOCK_DEVICE_ID_3',
+      'MOCK_DEVICE_ID_3'
     )
   })
 
   it('should return the first device if no preferred types match and no device is active', () => {
     const preferredTypes = ['NonExistentType1', 'NonExistentType2']
     expect(resolveSpotifyDeviceId(mockDevices, preferredTypes)).toBe(
-      'MOCK_DEVICE_ID_1',
+      'MOCK_DEVICE_ID_1'
     )
   })
 })


### PR DESCRIPTION
## Description

This change enhances the `resolveSpotifyDeviceId` utility function to provide more robust Spotify device selection logic. The updated function now prioritizes active devices and allows for preferred device types, improving the user experience in environments with multiple Spotify devices. I have also updated the unit tests to ensure the new logic is working correctly.

Fixes #4434

## Change Type: ✨ New feature (non-breaking change adding functionality)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [x] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [x] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

This change enhances the `resolveSpotifyDeviceId` utility function to provide more robust Spotify device selection logic. The updated function now prioritizes active devices and allows for preferred device types, improving the user experience in environments with multiple Spotify devices. I have also updated the unit tests to ensure the new logic is working correctly.

Fixes #4434

---
*PR created automatically by Jules for task [2614875851998546066](https://jules.google.com/task/2614875851998546066) started by @arii*
</details>