### PR TITLE
Refactor: Align Client-Side Timer ID Types to `number`

### DIFF
--- a/app/client/control/components/SpotifyControls.tsx
+++ b/app/client/control/components/SpotifyControls.tsx
@@ -193,11 +193,11 @@ const SpotifyControls = () => {
   useEffect(() => {
     // Clear any existing timer
     if (debounceTimeoutRef.current) {
-      clearTimeout(debounceTimeoutRef.current)
+      window.clearTimeout(debounceTimeoutRef.current)
     }
 
     // Set a new timer to send the volume command after 300ms
-    debounceTimeoutRef.current = setTimeout(() => {
+    debounceTimeoutRef.current = window.setTimeout(() => {
       sendVolumeCommand(volume)
     }, 300)
 
@@ -205,7 +205,7 @@ const SpotifyControls = () => {
     // or if the volume changes again before the timeout has passed
     return () => {
       if (debounceTimeoutRef.current) {
-        clearTimeout(debounceTimeoutRef.current)
+        window.clearTimeout(debounceTimeoutRef.current)
       }
     }
   }, [volume, sendVolumeCommand])

--- a/app/client/control/components/SpotifyControls.tsx
+++ b/app/client/control/components/SpotifyControls.tsx
@@ -182,7 +182,7 @@ const SpotifyControls = () => {
     [connectionStatus, resolveTargetDeviceId, sendData]
   )
 
-  const debounceTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+  const debounceTimeoutRef = useRef<number | null>(null)
 
   useEffect(() => {
     if (connectionStatus !== 'Connected') {

--- a/app/client/experimental/useLocalWorkoutBuffer.ts
+++ b/app/client/experimental/useLocalWorkoutBuffer.ts
@@ -111,10 +111,10 @@ export const useLocalWorkoutBuffer = (
     // This allows data collection to begin immediately and catch the HR
     // signal as soon as it's available.
     if (workoutData.status === 'running') {
-      intervalId = setInterval(recordHrData, 1000)
+      intervalId = window.setInterval(recordHrData, 1000)
     }
     return () => {
-      if (intervalId) clearInterval(intervalId)
+      if (intervalId) window.clearInterval(intervalId)
     }
   }, [workoutData.status, recordHrData])
 

--- a/app/client/experimental/useLocalWorkoutBuffer.ts
+++ b/app/client/experimental/useLocalWorkoutBuffer.ts
@@ -105,7 +105,7 @@ export const useLocalWorkoutBuffer = (
   }, [getZoneForHr, setWorkoutData])
 
   useEffect(() => {
-    let intervalId: NodeJS.Timeout | null = null
+    let intervalId: number | null = null
     // CHANGED: The interval now starts as soon as the workout is running,
     // regardless of whether there's an active HR signal.
     // This allows data collection to begin immediately and catch the HR

--- a/app/client/mock/page.tsx
+++ b/app/client/mock/page.tsx
@@ -25,7 +25,7 @@ export default function MockPage() {
   const [weight, setWeight] = useState(70) // Add weight state
   const [height, setHeight] = useState(175) // Add height state
   const [gender, setGender] = useState('male') // Add gender state
-  const [intervalId, setIntervalId] = useState<NodeJS.Timeout | null>(null)
+  const [intervalId, setIntervalId] = useState<number | null>(null)
 
   const isStreaming = intervalId !== null
   const maxHr = 220 - age

--- a/app/client/mock/page.tsx
+++ b/app/client/mock/page.tsx
@@ -32,14 +32,14 @@ export default function MockPage() {
 
   // Signal when page is ready for testing
   useEffect(() => {
-    const timer = setTimeout(() => {
+    const timer = window.setTimeout(() => {
       if (typeof window !== 'undefined') {
         window.__TEST_READY__ = true
         window.dispatchEvent(new CustomEvent('test-ready'))
       }
     }, 1000)
 
-    return () => clearTimeout(timer)
+    return () => window.clearTimeout(timer)
   }, [])
 
   const sendHrPacket = useCallback(
@@ -80,7 +80,7 @@ export default function MockPage() {
   const startStreaming = () => {
     if (isStreaming || connectionStatus !== 'Connected') return
     sendHrPacket(hrValue)
-    const id = setInterval(() => {
+    const id = window.setInterval(() => {
       const fluctuatedHr = Math.max(
         70,
         hrValue + Math.floor(Math.random() * 5) - 2
@@ -93,7 +93,7 @@ export default function MockPage() {
 
   const stopStreaming = () => {
     if (intervalId) {
-      clearInterval(intervalId)
+      window.clearInterval(intervalId)
       setIntervalId(null)
     }
   }

--- a/tests/unit/app/client/control/components/SpotifyControls.test.tsx
+++ b/tests/unit/app/client/control/components/SpotifyControls.test.tsx
@@ -25,7 +25,14 @@ jest.mock('@/context/WebSocketContext', () => ({
 }))
 
 // Mock the volume preference hook
-jest.mock('@/hooks/useVolumePreference')
+jest.mock('@/hooks/useVolumePreference', () => {
+  const originalModule = jest.requireActual('@/hooks/useVolumePreference')
+  return {
+    __esModule: true,
+    ...originalModule,
+    default: jest.fn(),
+  }
+})
 
 describe('components/SpotifyControls', () => {
   let mockSendData: jest.Mock
@@ -93,6 +100,43 @@ describe('components/SpotifyControls', () => {
     render(<SpotifyControls />)
     const muteButton = screen.getByLabelText(/mute volume/i)
     expect(muteButton).toBeInTheDocument()
+  })
+
+  it('debounces volume change commands', () => {
+    jest.useFakeTimers()
+    const setVolumeMock = jest.fn()
+    const mockUseVolumePreference = useVolumePreference as jest.Mock
+
+    // Initial render with volume 50
+    mockUseVolumePreference.mockReturnValue({
+      volume: 50,
+      muted: false,
+      setVolume: setVolumeMock,
+      toggleMute: jest.fn(),
+    })
+    const { rerender } = render(<SpotifyControls />)
+
+    // Simulate the state update by re-rendering with the new value
+    mockUseVolumePreference.mockReturnValue({
+      volume: 80,
+      muted: false,
+      setVolume: setVolumeMock,
+      toggleMute: jest.fn(),
+    })
+    rerender(<SpotifyControls />)
+
+    // Advance time past the debounce period
+    jest.advanceTimersByTime(300)
+
+    // Now the command should have been sent with the latest value
+    expect(mockSendData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'SPOTIFY_COMMAND',
+        command: 'SET_VOLUME',
+        volume: 80,
+      })
+    )
+    jest.useRealTimers()
   })
 
   it('selects HRM Web Player by default when no device is active', async () => {

--- a/tests/unit/app/client/mock/page.test.tsx
+++ b/tests/unit/app/client/mock/page.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * @jest-environment jsdom
+ */
+import { fireEvent, render, screen } from '@testing-library/react'
+import MockPage from '@/app/client/mock/page'
+import { useWebSocket } from '@/context/WebSocketContext'
+import '@testing-library/jest-dom'
+
+// Mock the WebSocket context
+jest.mock('@/context/WebSocketContext', () => ({
+  useWebSocket: jest.fn(),
+}))
+
+describe('app/client/mock/page', () => {
+  let mockSendData: jest.Mock
+
+  beforeEach(() => {
+    mockSendData = jest.fn()
+    ;(useWebSocket as jest.Mock).mockReturnValue({
+      connectionStatus: 'Connected',
+      sendData: mockSendData,
+    })
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders the mock streamer page with default values', () => {
+    render(<MockPage />)
+    expect(screen.getByText('HRM Mock Streamer')).toBeInTheDocument()
+    expect(screen.getByLabelText('User Name')).toHaveValue('Mock User')
+    expect(screen.getByLabelText('Age')).toHaveValue(30)
+    expect(screen.getByLabelText('Current BPM')).toHaveValue(100)
+    expect(
+      screen.getByTestId('streaming-start-button')
+    ).toBeInTheDocument()
+  })
+
+  it('sends an HR packet when BPM is changed and not streaming', () => {
+    render(<MockPage />)
+
+    // Metadata packet is sent on mount
+    expect(mockSendData).toHaveBeenCalledTimes(1)
+    expect(mockSendData).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'HRM_METADATA_UPDATE' })
+    )
+
+    const bpmInput = screen.getByLabelText('Current BPM')
+    fireEvent.change(bpmInput, { target: { value: '125' } })
+
+    // HR packet is sent on change
+    expect(mockSendData).toHaveBeenCalledTimes(2)
+    expect(mockSendData).toHaveBeenCalledWith({
+      type: 'HRM_INPUT',
+      data: { value: 125 },
+    })
+  })
+
+  it('starts and stops streaming HR data', () => {
+    jest.useFakeTimers()
+    render(<MockPage />)
+
+    const startButton = screen.getByTestId('streaming-start-button')
+    fireEvent.click(startButton)
+
+    // Check that streaming has started
+    expect(screen.getByTestId('streaming-stop-button')).toBeInTheDocument()
+
+    // It should send an initial HR packet immediately
+    expect(mockSendData).toHaveBeenCalledWith({
+      type: 'HRM_INPUT',
+      data: { value: 100 },
+    })
+
+    // Advance time to trigger the interval
+    jest.advanceTimersByTime(2000)
+
+    // The mock implementation fluctuates the HR, so we check that it was called again
+    // The exact value is random, so we just check the type
+    expect(mockSendData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'HRM_INPUT',
+      })
+    )
+
+    // Check total calls: metadata on mount + initial HR + interval HR
+    expect(mockSendData).toHaveBeenCalledTimes(3)
+
+    const stopButton = screen.getByTestId('streaming-stop-button')
+    fireEvent.click(stopButton)
+
+    // Check that streaming has stopped
+    expect(screen.getByTestId('streaming-start-button')).toBeInTheDocument()
+
+    // Advance time again to ensure no more packets are sent
+    jest.advanceTimersByTime(2000)
+    expect(mockSendData).toHaveBeenCalledTimes(3) // No new calls
+
+    jest.useRealTimers()
+  })
+})

--- a/tests/unit/app/client/mock/page.test.tsx
+++ b/tests/unit/app/client/mock/page.test.tsx
@@ -32,9 +32,7 @@ describe('app/client/mock/page', () => {
     expect(screen.getByLabelText('User Name')).toHaveValue('Mock User')
     expect(screen.getByLabelText('Age')).toHaveValue(30)
     expect(screen.getByLabelText('Current BPM')).toHaveValue(100)
-    expect(
-      screen.getByTestId('streaming-start-button')
-    ).toBeInTheDocument()
+    expect(screen.getByTestId('streaming-start-button')).toBeInTheDocument()
   })
 
   it('sends an HR packet when BPM is changed and not streaming', () => {


### PR DESCRIPTION
## Description

This pull request refactors client-side timer ID types from `NodeJS.Timeout` to `number` to align with browser API standards. The change improves type accuracy in `useLocalWorkoutBuffer.ts`, `mock/page.tsx`, and `SpotifyControls.tsx`.

Fixes #3751

## Change Type: 🏗️ Refactoring (code change that neither fixes bug nor adds feature)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [x] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [x] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

This pull request refactors client-side timer ID types from `NodeJS.Timeout` to `number` to align with browser API standards. The change improves type accuracy in `useLocalWorkoutBuffer.ts`, `mock/page.tsx`, and `SpotifyControls.tsx`.

Fixes #3751

---
*PR created automatically by Jules for task [16857582832288039257](https://jules.google.com/task/16857582832288039257) started by @arii*
</details>