### PR TITLE
feat(medium): Refactor Spotify Authentication to Handle Token Refresh Errors

### DIFF
--- a/components/Spotify/CurrentSpotifyItemDisplay.tsx
+++ b/components/Spotify/CurrentSpotifyItemDisplay.tsx
@@ -6,11 +6,7 @@ import useSpotifyWebPlayback from '@/hooks/useSpotifyWebPlayback'
 
 const CurrentSpotifyItemDisplay = () => {
   const { spotifyData, connectionStatus } = useWebSocket()
-  const {
-    isReady,
-    deviceId,
-    isAuthenticated: spotifyAuthenticated,
-  } = useSpotifyWebPlayback()
+  const { isReady, deviceId } = useSpotifyWebPlayback()
 
   if (connectionStatus === 'Connecting') {
     return (
@@ -80,7 +76,7 @@ const CurrentSpotifyItemDisplay = () => {
           {spotifyData.albumName}
         </Typography>
       </Box>
-      {spotifyAuthenticated && !isReady && (
+      {!isReady && (
         <Typography
           variant="caption"
           sx={{

--- a/components/SpotifyDisplay.tsx
+++ b/components/SpotifyDisplay.tsx
@@ -1,7 +1,6 @@
 'use client'
 // File: app/components/dashboard/SpotifyDisplay.tsx
-import { useError } from '@/context/ErrorContext'
-import { useSession, signOut } from 'next-auth/react'
+import { useSpotifyAuth } from '@/hooks/useSpotifyAuth'
 import useSpotifyWebPlayback from '@/hooks/useSpotifyWebPlayback'
 import { useSpotifyRemoteExecution } from '@/hooks/useSpotifyRemoteExecution'
 import { clampVolume } from '@/hooks/useVolumePreference'
@@ -16,6 +15,7 @@ import Button from '@mui/material/Button'
 import IconButton from '@mui/material/IconButton'
 import Typography from '@mui/material/Typography'
 import { useCallback, useEffect, useReducer, useRef } from 'react'
+import { signOut } from 'next-auth/react'
 import AuthButton from './AuthButton'
 import VolumeSlider from './Spotify/VolumeSlider'
 import SpotifyDeviceSelectorWrapper from './SpotifyDeviceSelectorWrapper'
@@ -117,22 +117,8 @@ const spotifyDisplayReducer = (
 }
 
 const SpotifyDisplay = () => {
-  const { data: session, status } = useSession()
-  const { addError } = useError()
-
-  // Effect to handle session-level errors, like token refresh failure
-  useEffect(() => {
-    if (session?.error === 'RefreshAccessTokenError') {
-      addError('Spotify session expired. Please log in again.', {
-        persist: true,
-      })
-      // Sign out to clear the invalid session
-      signOut()
-    }
-  }, [session, addError])
-
+  const { isLoggedIn } = useSpotifyAuth()
   const { spotifyData, sendData, connectionStatus } = useWebSocket()
-  const isLoggedIn = status === 'authenticated'
 
   // 5. Integrate useReducer
   const [state, dispatch] = useReducer(
@@ -150,12 +136,7 @@ const SpotifyDisplay = () => {
     window.location.reload()
   }
 
-  const {
-    player,
-    isReady,
-    deviceId,
-    isAuthenticated: spotifyAuthenticated,
-  } = useSpotifyWebPlayback()
+  const { player, isReady, deviceId } = useSpotifyWebPlayback()
 
   // Enable remote Spotify control from controllers
   useSpotifyRemoteExecution(player)
@@ -354,7 +335,7 @@ const SpotifyDisplay = () => {
           >
             {displayTrackName} {displayArtist}
           </Typography>
-          {spotifyAuthenticated && !isReady && (
+          {!isReady && (
             <Typography
               variant="caption"
               sx={{

--- a/hooks/useSpotifyAuth.ts
+++ b/hooks/useSpotifyAuth.ts
@@ -29,7 +29,10 @@ export const useSpotifyAuth = () => {
         persist: true,
       })
       // Automatically sign out the user to clear the invalid session
-      signOut()
+      const signOutUser = async () => {
+        await signOut()
+      }
+      signOutUser()
     }
   }, [session, addError])
 

--- a/hooks/useSpotifyAuth.ts
+++ b/hooks/useSpotifyAuth.ts
@@ -1,0 +1,41 @@
+'use client'
+
+import { useSession, signOut } from 'next-auth/react'
+import { useEffect } from 'react'
+import { useError } from '@/context/ErrorContext'
+
+/**
+ * Custom hook to manage Spotify authentication.
+ *
+ * This hook centralizes the logic for handling the NextAuth session,
+ * checking for token refresh errors, and initiating a sign-out if
+ * the session becomes invalid. It provides a clear and reusable
+ * interface for components that need to be aware of the user's
+ * authentication state.
+ *
+ * @returns {object} The authentication state, including:
+ * - `status`: The session status ('loading', 'authenticated', 'unauthenticated').
+ * - `isLoggedIn`: A boolean indicating if the user is authenticated.
+ * - `session`: The raw session object from NextAuth.
+ */
+export const useSpotifyAuth = () => {
+  const { data: session, status } = useSession()
+  const { addError } = useError()
+
+  useEffect(() => {
+    // Check for the specific error that NextAuth returns on token refresh failure
+    if (session?.error === 'RefreshAccessTokenError') {
+      addError('Spotify session expired. Please log in again.', {
+        persist: true,
+      })
+      // Automatically sign out the user to clear the invalid session
+      signOut()
+    }
+  }, [session, addError])
+
+  return {
+    status,
+    isLoggedIn: status === 'authenticated',
+    session,
+  }
+}

--- a/hooks/useSpotifyWebPlayback.ts
+++ b/hooks/useSpotifyWebPlayback.ts
@@ -99,6 +99,11 @@ const useSpotifyWebPlayback = () => {
           addError('Spotify session expired. Please log in again.', {
             persist: true,
           })
+          // Note: This is a redundant sign-out trigger. The `useSpotifyAuth`
+          // hook also handles the `RefreshAccessTokenError` and initiates a
+          // sign-out. While this is a safeguard, a future refactor could
+          // streamline this to rely on a single source of truth for session
+          // validity.
           await signOut()
         }
         // For other errors, we might not need to sign out.

--- a/hooks/useSpotifyWebPlayback.ts
+++ b/hooks/useSpotifyWebPlayback.ts
@@ -105,9 +105,13 @@ const useSpotifyWebPlayback = () => {
           // streamline this to rely on a single source of truth for session
           // validity.
           await signOut()
+        } else {
+          // For other errors, show a non-persistent error message to the user.
+          addError(`Failed to authenticate with Spotify: ${appError.message}`, {
+            persist: false,
+          })
         }
-        // For other errors, we might not need to sign out.
-        // The SDK might retry on its own.
+        // The SDK might retry on its own for certain errors.
       }
     },
     [addError]

--- a/hooks/useSpotifyWebPlayback.ts
+++ b/hooks/useSpotifyWebPlayback.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { useError } from '@/context/ErrorContext'
 import { API_SPOTIFY_ACCESS_TOKEN } from '@/constants/apiEndpoints'
 import { fetchWithRetry, AppError } from '@/utils/network'
+import { signOut } from 'next-auth/react'
 
 // Define event data types for better type safety
 interface SpotifyDeviceEvent {
@@ -66,7 +67,6 @@ const useSpotifyWebPlayback = () => {
   const [isReady, setIsReady] = useState(false)
   const [deviceId, setDeviceId] = useState<string | null>(null)
   const { addError } = useError()
-  const [isAuthenticated, setIsAuthenticated] = useState(false)
 
   /**
    * Fetches the Spotify OAuth token from our secure backend API.
@@ -81,28 +81,28 @@ const useSpotifyWebPlayback = () => {
         if (!accessToken) {
           throw new Error('Access token was not found in the response.')
         }
-
-        console.log(
-          '[Spotify Web Playback] Access token retrieved successfully'
-        )
-        setIsAuthenticated(true)
         cb(accessToken)
       } catch (error) {
         const appError = error as AppError
-        // Don't show a persistent error for unauthenticated users
+        console.error(
+          `[Spotify Web Playback] Failed to get OAuth token: ${appError.message}`
+        )
+
+        // If the error is a 401 Unauthorized, it likely means the session is
+        // invalid or expired. The Spotify SDK will cache this failing token
+        // and stop asking for a new one. To force a re-auth flow, we must
+        // sign the user out, which will clear the session and prompt a new login.
         if (appError.code === 'HTTP_ERROR_401') {
-          console.log(
-            '[Spotify Web Playback] User not logged in, Web Playback unavailable'
+          console.warn(
+            '[Spotify Web Playback] Received 401, signing out to force re-authentication.'
           )
-        } else {
-          addError(`Authentication failed: ${appError.message}`, {
+          addError('Spotify session expired. Please log in again.', {
             persist: true,
           })
-          console.warn(
-            `[Spotify Web Playback] getOAuthToken error: ${appError.message}`
-          )
+          await signOut()
         }
-        setIsAuthenticated(false)
+        // For other errors, we might not need to sign out.
+        // The SDK might retry on its own.
       }
     },
     [addError]
@@ -224,7 +224,7 @@ const useSpotifyWebPlayback = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [getOAuthToken])
 
-  return { player, isReady, deviceId, isAuthenticated }
+  return { player, isReady, deviceId }
 }
 
 export default useSpotifyWebPlayback

--- a/tests/unit/hooks/useSpotifyAuth.test.ts
+++ b/tests/unit/hooks/useSpotifyAuth.test.ts
@@ -1,0 +1,96 @@
+/** @jest-environment jsdom */
+import { renderHook } from '@testing-library/react'
+import { useSession, signOut } from 'next-auth/react'
+import { useError } from '@/context/ErrorContext'
+import { useSpotifyAuth } from '@/hooks/useSpotifyAuth'
+
+// Mock the dependencies
+jest.mock('next-auth/react', () => ({
+  useSession: jest.fn(),
+  signOut: jest.fn(),
+}))
+
+jest.mock('@/context/ErrorContext', () => ({
+  useError: jest.fn(),
+}))
+
+const mockUseSession = useSession as jest.Mock
+const mockSignOut = signOut as jest.Mock
+const mockUseError = useError as jest.Mock
+
+describe('useSpotifyAuth', () => {
+  let mockAddError: jest.Mock
+
+  beforeEach(() => {
+    // Reset mocks before each test
+    mockAddError = jest.fn()
+    mockUseSession.mockReturnValue({ data: null, status: 'unauthenticated' })
+    mockUseError.mockReturnValue({ addError: mockAddError })
+    mockSignOut.mockClear()
+  })
+
+  it('should return unauthenticated status when session is null', () => {
+    const { result } = renderHook(() => useSpotifyAuth())
+
+    expect(result.current.status).toBe('unauthenticated')
+    expect(result.current.isLoggedIn).toBe(false)
+    expect(result.current.session).toBeNull()
+  })
+
+  it('should return authenticated status when session exists', () => {
+    const mockSession = { accessToken: '123', user: { name: 'Test User' } }
+    mockUseSession.mockReturnValue({ data: mockSession, status: 'authenticated' })
+
+    const { result } = renderHook(() => useSpotifyAuth())
+
+    expect(result.current.status).toBe('authenticated')
+    expect(result.current.isLoggedIn).toBe(true)
+    expect(result.current.session).toEqual(mockSession)
+  })
+
+  it('should return loading status', () => {
+    mockUseSession.mockReturnValue({ data: null, status: 'loading' })
+
+    const { result } = renderHook(() => useSpotifyAuth())
+
+    expect(result.current.status).toBe('loading')
+    expect(result.current.isLoggedIn).toBe(false)
+  })
+
+  it('should call signOut and addError when session has RefreshAccessTokenError', () => {
+    const mockSession = {
+      error: 'RefreshAccessTokenError',
+      accessToken: 'expired-token',
+    }
+    mockUseSession.mockReturnValue({ data: mockSession, status: 'authenticated' })
+
+    renderHook(() => useSpotifyAuth())
+
+    expect(mockAddError).toHaveBeenCalledWith(
+      'Spotify session expired. Please log in again.',
+      { persist: true }
+    )
+    expect(mockSignOut).toHaveBeenCalled()
+  })
+
+  it('should not call signOut or addError for other errors or no error', () => {
+    const mockSession = {
+      error: 'SomeOtherError',
+      accessToken: 'valid-token',
+    }
+    mockUseSession.mockReturnValue({ data: mockSession, status: 'authenticated' })
+
+    const { rerender } = renderHook(() => useSpotifyAuth())
+
+    expect(mockAddError).not.toHaveBeenCalled()
+    expect(mockSignOut).not.toHaveBeenCalled()
+
+    // Rerender with no error
+    const validSession = { accessToken: 'valid-token' }
+    mockUseSession.mockReturnValue({ data: validSession, status: 'authenticated' })
+    rerender()
+
+    expect(mockAddError).not.toHaveBeenCalled()
+    expect(mockSignOut).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/hooks/useSpotifyAuth.test.ts
+++ b/tests/unit/hooks/useSpotifyAuth.test.ts
@@ -39,7 +39,10 @@ describe('useSpotifyAuth', () => {
 
   it('should return authenticated status when session exists', () => {
     const mockSession = { accessToken: '123', user: { name: 'Test User' } }
-    mockUseSession.mockReturnValue({ data: mockSession, status: 'authenticated' })
+    mockUseSession.mockReturnValue({
+      data: mockSession,
+      status: 'authenticated',
+    })
 
     const { result } = renderHook(() => useSpotifyAuth())
 
@@ -62,7 +65,10 @@ describe('useSpotifyAuth', () => {
       error: 'RefreshAccessTokenError',
       accessToken: 'expired-token',
     }
-    mockUseSession.mockReturnValue({ data: mockSession, status: 'authenticated' })
+    mockUseSession.mockReturnValue({
+      data: mockSession,
+      status: 'authenticated',
+    })
 
     renderHook(() => useSpotifyAuth())
 
@@ -78,7 +84,10 @@ describe('useSpotifyAuth', () => {
       error: 'SomeOtherError',
       accessToken: 'valid-token',
     }
-    mockUseSession.mockReturnValue({ data: mockSession, status: 'authenticated' })
+    mockUseSession.mockReturnValue({
+      data: mockSession,
+      status: 'authenticated',
+    })
 
     const { rerender } = renderHook(() => useSpotifyAuth())
 
@@ -87,7 +96,10 @@ describe('useSpotifyAuth', () => {
 
     // Rerender with no error
     const validSession = { accessToken: 'valid-token' }
-    mockUseSession.mockReturnValue({ data: validSession, status: 'authenticated' })
+    mockUseSession.mockReturnValue({
+      data: validSession,
+      status: 'authenticated',
+    })
     rerender()
 
     expect(mockAddError).not.toHaveBeenCalled()

--- a/tests/unit/hooks/useSpotifyWebPlayback.test.ts
+++ b/tests/unit/hooks/useSpotifyWebPlayback.test.ts
@@ -1,0 +1,103 @@
+/** @jest-environment jsdom */
+import { renderHook, waitFor } from '@testing-library/react'
+import { signOut } from 'next-auth/react'
+import { useError } from '@/context/ErrorContext'
+import useSpotifyWebPlayback from '@/hooks/useSpotifyWebPlayback'
+import * as networkUtils from '@/utils/network'
+
+// Mock dependencies
+jest.mock('next-auth/react', () => ({
+  signOut: jest.fn(),
+}))
+
+jest.mock('@/context/ErrorContext', () => ({
+  useError: jest.fn(),
+}))
+
+jest.mock('@/utils/network', () => ({
+  ...jest.requireActual('@/utils/network'),
+  fetchWithRetry: jest.fn(),
+}))
+
+const mockSignOut = signOut as jest.Mock
+const mockUseError = useError as jest.Mock
+const mockFetchWithRetry = networkUtils.fetchWithRetry as jest.Mock
+
+// Mock Spotify SDK
+const mockPlayer = {
+  connect: jest.fn().mockResolvedValue(true),
+  disconnect: jest.fn(),
+  addListener: jest.fn(),
+  removeListener: jest.fn(),
+}
+
+global.window.Spotify = {
+  Player: jest.fn().mockImplementation(() => mockPlayer),
+}
+
+describe('useSpotifyWebPlayback', () => {
+  let mockAddError: jest.Mock
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockAddError = jest.fn()
+    mockUseError.mockReturnValue({ addError: mockAddError })
+  })
+
+  it('should initialize the SDK and connect the player on mount', async () => {
+    mockFetchWithRetry.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ accessToken: 'fake-token' }),
+    })
+
+    renderHook(() => useSpotifyWebPlayback())
+
+    await waitFor(() => {
+      expect(window.Spotify.Player).toHaveBeenCalled()
+      expect(mockPlayer.connect).toHaveBeenCalled()
+    })
+  })
+
+  it('should call signOut and addError on 401 error from fetchWithRetry', async () => {
+    const error: networkUtils.AppError = {
+      message: 'Unauthorized',
+      code: 'HTTP_ERROR_401',
+      retryable: false,
+    }
+    mockFetchWithRetry.mockRejectedValue(error)
+
+    renderHook(() => useSpotifyWebPlayback())
+
+    // The hook's getOAuthToken is called by the Spotify Player constructor.
+    // We need to extract it and call it manually to test the error handling.
+    const playerOptions = (window.Spotify.Player as jest.Mock).mock.calls[0][0]
+    await playerOptions.getOAuthToken(() => {})
+
+    await waitFor(() => {
+      expect(mockAddError).toHaveBeenCalledWith(
+        'Spotify session expired. Please log in again.',
+        { persist: true }
+      )
+      expect(mockSignOut).toHaveBeenCalled()
+    })
+  })
+
+  it('should not call signOut for non-401 errors', async () => {
+    const error: networkUtils.AppError = {
+      message: 'Internal Server Error',
+      code: 'HTTP_ERROR_500',
+      retryable: true,
+    }
+    mockFetchWithRetry.mockRejectedValue(error)
+
+    renderHook(() => useSpotifyWebPlayback())
+
+    const playerOptions = (window.Spotify.Player as jest.Mock).mock.calls[0][0]
+    await playerOptions.getOAuthToken(() => {})
+
+    await waitFor(() => {
+      expect(mockAddError).not.toHaveBeenCalled()
+      expect(mockSignOut).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/tests/unit/hooks/useSpotifyWebPlayback.test.ts
+++ b/tests/unit/hooks/useSpotifyWebPlayback.test.ts
@@ -82,7 +82,7 @@ describe('useSpotifyWebPlayback', () => {
     })
   })
 
-  it('should not call signOut for non-401 errors', async () => {
+  it('should call addError but not signOut for non-401 errors', async () => {
     const error: networkUtils.AppError = {
       message: 'Internal Server Error',
       code: 'HTTP_ERROR_500',
@@ -96,7 +96,10 @@ describe('useSpotifyWebPlayback', () => {
     await playerOptions.getOAuthToken(() => {})
 
     await waitFor(() => {
-      expect(mockAddError).not.toHaveBeenCalled()
+      expect(mockAddError).toHaveBeenCalledWith(
+        'Failed to authenticate with Spotify: Internal Server Error',
+        { persist: false }
+      )
       expect(mockSignOut).not.toHaveBeenCalled()
     })
   })


### PR DESCRIPTION
## Description

This submission fixes a critical bug in the Spotify integration where the application would fail to recover from an expired access token, leading to a 401 Unauthorized error. I've refactored the authentication logic by introducing a new `useSpotifyAuth` hook that centralizes session management and gracefully handles token refresh errors. This ensures a more robust and reliable Spotify integration.

Fixes #5023

## Change Type: 🐛 Bug fix (non-breaking change fixing an issue)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [x] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [x] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

This submission fixes a critical bug in the Spotify integration where the application would fail to recover from an expired access token, leading to a 401 Unauthorized error. I've refactored the authentication logic by introducing a new `useSpotifyAuth` hook that centralizes session management and gracefully handles token refresh errors. This ensures a more robust and reliable Spotify integration.

Fixes #5023

---
*PR created automatically by Jules for task [17610130900498589268](https://jules.google.com/task/17610130900498589268) started by @arii*
</details>