### PR TITLE
fix(client): Ensure experimental page receives live HRM data

### DIFF
--- a/app/client/experimental/components/ExperimentalAnalyticsPage.tsx
+++ b/app/client/experimental/components/ExperimentalAnalyticsPage.tsx
@@ -1,6 +1,6 @@
 // app/client/experimental/components/ExperimentalAnalyticsPage.tsx
 'use client'
-import { useMemo } from 'react'
+import { useMemo, useEffect } from 'react'
 import { Container, Box, Button } from '@mui/material'
 import dynamic from 'next/dynamic'
 import { useWebSocket } from '@/context/WebSocketContext'
@@ -18,7 +18,7 @@ import { estimateCaloriesBurned } from '@/lib/calorie-estimation'
 import { useUserSettings } from '@/context/UserSettingsContext'
 
 const ExperimentalAnalyticsPage = () => {
-  const { hrmData, timerData } = useWebSocket()
+  const { hrmData, timerData, sendData, connectionStatus } = useWebSocket()
   const timerStatus = timerData?.currentPhase
   const [userSettings] = useUserSettings()
 
@@ -29,6 +29,21 @@ const ExperimentalAnalyticsPage = () => {
     hrmData[0]?.value ?? 0,
     workoutStatus
   )
+
+  // Send user metadata when WebSocket connects to ensure this client is registered
+  // to receive live HRM data updates. This is crucial for pages that are opened
+  // after a connection is already established elsewhere in the application.
+  useEffect(() => {
+    if (connectionStatus === 'Connected') {
+      sendData({
+        type: 'HRM_METADATA_UPDATE',
+        data: {
+          name: userSettings.userName || 'User', // Use a default name if not set
+          age: userSettings.userAge || 30, // Use a default age if not set
+        },
+      })
+    }
+  }, [connectionStatus, userSettings, sendData])
 
   const totalDuration = workoutData.hrHistory.length
 

--- a/tests/unit/components/ExperimentalAnalyticsPage.test.tsx
+++ b/tests/unit/components/ExperimentalAnalyticsPage.test.tsx
@@ -40,4 +40,28 @@ describe('ExperimentalAnalyticsPage', () => {
     expect(getByText('Time in Zones')).toBeInTheDocument()
     expect(getByText('Heart Rate Over Time')).toBeInTheDocument()
   })
+
+  it('sends HRM_METADATA_UPDATE when WebSocket is connected', () => {
+    const mockSendData = jest.fn()
+    mockUseWebSocket.mockReturnValue({
+      hrmData: [],
+      timerData: null,
+      sendData: mockSendData,
+      connectionStatus: 'Connected',
+    })
+    mockUseUserSettings.mockReturnValue([
+      { userName: 'Test User', userAge: 35 },
+      () => {},
+    ])
+
+    render(<ExperimentalAnalyticsPage />)
+
+    expect(mockSendData).toHaveBeenCalledWith({
+      type: 'HRM_METADATA_UPDATE',
+      data: {
+        name: 'Test User',
+        age: 35,
+      },
+    })
+  })
 })


### PR DESCRIPTION
## Description

This pull request addresses a bug where the `/client/experimental` page failed to display live heart rate data when opened after an existing WebSocket connection. The fix implements a `useEffect` hook within the `ExperimentalAnalyticsPage` component. This hook sends an `HRM_METADATA_UPDATE` message to the server upon connection, ensuring the client is properly registered to receive the live data stream.

Fixes #4988

## Change Type: 🐛 Bug fix (non-breaking change fixing an issue)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [x] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [x] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

This commit fixes a bug where the /client/experimental page would not display live heart rate data if it was opened after a WebSocket connection had already been established. The fix involves adding a useEffect hook to the ExperimentalAnalyticsPage component that sends an HRM_METADATA_UPDATE message to the server upon connection. This registers the client to receive the live data stream.

Fixes #4988

---
*PR created automatically by Jules for task [4719316887649268836](https://jules.google.com/task/4719316887649268836) started by @arii*
</details>