### PR TITLE
test(medium): Refactor Web Bluetooth API Mocks for Improved Type Safety

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -308,3 +308,17 @@ When integrating with third-party libraries that may have incorrect or incomplet
 **Problem**: The `@spotify/web-api-ts-sdk` library does not correctly type the `deviceId` parameter as optional for several of its player methods. This can lead to runtime errors and requires unsafe type assertions in the application code.
 
 **Solution**: The `safeSpotifyApi.ts` module provides a `createSafeSpotifyApi` function that wraps the Spotify SDK instance in a `Proxy`. This proxy intercepts calls to the player methods and dynamically handles the `deviceId` parameter, ensuring that `undefined` values are not passed to the SDK. This encapsulates the workaround in a single, reusable module, eliminating the need for scattered type assertions and improving the overall type safety of the codebase.
+## Testing
+
+### Mocking
+
+#### Web Bluetooth API Mocks
+
+To facilitate consistent and type-safe testing of Web Bluetooth API interactions, a set of mock utilities is available in `tests/unit/lib/bluetooth-test-utils.ts`. These utilities provide mock implementations for the following Web Bluetooth API objects:
+
+-   `BluetoothDevice`
+-   `BluetoothRemoteGATTServer`
+-   `BluetoothRemoteGATTService`
+-   `BluetoothRemoteGATTCharacteristic`
+
+These mocks are designed to be used in Jest unit tests and provide a type-safe way to simulate Bluetooth device interactions.

