### PR TITLE
fix(TimerControls): Synchronize optimistic UI with server state

### DIFF
--- a/app/client/control/components/TimerControls.effects.test.tsx
+++ b/app/client/control/components/TimerControls.effects.test.tsx
@@ -1,32 +1,34 @@
-
-import { act, render, screen, fireEvent, waitFor } from '@testing-library/react';
-import TimerControls from '@/app/client/control/components/TimerControls';
-import { WebSocketContext, WebSocketContextType } from '@/context/WebSocketContext';
-import { useWebSocket } from '@/context/WebSocketContext';
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react'
+import TimerControls from '@/app/client/control/components/TimerControls'
+import { useWebSocket } from '@/context/WebSocketContext'
 
 jest.mock('@/context/WebSocketContext', () => ({
   ...jest.requireActual('@/context/WebSocketContext'),
   useWebSocket: jest.fn(),
-}));
+}))
 
-const mockUseWebSocket = useWebSocket as jest.Mock;
+const mockUseWebSocket = useWebSocket as jest.Mock
 
 describe('TimerControls Effects', () => {
   it('should revert optimistic state when server state changes', async () => {
-    const mockSendData = jest.fn();
-    const initialTimerData = { isRunning: false, currentPhase: 'WORK', mode: 'TABATA' };
+    const mockSendData = jest.fn()
+    const initialTimerData = {
+      isRunning: false,
+      currentPhase: 'WORK',
+      mode: 'TABATA',
+    }
 
     mockUseWebSocket.mockReturnValue({
       timerData: initialTimerData,
       sendData: mockSendData,
       connectionStatus: 'Connected',
-    });
+    })
 
-    const { rerender } = render(<TimerControls />);
+    const { rerender } = render(<TimerControls />)
 
     // User clicks START, UI optimistically updates to 'Running'
-    fireEvent.click(screen.getByTestId('start-timer-button'));
-    expect(screen.getByTestId('timer-running')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('start-timer-button'))
+    expect(screen.getByTestId('timer-running')).toBeInTheDocument()
 
     // Server sends a delayed response indicating the timer is NOT running
     act(() => {
@@ -34,14 +36,14 @@ describe('TimerControls Effects', () => {
         timerData: { ...initialTimerData, isRunning: false },
         sendData: mockSendData,
         connectionStatus: 'Connected',
-      });
-    });
+      })
+    })
 
-    rerender(<TimerControls />);
+    rerender(<TimerControls />)
 
     // The UI should revert to the server's state
     await waitFor(() => {
-      expect(screen.getByTestId('timer-stopped')).toBeInTheDocument();
-    });
-  });
-});
+      expect(screen.getByTestId('timer-stopped')).toBeInTheDocument()
+    })
+  })
+})

--- a/app/client/control/components/TimerControls.effects.test.tsx
+++ b/app/client/control/components/TimerControls.effects.test.tsx
@@ -1,0 +1,47 @@
+
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react';
+import TimerControls from '@/app/client/control/components/TimerControls';
+import { WebSocketContext, WebSocketContextType } from '@/context/WebSocketContext';
+import { useWebSocket } from '@/context/WebSocketContext';
+
+jest.mock('@/context/WebSocketContext', () => ({
+  ...jest.requireActual('@/context/WebSocketContext'),
+  useWebSocket: jest.fn(),
+}));
+
+const mockUseWebSocket = useWebSocket as jest.Mock;
+
+describe('TimerControls Effects', () => {
+  it('should revert optimistic state when server state changes', async () => {
+    const mockSendData = jest.fn();
+    const initialTimerData = { isRunning: false, currentPhase: 'WORK', mode: 'TABATA' };
+
+    mockUseWebSocket.mockReturnValue({
+      timerData: initialTimerData,
+      sendData: mockSendData,
+      connectionStatus: 'Connected',
+    });
+
+    const { rerender } = render(<TimerControls />);
+
+    // User clicks START, UI optimistically updates to 'Running'
+    fireEvent.click(screen.getByTestId('start-timer-button'));
+    expect(screen.getByTestId('timer-running')).toBeInTheDocument();
+
+    // Server sends a delayed response indicating the timer is NOT running
+    act(() => {
+      mockUseWebSocket.mockReturnValue({
+        timerData: { ...initialTimerData, isRunning: false },
+        sendData: mockSendData,
+        connectionStatus: 'Connected',
+      });
+    });
+
+    rerender(<TimerControls />);
+
+    // The UI should revert to the server's state
+    await waitFor(() => {
+      expect(screen.getByTestId('timer-stopped')).toBeInTheDocument();
+    });
+  });
+});

--- a/app/client/control/components/TimerControls.tsx
+++ b/app/client/control/components/TimerControls.tsx
@@ -69,11 +69,11 @@ const TimerControls = () => {
       setOptimisticAction(null)
     }
     // Disabling the lint rule because we intentionally want this effect to run
-    // ONLY when timerData.isRunning changes, to synchronize the client state
+    // ONLY when timerData changes, to synchronize the client state
     // with the server's ground truth. Adding optimisticAction to the dependency
     // array would cause an infinite loop.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [timerData.isRunning])
+  }, [timerData])
 
   // Safety timeout to clear the optimistic action if the server doesn't
   // confirm it within a reasonable time.

--- a/app/client/control/components/TimerControls.tsx
+++ b/app/client/control/components/TimerControls.tsx
@@ -62,7 +62,7 @@ const TimerControls = () => {
   const debouncedWorkTime = useDebounce(workTime, 500)
   const debouncedRestTime = useDebounce(restTime, 500)
 
-  // When the server's running state changes, it becomes the source of truth.
+  // When the server's timer data changes, it becomes the source of truth.
   // We clear any optimistic action to ensure the UI reflects the server state.
   useEffect(() => {
     if (optimisticAction !== null) {


### PR DESCRIPTION
## Description

The TimerControls component's optimistic UI state (optimisticIsRunning) could become desynchronized from the server's authoritative timer state (timerData.isRunning). This change ensures that the optimistic UI state is always reset when new data is received from the server, preventing inconsistencies.

This fix addresses the issue where the client-side UI could show an incorrect timer state (e.g., running when the server indicates stopped, or vice versa) due to the optimistic update not being fully reconciled with the server's source of truth. By resetting the optimistic state upon receiving new server data, we guarantee eventual consistency and a more reliable user experience.

No specific external dependencies are required for this change.

Fixes #4125

## Change Type: 🐛 Bug fix (non-breaking change fixing an issue)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [x] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [x] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

The TimerControls component's optimistic UI state (optimisticIsRunning) could become desynchronized from the server's authoritative timer state (timerData.isRunning). This change ensures that the optimistic UI state is always reset when new data is received from the server, preventing inconsistencies.

Fixes #4125

---
*PR created automatically by Jules for task [11995794119441910154](https://jules.google.com/task/11995794119441910154) started by @arii*
</details>