### PR TITLE
Refactor: Decouple Workout State and Data Logic in `useWorkoutSession`

### DIFF
--- a/hooks/useWorkoutData.ts
+++ b/hooks/useWorkoutData.ts
@@ -43,6 +43,10 @@ function sessionDataReducer(
 
 // --- The Hook Implementation ---
 
+/**
+ * Handles the calculation and management of workout-specific data such as duration and calories burned.
+ * It relies on an external workoutStatus to drive its internal timing logic.
+ */
 interface WorkoutDataOptions {
   workoutStatus: SessionStatus
   totalCalories?: number

--- a/hooks/useWorkoutData.ts
+++ b/hooks/useWorkoutData.ts
@@ -49,7 +49,7 @@ function sessionDataReducer(
  */
 interface WorkoutDataOptions {
   workoutStatus: SessionStatus
-  totalCalories?: number
+  totalCalories: number
 }
 
 export const useWorkoutData = ({

--- a/hooks/useWorkoutData.ts
+++ b/hooks/useWorkoutData.ts
@@ -36,10 +36,13 @@ function sessionDataReducer(
       return { ...state, calories: action.payload }
     case 'RESET':
       return initialState
-    default:
-      // This helps catch any unhandled actions during development.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      throw new Error(`Unhandled action type: ${(action as any)?.type}`)
+    default: {
+      // This compile-time check ensures all actions are handled.
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const exhaustiveCheck: never = action
+      // This is a runtime safeguard.
+      throw new Error(`Unhandled action in sessionDataReducer`)
+    }
   }
 }
 

--- a/hooks/useWorkoutData.ts
+++ b/hooks/useWorkoutData.ts
@@ -37,7 +37,9 @@ function sessionDataReducer(
     case 'RESET':
       return initialState
     default:
-      return state
+      // This helps catch any unhandled actions during development.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      throw new Error(`Unhandled action type: ${(action as any)?.type}`)
   }
 }
 
@@ -66,6 +68,8 @@ export const useWorkoutData = ({
   })
 
   useEffect(() => {
+    // A workout is considered "over" if the status is idle but we have a startCalories value.
+    // This prevents the calorie count from updating after the workout has ended.
     const isWorkoutOver = workoutStatus === 'idle' && startCalories > 0
     if (isWorkoutOver) {
       return

--- a/hooks/useWorkoutData.ts
+++ b/hooks/useWorkoutData.ts
@@ -1,0 +1,133 @@
+import {
+  useEffect,
+  useRef,
+  useCallback,
+  useMemo,
+  useState,
+  useReducer,
+} from 'react'
+import { SessionStatus } from './useWorkoutState'
+
+// --- State, Actions, and Reducer for managing session data ---
+
+interface SessionDataState {
+  duration: number
+  calories: number
+}
+
+type SessionDataAction =
+  | { type: 'TICK'; payload: { duration: number } }
+  | { type: 'UPDATE_CALORIES'; payload: number }
+  | { type: 'RESET' }
+
+const initialState: SessionDataState = {
+  duration: 0,
+  calories: 0,
+}
+
+function sessionDataReducer(
+  state: SessionDataState,
+  action: SessionDataAction
+): SessionDataState {
+  switch (action.type) {
+    case 'TICK':
+      return { ...state, duration: action.payload.duration }
+    case 'UPDATE_CALORIES':
+      return { ...state, calories: action.payload }
+    case 'RESET':
+      return initialState
+    default:
+      return state
+  }
+}
+
+// --- The Hook Implementation ---
+
+interface WorkoutDataOptions {
+  workoutStatus: SessionStatus
+  totalCalories?: number
+}
+
+export const useWorkoutData = ({
+  workoutStatus,
+  totalCalories = 0,
+}: WorkoutDataOptions) => {
+  const [state, dispatch] = useReducer(sessionDataReducer, initialState)
+  const [startCalories, setStartCalories] = useState(0)
+
+  const sessionDataRef = useRef({
+    startTime: null as number | null,
+    pauseTime: null as number | null,
+    totalPaused: 0,
+  })
+
+  useEffect(() => {
+    const isWorkoutOver = workoutStatus === 'idle' && startCalories > 0
+    if (isWorkoutOver) {
+      return
+    }
+    dispatch({ type: 'UPDATE_CALORIES', payload: totalCalories })
+  }, [totalCalories, workoutStatus, startCalories])
+
+  useEffect(() => {
+    const session = sessionDataRef.current
+
+    if (workoutStatus === 'running' && session.startTime === null) {
+      session.startTime = Date.now()
+      session.pauseTime = null
+      session.totalPaused = 0
+    } else if (workoutStatus === 'running' && session.pauseTime !== null) {
+      session.totalPaused += Date.now() - session.pauseTime
+      session.pauseTime = null
+    } else if (workoutStatus === 'paused' && session.pauseTime === null) {
+      session.pauseTime = Date.now()
+    }
+  }, [workoutStatus])
+
+  useEffect(() => {
+    let interval: NodeJS.Timeout | null = null
+    const session = sessionDataRef.current
+
+    if (workoutStatus === 'running') {
+      interval = setInterval(() => {
+        if (session.startTime) {
+          const duration = Math.floor(
+            (Date.now() - session.startTime - session.totalPaused) / 1000
+          )
+          dispatch({ type: 'TICK', payload: { duration } })
+        }
+      }, 1000)
+    }
+    return () => {
+      if (interval) clearInterval(interval)
+    }
+  }, [workoutStatus])
+
+  const resetWorkoutData = useCallback(() => {
+    const session = sessionDataRef.current
+    session.startTime = null
+    session.pauseTime = null
+    session.totalPaused = 0
+    setStartCalories(0)
+    dispatch({ type: 'RESET' })
+  }, [])
+
+  const startWorkoutData = useCallback(() => {
+    setStartCalories(totalCalories)
+  }, [totalCalories])
+
+  const caloriesBurned = useMemo(() => {
+    if (startCalories === 0) {
+      return 0
+    }
+    const burned = Math.round(state.calories - startCalories)
+    return burned > 0 ? burned : 0
+  }, [state.calories, startCalories])
+
+  return {
+    workoutDuration: state.duration,
+    caloriesBurned,
+    resetWorkoutData,
+    startWorkoutData,
+  }
+}

--- a/hooks/useWorkoutData.ts
+++ b/hooks/useWorkoutData.ts
@@ -67,14 +67,11 @@ export const useWorkoutData = ({
   })
 
   useEffect(() => {
-    // A workout is considered "over" if the status is idle but we have a startCalories value.
-    // This prevents the calorie count from updating after the workout has ended.
-    const isWorkoutOver = workoutStatus === 'idle' && startCalories > 0
-    if (isWorkoutOver) {
+    if (workoutStatus === 'idle') {
       return
     }
     dispatch({ type: 'UPDATE_CALORIES', payload: totalCalories })
-  }, [totalCalories, workoutStatus, startCalories])
+  }, [totalCalories, workoutStatus])
 
   useEffect(() => {
     const session = sessionDataRef.current

--- a/hooks/useWorkoutData.ts
+++ b/hooks/useWorkoutData.ts
@@ -54,7 +54,7 @@ interface WorkoutDataOptions {
 
 export const useWorkoutData = ({
   workoutStatus,
-  totalCalories = 0,
+  totalCalories,
 }: WorkoutDataOptions) => {
   const [state, dispatch] = useReducer(sessionDataReducer, initialState)
   const [startCalories, setStartCalories] = useState(0)

--- a/hooks/useWorkoutData.ts
+++ b/hooks/useWorkoutData.ts
@@ -92,7 +92,7 @@ export const useWorkoutData = ({
   }, [workoutStatus])
 
   useEffect(() => {
-    let interval: NodeJS.Timeout | null = null
+    let interval: ReturnType<typeof setTimeout> | null = null
     const session = sessionDataRef.current
 
     if (workoutStatus === 'running') {

--- a/hooks/useWorkoutData.ts
+++ b/hooks/useWorkoutData.ts
@@ -36,13 +36,9 @@ function sessionDataReducer(
       return { ...state, calories: action.payload }
     case 'RESET':
       return initialState
-    default: {
-      // This compile-time check ensures all actions are handled.
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const exhaustiveCheck: never = action
-      // This is a runtime safeguard.
+    default:
+      // This is a runtime safeguard against unhandled actions.
       throw new Error(`Unhandled action in sessionDataReducer`)
-    }
   }
 }
 

--- a/hooks/useWorkoutSession.ts
+++ b/hooks/useWorkoutSession.ts
@@ -1,90 +1,9 @@
-import {
-  useEffect,
-  useReducer,
-  useRef,
-  useCallback,
-  useMemo,
-  useState,
-} from 'react'
-
-// --- State, Actions, and Reducer for managing session state ---
-
-type SessionStatus = 'idle' | 'running' | 'paused'
-
-interface SessionState {
-  status: SessionStatus
-  duration: number
-  calories: number
-}
-
-type SessionAction =
-  | { type: 'CONNECT' }
-  | { type: 'DISCONNECT' }
-  | { type: 'TICK'; payload: { duration: number } }
-  | { type: 'RESET' }
-  | { type: 'START_WORKOUT' }
-  | { type: 'PAUSE_WORKOUT' }
-  | { type: 'END_WORKOUT' }
-  | { type: 'UPDATE_CALORIES'; payload: number }
-
-const initialState: SessionState = {
-  status: 'idle',
-  duration: 0,
-  calories: 0,
-}
-
-function sessionReducer(
-  state: SessionState,
-  action: SessionAction
-): SessionState {
-  switch (action.type) {
-    case 'CONNECT':
-    case 'START_WORKOUT':
-      if (state.status === 'paused') {
-        // This is a resume. Don't reset duration.
-        return { ...state, status: 'running' }
-      }
-      if (state.status === 'idle') {
-        // This is a new workout. Reset duration.
-        return { ...state, status: 'running', duration: 0 }
-      }
-      return state
-    case 'PAUSE_WORKOUT':
-    case 'DISCONNECT':
-      if (state.status === 'running') {
-        return { ...state, status: 'paused' }
-      }
-      return state
-    case 'END_WORKOUT':
-      // Go idle, reset duration, but preserve calories for the final summary calculation.
-      return { ...state, status: 'idle', duration: 0 }
-    case 'TICK':
-      return {
-        ...state,
-        duration: action.payload.duration,
-      }
-    case 'UPDATE_CALORIES':
-      return {
-        ...state,
-        calories: action.payload,
-      }
-    case 'RESET':
-      return initialState
-    default:
-      return state
-  }
-}
+import { useCallback, useEffect, useRef } from 'react'
+import { useWorkoutState } from './useWorkoutState'
+import { useWorkoutData } from './useWorkoutData'
 
 // --- The Hook Implementation ---
 
-/**
- * Manages the state of a client-side workout session, tracking duration.
- *
- * NOTE: Calorie calculation is no longer performed in this hook.
- * It is now handled server-side and streamed via the WebSocket connection.
- * This hook consumes the final `totalCalories` value to ensure data consistency
- * across the application.
- */
 interface WorkoutSessionOptions {
   isConnected: boolean
   totalCalories?: number
@@ -94,119 +13,64 @@ export const useWorkoutSession = ({
   isConnected,
   totalCalories = 0,
 }: WorkoutSessionOptions) => {
-  const [state, dispatch] = useReducer(sessionReducer, initialState)
-  const [startCalories, setStartCalories] = useState(0)
+  const {
+    workoutStatus,
+    startWorkout: startState,
+    pauseWorkout: pauseState,
+    endWorkout: endState,
+    resetWorkout: resetState,
+    connect,
+    disconnect,
+  } = useWorkoutState()
 
-  const sessionDataRef = useRef({
-    startTime: null as number | null,
-    pauseTime: null as number | null,
-    totalPaused: 0,
+  const {
+    workoutDuration,
+    caloriesBurned,
+    resetWorkoutData,
+    startWorkoutData,
+  } = useWorkoutData({
+    workoutStatus,
+    totalCalories,
   })
-
-  useEffect(() => {
-    // A workout is considered "over" if the status is idle but we have a startCalories value.
-    const isWorkoutOver = state.status === 'idle' && startCalories > 0
-    if (isWorkoutOver) {
-      return // Don't update calories anymore
-    }
-    dispatch({ type: 'UPDATE_CALORIES', payload: totalCalories })
-  }, [totalCalories, state.status, startCalories])
 
   const prevIsConnected = useRef(isConnected)
   useEffect(() => {
     if (prevIsConnected.current !== isConnected) {
       if (isConnected) {
-        dispatch({ type: 'CONNECT' })
+        connect()
       } else {
-        dispatch({ type: 'DISCONNECT' })
+        disconnect()
       }
       prevIsConnected.current = isConnected
     }
-  }, [isConnected])
-
-  useEffect(() => {
-    const session = sessionDataRef.current
-
-    if (state.status === 'running' && session.startTime === null) {
-      // A new session is starting.
-      session.startTime = Date.now()
-      session.pauseTime = null
-      session.totalPaused = 0
-    } else if (state.status === 'running' && session.pauseTime !== null) {
-      // A paused session is resuming.
-      session.totalPaused += Date.now() - session.pauseTime
-      session.pauseTime = null
-    } else if (state.status === 'paused' && session.pauseTime === null) {
-      // A running session is being paused.
-      session.pauseTime = Date.now()
-    }
-  }, [state.status])
-
-  useEffect(() => {
-    let interval: NodeJS.Timeout | null = null
-    const session = sessionDataRef.current
-
-    if (state.status === 'running') {
-      interval = setInterval(() => {
-        if (session.startTime) {
-          const duration = Math.floor(
-            (Date.now() - session.startTime - session.totalPaused) / 1000
-          )
-          dispatch({
-            type: 'TICK',
-            payload: {
-              duration,
-            },
-          })
-        }
-      }, 1000)
-    }
-    return () => {
-      if (interval) clearInterval(interval)
-    }
-  }, [state.status])
-
-  const resetWorkout = useCallback(() => {
-    const session = sessionDataRef.current
-    session.startTime = null
-    session.pauseTime = null
-    session.totalPaused = 0
-    setStartCalories(0)
-    prevIsConnected.current = false
-    dispatch({ type: 'RESET' })
-  }, [])
+  }, [isConnected, connect, disconnect])
 
   const startWorkout = useCallback(() => {
-    // Capture the calorie count at the moment the workout starts.
-    setStartCalories(totalCalories)
-    dispatch({ type: 'START_WORKOUT' })
-  }, [totalCalories])
+    startState()
+    startWorkoutData()
+  }, [startState, startWorkoutData])
 
   const pauseWorkout = useCallback(() => {
-    dispatch({ type: 'PAUSE_WORKOUT' })
-  }, [])
+    pauseState()
+  }, [pauseState])
 
   const endWorkout = useCallback(() => {
-    dispatch({ type: 'END_WORKOUT' })
-  }, [])
+    endState()
+  }, [endState])
 
-  // Calculate the calories burned *during this session*.
-  const caloriesBurned = useMemo(() => {
-    if (startCalories === 0) {
-      return 0
-    }
-    const burned = Math.round(state.calories - startCalories)
-    return burned > 0 ? burned : 0
-  }, [state.calories, startCalories])
+  const resetWorkout = useCallback(() => {
+    resetState()
+    resetWorkoutData()
+  }, [resetState, resetWorkoutData])
 
   return {
-    workoutDuration: state.duration,
+    workoutDuration,
     caloriesBurned,
     resetWorkout,
     startWorkout,
     pauseWorkout,
     endWorkout,
-    workoutStatus: state.status,
-    hasStarted: state.status !== 'idle',
+    workoutStatus,
+    hasStarted: workoutStatus !== 'idle',
   }
 }

--- a/hooks/useWorkoutSession.ts
+++ b/hooks/useWorkoutSession.ts
@@ -6,12 +6,12 @@ import { useWorkoutData } from './useWorkoutData'
 
 interface WorkoutSessionOptions {
   isConnected: boolean
-  totalCalories?: number
+  totalCalories: number
 }
 
 export const useWorkoutSession = ({
   isConnected,
-  totalCalories = 0,
+  totalCalories,
 }: WorkoutSessionOptions) => {
   const {
     workoutStatus,

--- a/hooks/useWorkoutState.ts
+++ b/hooks/useWorkoutState.ts
@@ -41,13 +41,9 @@ function sessionReducer(
       return { ...state, status: 'idle' }
     case 'RESET':
       return initialState
-    default: {
-      // This compile-time check ensures all actions are handled.
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const exhaustiveCheck: never = action
-      // This is a runtime safeguard.
+    default:
+      // This is a runtime safeguard against unhandled actions.
       throw new Error(`Unhandled action in sessionReducer`)
-    }
   }
 }
 

--- a/hooks/useWorkoutState.ts
+++ b/hooks/useWorkoutState.ts
@@ -48,6 +48,8 @@ function sessionReducer(
       // This is a runtime safeguard.
       throw new Error(`Unhandled action in sessionReducer`)
     }
+  }
+}
 
 // --- The Hook Implementation ---
 

--- a/hooks/useWorkoutState.ts
+++ b/hooks/useWorkoutState.ts
@@ -41,10 +41,13 @@ function sessionReducer(
       return { ...state, status: 'idle' }
     case 'RESET':
       return initialState
-    default:
-      return state
-  }
-}
+    default: {
+      // This compile-time check ensures all actions are handled.
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const exhaustiveCheck: never = action
+      // This is a runtime safeguard.
+      throw new Error(`Unhandled action in sessionReducer`)
+    }
 
 // --- The Hook Implementation ---
 

--- a/hooks/useWorkoutState.ts
+++ b/hooks/useWorkoutState.ts
@@ -48,6 +48,9 @@ function sessionReducer(
 
 // --- The Hook Implementation ---
 
+/**
+ * Manages the core lifecycle status of a workout session (idle, running, paused).
+ */
 export const useWorkoutState = () => {
   const [state, dispatch] = useReducer(sessionReducer, initialState)
 

--- a/hooks/useWorkoutState.ts
+++ b/hooks/useWorkoutState.ts
@@ -1,0 +1,87 @@
+import { useReducer, useCallback } from 'react'
+
+// --- State, Actions, and Reducer for managing session state ---
+
+export type SessionStatus = 'idle' | 'running' | 'paused'
+
+interface SessionState {
+  status: SessionStatus
+}
+
+type SessionAction =
+  | { type: 'CONNECT' }
+  | { type: 'DISCONNECT' }
+  | { type: 'RESET' }
+  | { type: 'START_WORKOUT' }
+  | { type: 'PAUSE_WORKOUT' }
+  | { type: 'END_WORKOUT' }
+
+const initialState: SessionState = {
+  status: 'idle',
+}
+
+function sessionReducer(
+  state: SessionState,
+  action: SessionAction
+): SessionState {
+  switch (action.type) {
+    case 'CONNECT':
+    case 'START_WORKOUT':
+      if (state.status === 'paused' || state.status === 'idle') {
+        return { ...state, status: 'running' }
+      }
+      return state
+    case 'PAUSE_WORKOUT':
+    case 'DISCONNECT':
+      if (state.status === 'running') {
+        return { ...state, status: 'paused' }
+      }
+      return state
+    case 'END_WORKOUT':
+      return { ...state, status: 'idle' }
+    case 'RESET':
+      return initialState
+    default:
+      return state
+  }
+}
+
+// --- The Hook Implementation ---
+
+export const useWorkoutState = () => {
+  const [state, dispatch] = useReducer(sessionReducer, initialState)
+
+  const startWorkout = useCallback(() => {
+    dispatch({ type: 'START_WORKOUT' })
+  }, [])
+
+  const pauseWorkout = useCallback(() => {
+    dispatch({ type: 'PAUSE_WORKOUT' })
+  }, [])
+
+  const endWorkout = useCallback(() => {
+    dispatch({ type: 'END_WORKOUT' })
+  }, [])
+
+  const resetWorkout = useCallback(() => {
+    dispatch({ type: 'RESET' })
+  }, [])
+
+  const connect = useCallback(() => {
+    dispatch({ type: 'CONNECT' })
+  }, [])
+
+  const disconnect = useCallback(() => {
+    dispatch({ type: 'DISCONNECT' })
+  }, [])
+
+  return {
+    workoutStatus: state.status,
+    startWorkout,
+    pauseWorkout,
+    endWorkout,
+    resetWorkout,
+    connect,
+    disconnect,
+  }
+}

--- a/tests/unit/hooks/useWorkoutData.test.ts
+++ b/tests/unit/hooks/useWorkoutData.test.ts
@@ -1,0 +1,108 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook, act } from '@testing-library/react'
+import { useWorkoutData } from '@/hooks/useWorkoutData'
+
+describe('useWorkoutData', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('should initialize with 0 duration and calories', () => {
+    const { result } = renderHook(() =>
+      useWorkoutData({ workoutStatus: 'idle' })
+    )
+    expect(result.current.workoutDuration).toBe(0)
+    expect(result.current.caloriesBurned).toBe(0)
+  })
+
+  it('should calculate duration when the workout is running', () => {
+    const { result, rerender } = renderHook(
+      ({ workoutStatus }) => useWorkoutData({ workoutStatus }),
+      {
+        initialProps: { workoutStatus: 'idle' },
+      }
+    )
+
+    rerender({ workoutStatus: 'running' })
+
+    act(() => {
+      jest.advanceTimersByTime(5000)
+    })
+
+    expect(result.current.workoutDuration).toBe(5)
+  })
+
+  it('should pause duration calculation when the workout is paused', () => {
+    const { result, rerender } = renderHook(
+      ({ workoutStatus }) => useWorkoutData({ workoutStatus }),
+      {
+        initialProps: { workoutStatus: 'idle' },
+      }
+    )
+
+    rerender({ workoutStatus: 'running' })
+
+    act(() => {
+      jest.advanceTimersByTime(3000)
+    })
+
+    rerender({ workoutStatus: 'paused' })
+
+    act(() => {
+      jest.advanceTimersByTime(5000)
+    })
+
+    expect(result.current.workoutDuration).toBe(3)
+  })
+
+  it('should calculate calories burned during the session', () => {
+    const { result, rerender } = renderHook(
+      ({ workoutStatus, totalCalories }) =>
+        useWorkoutData({ workoutStatus, totalCalories }),
+      {
+        initialProps: { workoutStatus: 'idle', totalCalories: 100 },
+      }
+    )
+
+    act(() => {
+      result.current.startWorkoutData()
+    })
+
+    rerender({ workoutStatus: 'running', totalCalories: 150 })
+
+    expect(result.current.caloriesBurned).toBe(50)
+  })
+
+  it('should reset data when resetWorkoutData is called', () => {
+    const { result, rerender } = renderHook(
+      ({ workoutStatus, totalCalories }) =>
+        useWorkoutData({ workoutStatus, totalCalories }),
+      {
+        initialProps: { workoutStatus: 'idle', totalCalories: 100 },
+      }
+    )
+
+    act(() => {
+      result.current.startWorkoutData()
+    })
+
+    rerender({ workoutStatus: 'running', totalCalories: 150 })
+
+    act(() => {
+      jest.advanceTimersByTime(5000)
+    })
+
+    act(() => {
+      result.current.resetWorkoutData()
+    })
+
+    expect(result.current.workoutDuration).toBe(0)
+    expect(result.current.caloriesBurned).toBe(0)
+  })
+})

--- a/tests/unit/hooks/useWorkoutData.test.ts
+++ b/tests/unit/hooks/useWorkoutData.test.ts
@@ -15,7 +15,7 @@ describe('useWorkoutData', () => {
 
   it('should initialize with 0 duration and calories', () => {
     const { result } = renderHook(() =>
-      useWorkoutData({ workoutStatus: 'idle' })
+      useWorkoutData({ workoutStatus: 'idle', totalCalories: 0 })
     )
     expect(result.current.workoutDuration).toBe(0)
     expect(result.current.caloriesBurned).toBe(0)

--- a/tests/unit/hooks/useWorkoutSession.test.ts
+++ b/tests/unit/hooks/useWorkoutSession.test.ts
@@ -3,149 +3,155 @@
  */
 import { renderHook, act } from '@testing-library/react'
 import { useWorkoutSession } from '@/hooks/useWorkoutSession'
+import { useWorkoutState } from '@/hooks/useWorkoutState'
+import { useWorkoutData } from '@/hooks/useWorkoutData'
 
-describe('useWorkoutSession calorie logic', () => {
-  it('should initialize with zero calories burned', () => {
+jest.mock('@/hooks/useWorkoutState')
+jest.mock('@/hooks/useWorkoutData')
+
+const useWorkoutStateMock = useWorkoutState as jest.Mock
+const useWorkoutDataMock = useWorkoutData as jest.Mock
+
+describe('useWorkoutSession', () => {
+  beforeEach(() => {
+    // Reset mocks before each test
+    useWorkoutStateMock.mockClear()
+    useWorkoutDataMock.mockClear()
+  })
+  it('should return the correct initial values', () => {
+    useWorkoutStateMock.mockReturnValue({
+      workoutStatus: 'idle',
+      startWorkout: jest.fn(),
+      pauseWorkout: jest.fn(),
+      endWorkout: jest.fn(),
+      resetWorkout: jest.fn(),
+    })
+    useWorkoutDataMock.mockReturnValue({
+      workoutDuration: 0,
+      caloriesBurned: 0,
+      resetWorkoutData: jest.fn(),
+      startWorkoutData: jest.fn(),
+    })
+
     const { result } = renderHook(() =>
       useWorkoutSession({ isConnected: false, totalCalories: 0 })
     )
+
+    expect(result.current.workoutStatus).toBe('idle')
+    expect(result.current.workoutDuration).toBe(0)
     expect(result.current.caloriesBurned).toBe(0)
+    expect(result.current.hasStarted).toBe(false)
   })
 
-  it('should start with zero calories burned even if totalCalories is non-zero', () => {
+  it('should call the correct functions when startWorkout is called', () => {
+    const startState = jest.fn()
+    const startWorkoutData = jest.fn()
+    useWorkoutStateMock.mockReturnValue({
+      workoutStatus: 'idle',
+      startWorkout: startState,
+      pauseWorkout: jest.fn(),
+      endWorkout: jest.fn(),
+      resetWorkout: jest.fn(),
+    })
+    useWorkoutDataMock.mockReturnValue({
+      workoutDuration: 0,
+      caloriesBurned: 0,
+      resetWorkoutData: jest.fn(),
+      startWorkoutData,
+    })
+
     const { result } = renderHook(() =>
-      useWorkoutSession({ isConnected: false, totalCalories: 100 })
-    )
-    expect(result.current.caloriesBurned).toBe(0)
-  })
-
-  it('should capture the starting calorie count on startWorkout', () => {
-    const { result, rerender } = renderHook(
-      ({ totalCalories }) =>
-        useWorkoutSession({ isConnected: false, totalCalories }),
-      { initialProps: { totalCalories: 100 } }
+      useWorkoutSession({ isConnected: false, totalCalories: 0 })
     )
 
     act(() => {
       result.current.startWorkout()
     })
 
-    rerender({ totalCalories: 110 })
-    expect(result.current.caloriesBurned).toBe(10)
+    expect(startState).toHaveBeenCalled()
+    expect(startWorkoutData).toHaveBeenCalled()
   })
 
-  it('should calculate calories burned based on the difference from the start', () => {
-    const { result, rerender } = renderHook(
-      ({ totalCalories }) =>
-        useWorkoutSession({ isConnected: true, totalCalories }),
-      { initialProps: { totalCalories: 50 } }
+  it('should call the correct functions when pauseWorkout is called', () => {
+    const pauseState = jest.fn()
+    useWorkoutStateMock.mockReturnValue({
+      workoutStatus: 'running',
+      startWorkout: jest.fn(),
+      pauseWorkout: pauseState,
+      endWorkout: jest.fn(),
+      resetWorkout: jest.fn(),
+    })
+    useWorkoutDataMock.mockReturnValue({
+      workoutDuration: 10,
+      caloriesBurned: 5,
+      resetWorkoutData: jest.fn(),
+      startWorkoutData: jest.fn(),
+    })
+
+    const { result } = renderHook(() =>
+      useWorkoutSession({ isConnected: false, totalCalories: 0 })
     )
 
     act(() => {
-      result.current.startWorkout()
+      result.current.pauseWorkout()
     })
 
-    rerender({ totalCalories: 55 })
-    expect(result.current.caloriesBurned).toBe(5)
-
-    rerender({ totalCalories: 75 })
-    expect(result.current.caloriesBurned).toBe(25)
+    expect(pauseState).toHaveBeenCalled()
   })
 
-  it('should not show negative calories if totalCalories decreases', () => {
-    const { result, rerender } = renderHook(
-      ({ totalCalories }) =>
-        useWorkoutSession({ isConnected: true, totalCalories }),
-      { initialProps: { totalCalories: 100 } }
-    )
-
-    act(() => {
-      result.current.startWorkout()
+  it('should call the correct functions when endWorkout is called', () => {
+    const endState = jest.fn()
+    useWorkoutStateMock.mockReturnValue({
+      workoutStatus: 'running',
+      startWorkout: jest.fn(),
+      pauseWorkout: jest.fn(),
+      endWorkout: endState,
+      resetWorkout: jest.fn(),
+    })
+    useWorkoutDataMock.mockReturnValue({
+      workoutDuration: 10,
+      caloriesBurned: 5,
+      resetWorkoutData: jest.fn(),
+      startWorkoutData: jest.fn(),
     })
 
-    rerender({ totalCalories: 90 }) // totalCalories decreased
-    expect(result.current.caloriesBurned).toBe(0)
-  })
-
-  it('should preserve the last calculated calories when the workout ends', () => {
-    const { result, rerender } = renderHook(
-      ({ totalCalories }) =>
-        useWorkoutSession({ isConnected: true, totalCalories }),
-      { initialProps: { totalCalories: 200 } }
+    const { result } = renderHook(() =>
+      useWorkoutSession({ isConnected: false, totalCalories: 0 })
     )
-
-    act(() => {
-      result.current.startWorkout()
-    })
-
-    rerender({ totalCalories: 250 })
-    expect(result.current.caloriesBurned).toBe(50)
 
     act(() => {
       result.current.endWorkout()
     })
 
-    expect(result.current.caloriesBurned).toBe(50)
-    rerender({ totalCalories: 260 }) // Further changes should not affect burned calories
-    expect(result.current.caloriesBurned).toBe(50)
+    expect(endState).toHaveBeenCalled()
   })
 
-  it('should reset caloriesBurned to zero on resetWorkout', () => {
-    const { result, rerender } = renderHook(
-      ({ totalCalories }) =>
-        useWorkoutSession({ isConnected: true, totalCalories }),
-      { initialProps: { totalCalories: 300 } }
-    )
-
-    act(() => {
-      result.current.startWorkout()
+  it('should call the correct functions when resetWorkout is called', () => {
+    const resetState = jest.fn()
+    const resetWorkoutData = jest.fn()
+    useWorkoutStateMock.mockReturnValue({
+      workoutStatus: 'idle',
+      startWorkout: jest.fn(),
+      pauseWorkout: jest.fn(),
+      endWorkout: jest.fn(),
+      resetWorkout: resetState,
+    })
+    useWorkoutDataMock.mockReturnValue({
+      workoutDuration: 0,
+      caloriesBurned: 0,
+      resetWorkoutData,
+      startWorkoutData: jest.fn(),
     })
 
-    rerender({ totalCalories: 320 })
-    expect(result.current.caloriesBurned).toBe(20)
+    const { result } = renderHook(() =>
+      useWorkoutSession({ isConnected: false, totalCalories: 0 })
+    )
 
     act(() => {
       result.current.resetWorkout()
     })
 
-    expect(result.current.caloriesBurned).toBe(0)
-  })
-
-  it('should not be affected by pause and resume', () => {
-    const { result, rerender } = renderHook(
-      ({ isConnected, totalCalories }) =>
-        useWorkoutSession({ isConnected, totalCalories }),
-      { initialProps: { isConnected: true, totalCalories: 100 } }
-    )
-
-    act(() => {
-      result.current.startWorkout()
-    })
-    rerender({ isConnected: true, totalCalories: 110 })
-    expect(result.current.caloriesBurned).toBe(10)
-
-    // Pause
-    rerender({ isConnected: false, totalCalories: 115 })
-    expect(result.current.caloriesBurned).toBe(15)
-
-    // Resume
-    rerender({ isConnected: true, totalCalories: 125 })
-    expect(result.current.caloriesBurned).toBe(25)
-  })
-
-  it('should pause the workout when pauseWorkout is called', () => {
-    const { result } = renderHook(() =>
-      useWorkoutSession({ isConnected: true })
-    )
-
-    act(() => {
-      result.current.startWorkout()
-    })
-    expect(result.current.workoutStatus).toBe('running')
-
-    act(() => {
-      result.current.pauseWorkout()
-    })
-    expect(result.current.workoutStatus).toBe('paused')
+    expect(resetState).toHaveBeenCalled()
+    expect(resetWorkoutData).toHaveBeenCalled()
   })
 })

--- a/tests/unit/hooks/useWorkoutState.test.ts
+++ b/tests/unit/hooks/useWorkoutState.test.ts
@@ -1,0 +1,92 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook, act } from '@testing-library/react'
+import { useWorkoutState } from '@/hooks/useWorkoutState'
+
+describe('useWorkoutState', () => {
+  it('should initialize with an "idle" status', () => {
+    const { result } = renderHook(() => useWorkoutState())
+    expect(result.current.workoutStatus).toBe('idle')
+  })
+
+  it('should transition from "idle" to "running" when startWorkout is called', () => {
+    const { result } = renderHook(() => useWorkoutState())
+    act(() => {
+      result.current.startWorkout()
+    })
+    expect(result.current.workoutStatus).toBe('running')
+  })
+
+  it('should transition from "running" to "paused" when pauseWorkout is called', () => {
+    const { result } = renderHook(() => useWorkoutState())
+    act(() => {
+      result.current.startWorkout()
+    })
+    act(() => {
+      result.current.pauseWorkout()
+    })
+    expect(result.current.workoutStatus).toBe('paused')
+  })
+
+  it('should transition from "paused" to "running" when startWorkout is called', () => {
+    const { result } = renderHook(() => useWorkoutState())
+    act(() => {
+      result.current.startWorkout()
+    })
+    act(() => {
+      result.current.pauseWorkout()
+    })
+    act(() => {
+      result.current.startWorkout()
+    })
+    expect(result.current.workoutStatus).toBe('running')
+  })
+
+  it('should transition from "running" to "idle" when endWorkout is called', () => {
+    const { result } = renderHook(() => useWorkoutState())
+    act(() => {
+      result.current.startWorkout()
+    })
+    act(() => {
+      result.current.endWorkout()
+    })
+    expect(result.current.workoutStatus).toBe('idle')
+  })
+
+  it('should reset to "idle" when resetWorkout is called', () => {
+    const { result } = renderHook(() => useWorkoutState())
+    act(() => {
+      result.current.startWorkout()
+    })
+    act(() => {
+      result.current.resetWorkout()
+    })
+    expect(result.current.workoutStatus).toBe('idle')
+  })
+
+  it('should transition from "paused" to "running" when connect is called', () => {
+    const { result } = renderHook(() => useWorkoutState())
+    act(() => {
+      result.current.startWorkout()
+    })
+    act(() => {
+      result.current.pauseWorkout()
+    })
+    act(() => {
+      result.current.connect()
+    })
+    expect(result.current.workoutStatus).toBe('running')
+  })
+
+  it('should transition from "running" to "paused" when disconnect is called', () => {
+    const { result } = renderHook(() => useWorkoutState())
+    act(() => {
+      result.current.startWorkout()
+    })
+    act(() => {
+      result.current.disconnect()
+    })
+    expect(result.current.workoutStatus).toBe('paused')
+  })
+})


### PR DESCRIPTION
## Description

This pull request refactors the `useWorkoutSession` hook by decoupling the workout's state management from its data calculations. This change improves the clarity, testability, and maintainability of the code.

Fixes #3554

## Change Type: 🏗️ Refactoring (code change that neither fixes bug nor adds feature)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [ ] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [ ] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [ ] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [ ] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [ ] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [ ] Changes are **backward compatible** (or breaking changes are documented)
- [ ] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

This pull request refactors the `useWorkoutSession` hook by decoupling the workout's state management from its data calculations. This change improves the clarity, testability, and maintainability of the code.

Fixes #3554

---
*PR created automatically by Jules for task [12279591785663481289](https://jules.google.com/task/12279591785663481289) started by @arii*
</details>