### PR TITLE
chore(medium): Persist Experimental Data Across Pages

### DIFF
--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -177,15 +177,20 @@ export const WebSocketProvider = ({
     INITIAL_STATE
   )
 
-  const dispatch = (message: ServerMessage | { type: 'RESET_STATE' }) => {
-    setAppState((prevState) => reducer(prevState, message))
-  }
+  const dispatch = useCallback(
+    (message: ServerMessage | { type: 'RESET_STATE' }) => {
+      setAppState((prevState) => reducer(prevState, message))
+    },
+    [setAppState]
+  )
 
-  const throttledDispatch = useRef(
-    throttle((message: ServerMessage) => {
-      dispatch(message)
-    }, 100)
-  ).current
+  const throttledDispatch = useMemo(
+    () =>
+      throttle((message: ServerMessage) => {
+        dispatch(message)
+      }, 100),
+    [dispatch]
+  )
 
   const wsRef = useRef<WebSocket | null>(null)
   const shouldReconnect = useRef(true)
@@ -392,7 +397,7 @@ export const WebSocketProvider = ({
         })
       }
     }
-  }, [wsUrl, throttledDispatch, startHeartbeat, stopHeartbeat])
+  }, [wsUrl, throttledDispatch, startHeartbeat, stopHeartbeat, dispatch])
 
   const disconnect = useCallback(() => {
     shouldReconnect.current = false

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -9,12 +9,12 @@ import {
   useEffect,
   useRef,
   useState,
-  useReducer,
   useMemo,
 } from 'react'
 import { ClientCommandMessage, ServerMessage } from '../types/websocket'
 import { HrmStreamData as ServerHrmData } from '../types/core'
 import { getWebSocketURL } from '../utils/urls'
+import useLocalStorage from '@/hooks/useLocalStorage'
 
 // Define a type for the test controls to avoid using 'any'
 interface TestControls {
@@ -172,7 +172,14 @@ export const WebSocketProvider = ({
   // The factor by which the reconnection delay is randomized to prevent clients from reconnecting simultaneously.
   const JITTER_FACTOR = 0.2 // 20% jitter
 
-  const [appState, dispatch] = useReducer(reducer, INITIAL_STATE)
+  const [appState, setAppState] = useLocalStorage<WebSocketState>(
+    'webSocketState',
+    INITIAL_STATE
+  )
+
+  const dispatch = (message: ServerMessage | { type: 'RESET_STATE' }) => {
+    setAppState((prevState) => reducer(prevState, message))
+  }
 
   const throttledDispatch = useRef(
     throttle((message: ServerMessage) => {


### PR DESCRIPTION
## Description

This change persists the WebSocket state to `localStorage`, ensuring that the `/client/experimental` page is populated with data even if it's not open when the data is received. It also refactors the `useLocalWorkoutBuffer` hook to process the historical data on initialization and adds logic to clear the persisted state on disconnect.

Fixes #4988

## Change Type: ✨ New feature (non-breaking change adding functionality)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [x] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [x] **Tests** are added/updated for new functionality
- [x] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

This change persists the WebSocket state to `localStorage`, ensuring that the `/client/experimental` page is populated with data even if it's not open when the data is received. It also refactors the `useLocalWorkoutBuffer` hook to process the historical data on initialization and adds logic to clear the persisted state on disconnect.

Fixes #4988

---
*PR created automatically by Jules for task [10999685609003610889](https://jules.google.com/task/10999685609003610889) started by @arii*
</details>