--- a/tests/unit/lib/bluetooth-test-utils.ts
+++ b/tests/unit/lib/bluetooth-test-utils.ts
@@ -21,8 +21,12 @@ export const mockBluetoothGattCharacteristic = (
   const characteristicMock: any = {}
 
   const implementation = {
-    startNotifications: jest.fn().mockResolvedValue(characteristicMock),
-    stopNotifications: jest.fn().mockResolvedValue(characteristicMock),
+    startNotifications: jest
+      .fn()
+      .mockImplementation(() => Promise.resolve(characteristicMock)),
+    stopNotifications: jest
+      .fn()
+      .mockImplementation(() => Promise.resolve(characteristicMock)),
     addEventListener: jest.fn(
       (eventName: string, callback: (event: Event) => void) => {
         if (!listeners[eventName]) {

--- a/tests/unit/lib/bluetooth-test-utils.ts
+++ b/tests/unit/lib/bluetooth-test-utils.ts
@@ -1,0 +1,111 @@
+import { jest } from '@jest/globals'
+
+// A helper type for the event listener map
+type ListenerMap = {
+  [eventName: string]: ((event: Event) => void)[]
+}
+
+/**
+ * Mocks a BluetoothGATTCharacteristic object.
+ * This is the object that represents a GATT characteristic, which is a basic data element used to construct a GATT service.
+ */
+export const mockBluetoothGattCharacteristic = (
+  overrides: Partial<BluetoothGATTCharacteristic> = {}
+): jest.Mocked<BluetoothGATTCharacteristic> & {
+  _listeners: ListenerMap
+  _trigger: (eventName: string, event: Partial<Event>) => void
+} => {
+  const listeners: ListenerMap = {}
+
+  const characteristic = {
+    startNotifications: jest.fn().mockResolvedValue(undefined),
+    stopNotifications: jest.fn().mockResolvedValue(undefined),
+    addEventListener: jest.fn(
+      (eventName: string, callback: (event: Event) => void) => {
+        if (!listeners[eventName]) {
+          listeners[eventName] = []
+        }
+        listeners[eventName].push(callback)
+      }
+    ),
+    removeEventListener: jest.fn(
+      (eventName: string, callback: (event: Event) => void) => {
+        if (listeners[eventName]) {
+          listeners[eventName] = listeners[eventName].filter(
+            (cb) => cb !== callback
+          )
+        }
+      }
+    ),
+    readValue: jest.fn().mockResolvedValue(new DataView(new ArrayBuffer(1))),
+    writeValue: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+    // Test utilities
+    _listeners: listeners,
+    _trigger: (eventName: string, event: Partial<Event>) => {
+      if (listeners[eventName]) {
+        listeners[eventName].forEach((callback) => callback(event as Event))
+      }
+    },
+  }
+  return characteristic as jest.Mocked<BluetoothGATTCharacteristic> & {
+    _listeners: ListenerMap
+    _trigger: (eventName: string, event: Partial<Event>) => void
+  }
+}
+
+/**
+ * Mocks a BluetoothGATTService object.
+ * This is the object that represents a GATT service, which is a collection of GATT characteristics.
+ */
+export const mockBluetoothGattService = (
+  overrides: Partial<BluetoothGATTService> = {},
+  mockCharacteristic: jest.Mocked<BluetoothGATTCharacteristic>
+): jest.Mocked<BluetoothGATTService> => {
+  const service = {
+    getCharacteristic: jest.fn().mockResolvedValue(mockCharacteristic),
+    ...overrides,
+  }
+  return service as jest.Mocked<BluetoothGATTService>
+}
+
+/**
+ * Mocks a BluetoothRemoteGATTServer object.
+ * This is the object that represents a GATT server on a remote Bluetooth device.
+ */
+export const mockBluetoothRemoteGattServer = (
+  overrides: Partial<BluetoothRemoteGATTServer> = {},
+  mockService: jest.Mocked<BluetoothGATTService>
+): jest.Mocked<BluetoothRemoteGATTServer> => {
+  const gattServer = {
+    connect: jest.fn().mockResolvedValue(undefined),
+    disconnect: jest.fn(),
+    getPrimaryService: jest.fn().mockResolvedValue(mockService),
+    ...overrides,
+  }
+  return gattServer as jest.Mocked<BluetoothRemoteGATTServer>
+}
+
+/**
+ * Mocks a BluetoothDevice object.
+ * This is the object that represents a Bluetooth device.
+ */
+export const mockBluetoothDevice = (
+  overrides: Partial<BluetoothDevice> = {},
+  mockGattServer: jest.Mocked<BluetoothRemoteGATTServer>
+): jest.Mocked<BluetoothDevice> => {
+  const device = {
+    id: 'test-device-id',
+    name: 'Test HRM',
+    gatt: {
+      ...mockGattServer,
+      connected: false,
+      connect: jest.fn().mockResolvedValue(mockGattServer),
+      disconnect: jest.fn(),
+    },
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    ...overrides,
+  }
+  return device as jest.Mocked<BluetoothDevice>
+}

--- a/tests/unit/lib/bluetooth-test-utils.ts
+++ b/tests/unit/lib/bluetooth-test-utils.ts
@@ -6,12 +6,12 @@ type ListenerMap = {
 }
 
 /**
- * Mocks a BluetoothGATTCharacteristic object.
+ * Mocks a BluetoothRemoteGATTCharacteristic object.
  * This is the object that represents a GATT characteristic, which is a basic data element used to construct a GATT service.
  */
 export const mockBluetoothGattCharacteristic = (
-  overrides: Partial<BluetoothGATTCharacteristic> = {}
-): jest.Mocked<BluetoothGATTCharacteristic> & {
+  overrides: Partial<BluetoothRemoteGATTCharacteristic> = {}
+): jest.Mocked<BluetoothRemoteGATTCharacteristic> & {
   _listeners: ListenerMap
   _trigger: (eventName: string, event: Partial<Event>) => void
 } => {
@@ -48,25 +48,25 @@ export const mockBluetoothGattCharacteristic = (
       }
     },
   }
-  return characteristic as jest.Mocked<BluetoothGATTCharacteristic> & {
+  return characteristic as jest.Mocked<BluetoothRemoteGATTCharacteristic> & {
     _listeners: ListenerMap
     _trigger: (eventName: string, event: Partial<Event>) => void
   }
 }
 
 /**
- * Mocks a BluetoothGATTService object.
+ * Mocks a BluetoothRemoteGATTService object.
  * This is the object that represents a GATT service, which is a collection of GATT characteristics.
  */
 export const mockBluetoothGattService = (
-  overrides: Partial<BluetoothGATTService> = {},
-  mockCharacteristic: jest.Mocked<BluetoothGATTCharacteristic>
-): jest.Mocked<BluetoothGATTService> => {
+  overrides: Partial<BluetoothRemoteGATTService> = {},
+  mockCharacteristic: jest.Mocked<BluetoothRemoteGATTCharacteristic>
+): jest.Mocked<BluetoothRemoteGATTService> => {
   const service = {
     getCharacteristic: jest.fn().mockResolvedValue(mockCharacteristic),
     ...overrides,
   }
-  return service as jest.Mocked<BluetoothGATTService>
+  return service as jest.Mocked<BluetoothRemoteGATTService>
 }
 
 /**
@@ -75,7 +75,7 @@ export const mockBluetoothGattService = (
  */
 export const mockBluetoothRemoteGattServer = (
   overrides: Partial<BluetoothRemoteGATTServer> = {},
-  mockService: jest.Mocked<BluetoothGATTService>
+  mockService: jest.Mocked<BluetoothRemoteGATTService>
 ): jest.Mocked<BluetoothRemoteGATTServer> => {
   const gattServer = {
     connect: jest.fn().mockResolvedValue(undefined),

--- a/tests/unit/lib/bluetooth-test-utils.ts
+++ b/tests/unit/lib/bluetooth-test-utils.ts
@@ -91,9 +91,11 @@ export const mockBluetoothRemoteGattServer = (
   mockService: jest.Mocked<BluetoothRemoteGATTService>
 ): jest.Mocked<BluetoothRemoteGATTServer> => {
   const gattServer = {
-    connect: jest.fn().mockResolvedValue(undefined),
+    connect: jest.fn().mockImplementation(() => Promise.resolve(undefined)),
     disconnect: jest.fn(),
-    getPrimaryService: jest.fn().mockResolvedValue(mockService),
+    getPrimaryService: jest
+      .fn()
+      .mockImplementation(() => Promise.resolve(mockService)),
     ...overrides,
   }
   return gattServer as jest.Mocked<BluetoothRemoteGATTServer>
@@ -113,7 +115,9 @@ export const mockBluetoothDevice = (
     gatt: {
       ...mockGattServer,
       connected: false,
-      connect: jest.fn().mockResolvedValue(mockGattServer),
+      connect: jest
+        .fn()
+        .mockImplementation(() => Promise.resolve(mockGattServer)),
       disconnect: jest.fn(),
     },
     addEventListener: jest.fn(),

--- a/tests/unit/lib/bluetooth-test-utils.ts
+++ b/tests/unit/lib/bluetooth-test-utils.ts
@@ -17,9 +17,12 @@ export const mockBluetoothGattCharacteristic = (
 } => {
   const listeners: ListenerMap = {}
 
-  const characteristic = {
-    startNotifications: jest.fn().mockResolvedValue(this),
-    stopNotifications: jest.fn().mockResolvedValue(this),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const characteristicMock: any = {}
+
+  const implementation = {
+    startNotifications: jest.fn().mockResolvedValue(characteristicMock),
+    stopNotifications: jest.fn().mockResolvedValue(characteristicMock),
     addEventListener: jest.fn(
       (eventName: string, callback: (event: Event) => void) => {
         if (!listeners[eventName]) {
@@ -48,10 +51,10 @@ export const mockBluetoothGattCharacteristic = (
       }
     },
   }
-  return characteristic as jest.Mocked<BluetoothRemoteGATTCharacteristic> & {
-    _listeners: ListenerMap
-    _trigger: (eventName: string, event: Partial<Event>) => void
-  }
+
+  Object.assign(characteristicMock, implementation)
+
+  return characteristicMock
 }
 
 /**

--- a/tests/unit/lib/bluetooth-test-utils.ts
+++ b/tests/unit/lib/bluetooth-test-utils.ts
@@ -17,10 +17,11 @@ export const mockBluetoothGattCharacteristic = (
 } => {
   const listeners: ListenerMap = {}
 
-  const characteristicMock = {} as jest.Mocked<BluetoothRemoteGATTCharacteristic> & {
-    _listeners: ListenerMap
-    _trigger: (eventName: string, event: Partial<Event>) => void
-  }
+  const characteristicMock =
+    {} as jest.Mocked<BluetoothRemoteGATTCharacteristic> & {
+      _listeners: ListenerMap
+      _trigger: (eventName: string, event: Partial<Event>) => void
+    }
 
   const implementation = {
     startNotifications: jest

--- a/tests/unit/lib/bluetooth-test-utils.ts
+++ b/tests/unit/lib/bluetooth-test-utils.ts
@@ -55,8 +55,21 @@ export const mockBluetoothGattCharacteristic = (
     writeValue: jest.fn().mockImplementation(() => Promise.resolve(undefined)),
     ...overrides,
     // Test utilities
+    /**
+     * @internal
+     * Test-only property to inspect registered event listeners.
+     */
     _listeners: listeners,
-    _trigger: (eventName: string, event: Partial<Event>) => {
+    /**
+     * @internal
+     * Test-only utility to simulate a characteristic event.
+     * @param eventName - The name of the event to trigger.
+     * @param event - The partial event object to dispatch.
+     */
+    _trigger: (
+      eventName: string,
+      event: Partial<{ target: Partial<BluetoothRemoteGATTCharacteristic> }>
+    ) => {
       if (listeners[eventName]) {
         listeners[eventName].forEach((callback) => callback(event as Event))
       }

--- a/tests/unit/lib/bluetooth-test-utils.ts
+++ b/tests/unit/lib/bluetooth-test-utils.ts
@@ -18,8 +18,8 @@ export const mockBluetoothGattCharacteristic = (
   const listeners: ListenerMap = {}
 
   const characteristic = {
-    startNotifications: jest.fn().mockResolvedValue(undefined),
-    stopNotifications: jest.fn().mockResolvedValue(undefined),
+    startNotifications: jest.fn().mockResolvedValue(this),
+    stopNotifications: jest.fn().mockResolvedValue(this),
     addEventListener: jest.fn(
       (eventName: string, callback: (event: Event) => void) => {
         if (!listeners[eventName]) {

--- a/tests/unit/lib/bluetooth-test-utils.ts
+++ b/tests/unit/lib/bluetooth-test-utils.ts
@@ -49,9 +49,7 @@ export const mockBluetoothGattCharacteristic = (
       .mockImplementation(() =>
         Promise.resolve(new DataView(new ArrayBuffer(1)))
       ),
-    writeValue: jest
-      .fn()
-      .mockImplementation(() => Promise.resolve(undefined)),
+    writeValue: jest.fn().mockImplementation(() => Promise.resolve(undefined)),
     ...overrides,
     // Test utilities
     _listeners: listeners,
@@ -76,7 +74,9 @@ export const mockBluetoothGattService = (
   mockCharacteristic: jest.Mocked<BluetoothRemoteGATTCharacteristic>
 ): jest.Mocked<BluetoothRemoteGATTService> => {
   const service = {
-    getCharacteristic: jest.fn().mockResolvedValue(mockCharacteristic),
+    getCharacteristic: jest
+      .fn()
+      .mockImplementation(() => Promise.resolve(mockCharacteristic)),
     ...overrides,
   }
   return service as jest.Mocked<BluetoothRemoteGATTService>

--- a/tests/unit/lib/bluetooth-test-utils.ts
+++ b/tests/unit/lib/bluetooth-test-utils.ts
@@ -106,15 +106,23 @@ export const mockBluetoothRemoteGattServer = (
   overrides: Partial<BluetoothRemoteGATTServer> = {},
   mockService: jest.Mocked<BluetoothRemoteGATTService>
 ): jest.Mocked<BluetoothRemoteGATTServer> => {
-  const gattServer = {
-    connect: jest.fn().mockImplementation(() => Promise.resolve(undefined)),
+  const gattServerMock = {} as jest.Mocked<BluetoothRemoteGATTServer>
+
+  const implementation = {
+    connect: jest
+      .fn()
+      .mockImplementation(() => Promise.resolve(gattServerMock)),
     disconnect: jest.fn(),
     getPrimaryService: jest
       .fn()
       .mockImplementation(() => Promise.resolve(mockService)),
+    connected: false,
     ...overrides,
   }
-  return gattServer as jest.Mocked<BluetoothRemoteGATTServer>
+
+  Object.assign(gattServerMock, implementation)
+
+  return gattServerMock
 }
 
 /**
@@ -128,14 +136,7 @@ export const mockBluetoothDevice = (
   const device = {
     id: 'test-device-id',
     name: 'Test HRM',
-    gatt: {
-      ...mockGattServer,
-      connected: false,
-      connect: jest
-        .fn()
-        .mockImplementation(() => Promise.resolve(mockGattServer)),
-      disconnect: jest.fn(),
-    },
+    gatt: mockGattServer,
     addEventListener: jest.fn(),
     removeEventListener: jest.fn(),
     ...overrides,

--- a/tests/unit/lib/bluetooth-test-utils.ts
+++ b/tests/unit/lib/bluetooth-test-utils.ts
@@ -17,8 +17,10 @@ export const mockBluetoothGattCharacteristic = (
 } => {
   const listeners: ListenerMap = {}
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const characteristicMock: any = {}
+  const characteristicMock = {} as jest.Mocked<BluetoothRemoteGATTCharacteristic> & {
+    _listeners: ListenerMap
+    _trigger: (eventName: string, event: Partial<Event>) => void
+  }
 
   const implementation = {
     startNotifications: jest

--- a/tests/unit/lib/bluetooth-test-utils.ts
+++ b/tests/unit/lib/bluetooth-test-utils.ts
@@ -44,8 +44,14 @@ export const mockBluetoothGattCharacteristic = (
         }
       }
     ),
-    readValue: jest.fn().mockResolvedValue(new DataView(new ArrayBuffer(1))),
-    writeValue: jest.fn().mockResolvedValue(undefined),
+    readValue: jest
+      .fn()
+      .mockImplementation(() =>
+        Promise.resolve(new DataView(new ArrayBuffer(1)))
+      ),
+    writeValue: jest
+      .fn()
+      .mockImplementation(() => Promise.resolve(undefined)),
     ...overrides,
     // Test utilities
     _listeners: listeners,

--- a/tests/unit/useBluetoothHRM.test.ts
+++ b/tests/unit/useBluetoothHRM.test.ts
@@ -29,7 +29,7 @@ Object.defineProperty(navigator, 'bluetooth', {
 
 describe('useBluetoothHRM', () => {
   let mockSendData: jest.Mock
-  let mockCharacteristic: jest.Mocked<BluetoothGATTCharacteristic>
+  let mockCharacteristic: jest.Mocked<BluetoothRemoteGATTCharacteristic>
   let mockGattServer: jest.Mocked<BluetoothRemoteGATTServer>
   let mockDevice: jest.Mocked<BluetoothDevice>
   let consoleWarnSpy: jest.SpyInstance
@@ -323,9 +323,7 @@ describe('useBluetoothHRM', () => {
       await simulateConnection({ result })
 
       // The listener should have been added
-      expect(
-        mockCharacteristic.addEventListener
-      ).toHaveBeenCalledWith(
+      expect(mockCharacteristic.addEventListener).toHaveBeenCalledWith(
         'characteristicvaluechanged',
         expect.any(Function)
       )

--- a/tests/unit/useBluetoothHRM.test.ts
+++ b/tests/unit/useBluetoothHRM.test.ts
@@ -5,6 +5,12 @@ import { jest } from '@jest/globals'
 import { renderHook, act, waitFor } from '@testing-library/react'
 import useBluetoothHRM from '@/hooks/useBluetoothHRM'
 import { useWebSocket } from '@/context/WebSocketContext'
+import {
+  mockBluetoothGattCharacteristic,
+  mockBluetoothGattService,
+  mockBluetoothRemoteGattServer,
+  mockBluetoothDevice,
+} from './lib/bluetooth-test-utils'
 
 // Mock the WebSocket context
 jest.mock('@/context/WebSocketContext', () => ({
@@ -23,27 +29,9 @@ Object.defineProperty(navigator, 'bluetooth', {
 
 describe('useBluetoothHRM', () => {
   let mockSendData: jest.Mock
-  let mockCharacteristic: {
-    startNotifications: jest.Mock
-    addEventListener: jest.Mock
-    removeEventListener: jest.Mock
-  }
-  let mockGattServer: {
-    connect: jest.Mock
-    disconnect: jest.Mock
-    getPrimaryService: jest.Mock
-  }
-  let mockDevice: {
-    id: string
-    name: string
-    gatt: {
-      connected: boolean
-      connect: jest.Mock
-      disconnect: jest.Mock
-    }
-    addEventListener: jest.Mock
-    removeEventListener: jest.Mock
-  }
+  let mockCharacteristic: jest.Mocked<BluetoothGATTCharacteristic>
+  let mockGattServer: jest.Mocked<BluetoothRemoteGATTServer>
+  let mockDevice: jest.Mocked<BluetoothDevice>
   let consoleWarnSpy: jest.SpyInstance
   let consoleInfoSpy: jest.SpyInstance
 
@@ -67,33 +55,10 @@ describe('useBluetoothHRM', () => {
       connectionStatus: 'Connected',
     })
 
-    mockCharacteristic = {
-      startNotifications: jest.fn().mockResolvedValue(undefined),
-      addEventListener: jest.fn(),
-      removeEventListener: jest.fn(),
-    }
-    const mockService = {
-      getCharacteristic: jest.fn().mockResolvedValue(mockCharacteristic),
-    }
-    mockGattServer = {
-      connect: jest.fn().mockResolvedValue({
-        getPrimaryService: jest.fn().mockResolvedValue(mockService),
-      }),
-      disconnect: jest.fn(),
-      getPrimaryService: jest.fn().mockResolvedValue(mockService),
-    }
-
-    mockDevice = {
-      id: 'test-device-id',
-      name: 'Test HRM',
-      gatt: {
-        connected: false,
-        connect: jest.fn().mockResolvedValue(mockGattServer),
-        disconnect: jest.fn(),
-      },
-      addEventListener: jest.fn(),
-      removeEventListener: jest.fn(),
-    }
+    mockCharacteristic = mockBluetoothGattCharacteristic()
+    const mockService = mockBluetoothGattService({}, mockCharacteristic)
+    mockGattServer = mockBluetoothRemoteGattServer({}, mockService)
+    mockDevice = mockBluetoothDevice({}, mockGattServer)
 
     mockBluetooth.requestDevice.mockResolvedValue(mockDevice)
     mockBluetooth.getDevices.mockResolvedValue([])
@@ -357,15 +322,20 @@ describe('useBluetoothHRM', () => {
       )
       await simulateConnection({ result })
 
-      const characteristicCallback =
-        mockCharacteristic.addEventListener.mock.calls.find(
-          (call) => call[0] === 'characteristicvaluechanged'
-        )?.[1]
-      expect(characteristicCallback).toBeDefined()
+      // The listener should have been added
+      expect(
+        mockCharacteristic.addEventListener
+      ).toHaveBeenCalledWith(
+        'characteristicvaluechanged',
+        expect.any(Function)
+      )
 
+      // Simulate the event
       act(() => {
-        characteristicCallback({
-          target: { value: new DataView(new Uint8Array([0, 75]).buffer) },
+        mockCharacteristic._trigger('characteristicvaluechanged', {
+          target: {
+            value: new DataView(new Uint8Array([0, 75]).buffer),
+          },
         })
       })
 


### PR DESCRIPTION
## Description

This refactoring improves the type safety and maintainability of the Web Bluetooth API mocks in the test suite. It introduces a new utility file with typed mock object factories and updates the relevant test file to use these new utilities. This eliminates the need for `@ts-expect-error` and makes the tests cleaner and more robust.

Fixes #3740

## Change Type: 🏗️ Refactoring (code change that neither fixes bug nor adds feature)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [x] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [x] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

This refactoring improves the type safety and maintainability of the Web Bluetooth API mocks in the test suite. It introduces a new utility file with typed mock object factories and updates the relevant test file to use these new utilities. This eliminates the need for `@ts-expect-error` and makes the tests cleaner and more robust.

Fixes #3740

---
*PR created automatically by Jules for task [2486860394715691888](https://jules.google.com/task/2486860394715691888) started by @arii*
</details>