### PR TITLE
fix(spotify): Improve token refresh error handling

### DIFF
--- a/lib/spotify.ts
+++ b/lib/spotify.ts
@@ -1,4 +1,5 @@
 import { env } from './env'
+import logger from '@/utils/logger'
 
 export const SPOTIFY_CONSTANTS = {
   TOKEN_URL: 'https://accounts.spotify.com/api/token',
@@ -34,7 +35,30 @@ export async function refreshSpotifyToken(refreshToken: string) {
   })
 
   if (!response.ok) {
-    throw await response.json()
+    const errorBody = await response.text()
+    logger.error(
+      {
+        status: response.status,
+        statusText: response.statusText,
+        body: errorBody,
+      },
+      'Failed to refresh Spotify token'
+    )
+
+    // Attempt to parse the error body as JSON, but fall back to a generic error
+    try {
+      const errorJson = JSON.parse(errorBody)
+      throw new Error(
+        errorJson.error_description ||
+          errorJson.error ||
+          'Spotify token refresh failed'
+      )
+    } catch (_e) {
+      // If parsing fails, throw a more generic error with the raw text
+      throw new Error(
+        `Spotify token refresh failed: ${response.status} ${response.statusText} - ${errorBody}`
+      )
+    }
   }
 
   return response.json()

--- a/tests/unit/lib/spotify.test.ts
+++ b/tests/unit/lib/spotify.test.ts
@@ -1,0 +1,139 @@
+/**
+ * @jest-environment jsdom
+ */
+import { refreshSpotifyToken, getSpotifyBasicAuth } from '@/lib/spotify'
+import { SPOTIFY_CONSTANTS } from '@/lib/spotify'
+import logger from '@/utils/logger'
+import { env } from '@/lib/env'
+
+// Mock the logger to prevent console output during tests
+jest.mock('@/utils/logger', () => ({
+  error: jest.fn(),
+}))
+
+describe('lib/spotify', () => {
+  beforeEach(() => {
+    // Manually mock the global fetch function
+    global.fetch = jest.fn()
+    process.env.SPOTIFY_CLIENT_ID = 'test-client-id'
+    process.env.SPOTIFY_CLIENT_SECRET = 'test-client-secret'
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+    // Restore fetch to its original state
+    ;(global.fetch as jest.Mock).mockRestore()
+  })
+
+  describe('getSpotifyBasicAuth', () => {
+    it('should return the correct Basic Auth header', () => {
+      const expectedAuth =
+        'Basic ' +
+        Buffer.from(
+          `${env.SPOTIFY_CLIENT_ID}:${env.SPOTIFY_CLIENT_SECRET}`
+        ).toString('base64')
+      expect(getSpotifyBasicAuth()).toBe(expectedAuth)
+    })
+  })
+
+  describe('refreshSpotifyToken', () => {
+    const refreshToken = 'test-refresh-token'
+
+    it('should return a new token on successful refresh', async () => {
+      const mockResponse = {
+        access_token: 'new-access-token',
+        expires_in: 3600,
+        token_type: 'Bearer',
+      }
+      ;(global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      })
+
+      const result = await refreshSpotifyToken(refreshToken)
+
+      expect(result).toEqual(mockResponse)
+      expect(global.fetch).toHaveBeenCalledWith(SPOTIFY_CONSTANTS.TOKEN_URL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          Authorization: getSpotifyBasicAuth(),
+        },
+        body: new URLSearchParams({
+          grant_type: 'refresh_token',
+          refresh_token: refreshToken,
+        }),
+      })
+    })
+
+    it('should throw an error with a valid JSON error response', async () => {
+      const errorResponse = {
+        error: 'invalid_grant',
+        error_description: 'Invalid refresh token',
+      }
+      ;(global.fetch as jest.Mock).mockResolvedValue({
+        ok: false,
+        status: 400,
+        statusText: 'Bad Request',
+        text: () => Promise.resolve(JSON.stringify(errorResponse)),
+        json: () => Promise.resolve(errorResponse),
+      })
+
+      await expect(refreshSpotifyToken(refreshToken)).rejects.toThrow(
+        'Invalid refresh token'
+      )
+      expect(logger.error).toHaveBeenCalledWith(
+        {
+          status: 400,
+          statusText: 'Bad Request',
+          body: JSON.stringify(errorResponse),
+        },
+        'Failed to refresh Spotify token'
+      )
+    })
+
+    it('should throw an error with a non-JSON error response', async () => {
+      const errorResponse = 'Internal Server Error'
+      ;(global.fetch as jest.Mock).mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        text: () => Promise.resolve(errorResponse),
+      })
+
+      await expect(refreshSpotifyToken(refreshToken)).rejects.toThrow(
+        `Spotify token refresh failed: 500 Internal Server Error - ${errorResponse}`
+      )
+      expect(logger.error).toHaveBeenCalledWith(
+        {
+          status: 500,
+          statusText: 'Internal Server Error',
+          body: errorResponse,
+        },
+        'Failed to refresh Spotify token'
+      )
+    })
+
+    it('should throw an error with a malformed JSON error response', async () => {
+      const errorResponse = '{"error": "invalid_grant",,}'
+      ;(global.fetch as jest.Mock).mockResolvedValue({
+        ok: false,
+        status: 400,
+        statusText: 'Bad Request',
+        text: () => Promise.resolve(errorResponse),
+      })
+
+      await expect(refreshSpotifyToken(refreshToken)).rejects.toThrow(
+        `Spotify token refresh failed: 400 Bad Request - ${errorResponse}`
+      )
+      expect(logger.error).toHaveBeenCalledWith(
+        {
+          status: 400,
+          statusText: 'Bad Request',
+          body: errorResponse,
+        },
+        'Failed to refresh Spotify token'
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Description

This pull request fixes a bug where Spotify playlist details would fail to load due to a silent authentication error. The token refresh logic has been updated to handle non-JSON error responses from the Spotify API, preventing unhandled exceptions and providing clearer error logging. This ensures a more robust and reliable connection to the Spotify service.

Fixes #4989

## Change Type: 🐛 Bug fix (non-breaking change fixing an issue)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [ ] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [ ] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [ ] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [ ] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [ ] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [ ] Changes are **backward compatible** (or breaking changes are documented)
- [ ] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

This pull request fixes a bug where Spotify playlist details would fail to load due to a silent authentication error. The token refresh logic has been updated to handle non-JSON error responses from the Spotify API, preventing unhandled exceptions and providing clearer error logging. This ensures a more robust and reliable connection to the Spotify service.

Fixes #4989

---
*PR created automatically by Jules for task [2430528214224638630](https://jules.google.com/task/2430528214224638630) started by @arii*
</details>