### PR TITLE
chore(small): Refactor: Improve WebSocket Client Session Cleanup Logic

### DIFF
--- a/tests/unit/socketManager.test.ts
+++ b/tests/unit/socketManager.test.ts
@@ -566,4 +566,77 @@ describe('WebSocket Manager', () => {
       )
     })
   })
+  describe('Session Cleanup', () => {
+    it('should clean up client session after grace period', () => {
+      const clientId = 'test-client-cleanup'
+      const mockReq = createMockRequest(`/?clientId=${clientId}`)
+      const newWs = new MockWebSocket()
+      mockWss.emit('connection', newWs, mockReq)
+
+      // Disconnect the client
+      newWs.emit('close')
+
+      // Advance timers to trigger cleanup
+      jest.runAllTimers()
+
+      // Verify that the cleanup logic was called
+      expect(logger.info).toHaveBeenCalledWith(
+        { clientId },
+        'Session expired. Deleting data.'
+      )
+
+      // Verify the broadcast payload contains the other client but not the cleaned-up one
+      const mockBroadcast = broadcast as jest.Mock
+      const lastCall =
+        mockBroadcast.mock.calls[mockBroadcast.mock.calls.length - 1]
+      const payload: HrmData[] = lastCall[1].payload
+
+      expect(payload.length).toBe(1)
+      expect(payload[0].clientId).toBe('test-client')
+      expect(payload.find((c) => c.clientId === clientId)).toBeUndefined()
+    })
+
+    it('should not clean up session if client reconnects within grace period', () => {
+      const clientId = 'test-client-reconnect'
+      const mockReq = createMockRequest(`/?clientId=${clientId}`)
+      const firstWs = new MockWebSocket()
+      mockWss.emit('connection', firstWs, mockReq)
+
+      // Disconnect the first client
+      firstWs.emit('close')
+
+      // Reconnect with a new WebSocket instance before the timer fires
+      const secondWs = new MockWebSocket()
+      mockWss.emit('connection', secondWs, mockReq)
+
+      // Advance timers past the grace period
+      jest.runAllTimers()
+
+      // Verify that the cleanup was NOT called for the original session
+      expect(logger.info).not.toHaveBeenCalledWith(
+        { clientId },
+        'Session expired. Deleting data.'
+      )
+      // Verify that the "timer cleared" message was logged
+      expect(logger.info).toHaveBeenCalledWith(
+        { clientId },
+        'Cleared cleanup timer for reconnected client.'
+      )
+
+      // Trigger a broadcast by having the other client disconnect
+      mockWs.emit('close') // This is the 'test-client' from beforeEach
+      jest.runAllTimers()
+
+      // Verify that the client's data still exists in the broadcast from the *other* client's cleanup
+      const mockBroadcast = broadcast as jest.Mock
+      const lastCall =
+        mockBroadcast.mock.calls[mockBroadcast.mock.calls.length - 1]
+      const payload: HrmData[] = lastCall[1].payload
+
+      // The payload should contain our reconnected client
+      expect(payload.find((c) => c.clientId === clientId)).toBeDefined()
+      // The payload should NOT contain the client that just disconnected to trigger the broadcast
+      expect(payload.find((c) => c.clientId === 'test-client')).toBeUndefined()
+    })
+  })
 })

--- a/utils/socketManager.ts
+++ b/utils/socketManager.ts
@@ -53,6 +53,9 @@ const clientSessionState = new Map<
   { lastUpdate: number; accumulatedCalories: number }
 >()
 
+// New: Map to hold cleanup timers for disconnected clients
+const clientCleanupTimers = new Map<string, NodeJS.Timeout>()
+
 /**
  * Safely parses the WebSocket request URL to extract search parameters.
  * Handles cases where headers or URL might be malformed.
@@ -70,6 +73,28 @@ const getRequestParams = (req: IncomingMessage): URLSearchParams => {
     logger.error({ error }, 'Failed to parse WebSocket connection URL')
     // Return empty params to prevent a crash on invalid URL
     return new URLSearchParams()
+  }
+}
+
+/**
+ * Centralized function to clean up a client's session data.
+ * @param clientId The identifier of the client to clean up.
+ */
+const cleanupClientSession = (clientId: string) => {
+  logger.info({ clientId }, 'Session expired. Deleting data.')
+  try {
+    hrmDataRepository.deleteById(clientId)
+    clientSessionState.delete(clientId)
+    broadcastState()
+  } catch (err) {
+    logger.error(
+      { clientId: clientId, error: err },
+      'Error during session cleanup'
+    )
+  } finally {
+    // Always remove the socket reference and cleanup timer to prevent leaks
+    clientSockets.delete(clientId)
+    clientCleanupTimers.delete(clientId)
   }
 }
 
@@ -126,6 +151,13 @@ const initSocketManager = (
     const logMeta = getLogMeta(req, clientId)
     extWs.clientId = clientId
 
+    // New: If a cleanup timer exists for this client, clear it
+    if (clientCleanupTimers.has(clientId)) {
+      clearTimeout(clientCleanupTimers.get(clientId))
+      clientCleanupTimers.delete(clientId)
+      logger.info({ clientId }, 'Cleared cleanup timer for reconnected client.')
+    }
+
     // it's a stale or "zombie" connection. Overwrite it with the new socket.
 
     if (clientSockets.has(clientId)) {
@@ -175,28 +207,23 @@ const initSocketManager = (
       // memory pressure if many clients disconnect and don't reconnect.
       // A more robust solution might involve a separate cleanup process
       // or a maximum number of inactive sessions.
-      setTimeout(() => {
-        // Only delete if they haven't reconnected (i.e., the current socket is still this closed one)
+      const timer = setTimeout(() => {
+        // Only cleanup if the client has not reconnected.
+        // We verify this by checking if the socket associated with the clientId is the one that just closed.
+        // If they are different, it means a new connection has been established.
         if (clientSockets.get(clientId) === extWs) {
+          cleanupClientSession(clientId)
+        } else {
+          // If the client has reconnected, we can safely remove the timer without taking further action.
+          clientCleanupTimers.delete(clientId)
           logger.info(
-            { clientId: extWs.clientId },
-            'Session expired. Deleting data.'
+            { clientId },
+            'Client reconnected before cleanup timer expired. Timer cleared.'
           )
-          try {
-            hrmDataRepository.deleteById(extWs.clientId)
-            clientSessionState.delete(extWs.clientId)
-            broadcastState()
-          } catch (err) {
-            logger.error(
-              { clientId: extWs.clientId, error: err },
-              'Error during session cleanup'
-            )
-          } finally {
-            // Always remove the socket reference to prevent leaks
-            clientSockets.delete(extWs.clientId)
-          }
         }
       }, env.WEBSOCKET_GRACE_PERIOD_MS)
+
+      clientCleanupTimers.set(clientId, timer)
     })
   })
 


### PR DESCRIPTION
## Description

This pull request refactors the WebSocket client session cleanup logic to improve its robustness, readability, and maintainability. It introduces a centralized `cleanupClientSession` function and a `clientCleanupTimers` map to explicitly manage the cleanup process for disconnected clients.

Fixes #3791

No dependencies are required for this change.

## Change Type: 🏗️ Refactoring (code change that neither fixes bug nor adds feature)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [ ] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [ ] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [ ] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [ ] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [ ] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [ ] Changes are **backward compatible** (or breaking changes are documented)
- [ ] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

This pull request refactors the WebSocket client session cleanup logic to improve its robustness, readability, and maintainability. It introduces a centralized `cleanupClientSession` function and a `clientCleanupTimers` map to explicitly manage the cleanup process for disconnected clients.

Fixes #3791

---
*PR created automatically by Jules for task [1347988311283578652](https://jules.google.com/task/1347988311283578652) started by @arii*
</details>