### PR TITLE
feat(small): Make Experimental Workout Viewer Persistent

### DIFF
--- a/app/client/experimental/components/ExperimentalAnalyticsPage.tsx
+++ b/app/client/experimental/components/ExperimentalAnalyticsPage.tsx
@@ -50,11 +50,7 @@ const ExperimentalAnalyticsPage = () => {
   return (
     <Container maxWidth="lg" sx={{ py: 4 }}>
       <Box display="flex" flexDirection="column" gap={3}>
-        <Box
-          display="flex"
-          justifyContent="space-between"
-          alignItems="center"
-        >
+        <Box display="flex" justifyContent="space-between" alignItems="center">
           <WorkoutSummary
             duration={totalDuration}
             calories={caloriesBurned}

--- a/app/client/experimental/components/ExperimentalAnalyticsPage.tsx
+++ b/app/client/experimental/components/ExperimentalAnalyticsPage.tsx
@@ -1,7 +1,7 @@
 // app/client/experimental/components/ExperimentalAnalyticsPage.tsx
 'use client'
 import { useMemo } from 'react'
-import { Container, Box, Button } from '@mui/material'
+import { Container, Box, Button, Chip } from '@mui/material'
 import dynamic from 'next/dynamic'
 import { useWebSocket } from '@/context/WebSocketContext'
 import {
@@ -44,14 +44,28 @@ const ExperimentalAnalyticsPage = () => {
     }, 0)
   }, [workoutData.hrHistory, userSettings])
 
+  // Determine if the displayed data is from a live session.
+  const isLive = workoutStatus === 'running' && workoutData.status === 'running'
+
   return (
     <Container maxWidth="lg" sx={{ py: 4 }}>
       <Box display="flex" flexDirection="column" gap={3}>
-        <WorkoutSummary
-          duration={totalDuration}
-          calories={caloriesBurned}
-          status={workoutData.status}
-        />
+        <Box
+          display="flex"
+          justifyContent="space-between"
+          alignItems="center"
+        >
+          <WorkoutSummary
+            duration={totalDuration}
+            calories={caloriesBurned}
+            status={workoutData.status}
+          />
+          <Chip
+            label={isLive ? 'Status: Live' : 'Status: Stored'}
+            color={isLive ? 'success' : 'default'}
+            variant="outlined"
+          />
+        </Box>
         <Box display="flex" gap={3}>
           <Box flex={1}>
             <ZoneDistribution

--- a/app/client/experimental/useLocalWorkoutBuffer.ts
+++ b/app/client/experimental/useLocalWorkoutBuffer.ts
@@ -17,6 +17,7 @@ export type ActiveWorkoutInputStatus = Exclude<WorkoutStatus, 'finished'>
 
 // Define the structure for the entire workout session
 export interface WorkoutSessionData {
+  sessionId: string
   startTime: number | null
   endTime: number | null
   status: WorkoutStatus
@@ -25,6 +26,7 @@ export interface WorkoutSessionData {
 }
 
 const initialWorkoutData: WorkoutSessionData = {
+  sessionId: '',
   startTime: null,
   endTime: null,
   status: 'idle',
@@ -106,30 +108,35 @@ export const useLocalWorkoutBuffer = (
 
   useEffect(() => {
     let intervalId: number | null = null
-    // CHANGED: The interval now starts as soon as the workout is running,
-    // regardless of whether there's an active HR signal.
-    // This allows data collection to begin immediately and catch the HR
-    // signal as soon as it's available.
-    if (workoutData.status === 'running') {
+    // The interval should only run when the stored session is 'running' AND
+    // the live workout signal is also 'running'. This prevents the hook
+    // from recording empty data points when viewing a stored session
+    // without an active connection.
+    if (workoutData.status === 'running' && workoutStatus === 'running') {
       intervalId = window.setInterval(recordHrData, 1000)
     }
     return () => {
       if (intervalId) window.clearInterval(intervalId)
     }
-  }, [workoutData.status, recordHrData])
+  }, [workoutData.status, workoutStatus, recordHrData])
 
   useEffect(() => {
     const prevStatus = prevWorkoutStatusRef.current
     if (prevStatus !== workoutStatus) {
       if (workoutStatus === 'running') {
         setWorkoutData((prev) => {
+          // A new workout is starting. Generate a new session ID.
           if (prev.status === 'idle' || prev.status === 'finished') {
             return {
               ...initialWorkoutData,
+              sessionId: `${Date.now().toString(36)}-${Math.random()
+                .toString(36)
+                .substring(2, 9)}`,
               status: 'running',
               startTime: Date.now(),
             }
           }
+          // The workout is resuming from a paused state.
           if (prev.status === 'paused') {
             return { ...prev, status: 'running' }
           }
@@ -140,7 +147,7 @@ export const useLocalWorkoutBuffer = (
           prev.status === 'running' ? { ...prev, status: 'paused' } : prev
         )
       } else if (workoutStatus === 'idle') {
-        // CHANGED: When the external timer goes idle (e.g., Tabata cycle ends),
+        // When the external timer goes idle (e.g., Tabata cycle ends),
         // we now pause the local workout instead of finishing it.
         // This preserves the session, allowing for continuous workouts that
         // span multiple timer cycles.

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -194,9 +194,7 @@ export const WebSocketProvider = ({
       }
 
       if (process.env.NODE_ENV !== 'production') {
-        ;(
-          window as Window & { TEST_CONTROLS?: TestControls }
-        ).TEST_CONTROLS = {
+        ;(window as Window & { TEST_CONTROLS?: TestControls }).TEST_CONTROLS = {
           dispatch,
           disconnect: () => {},
           connect: () => {},
@@ -409,9 +407,8 @@ export const WebSocketProvider = ({
       typeof window !== 'undefined' &&
       process.env.NODE_ENV !== 'production'
     ) {
-      const testControls = (
-        window as Window & { TEST_CONTROLS?: TestControls }
-      ).TEST_CONTROLS
+      const testControls = (window as Window & { TEST_CONTROLS?: TestControls })
+        .TEST_CONTROLS
       if (testControls) {
         testControls.disconnect = disconnect
         testControls.connect = connect

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -195,8 +195,8 @@ export const WebSocketProvider = ({
 
       if (process.env.NODE_ENV !== 'production') {
         ;(
-          window as Window & { __TEST_CONTROLS__?: TestControls }
-        ).__TEST_CONTROLS__ = {
+          window as Window & { TEST_CONTROLS?: TestControls }
+        ).TEST_CONTROLS = {
           dispatch,
           disconnect: () => {},
           connect: () => {},
@@ -410,8 +410,8 @@ export const WebSocketProvider = ({
       process.env.NODE_ENV !== 'production'
     ) {
       const testControls = (
-        window as Window & { __TEST_CONTROLS__?: TestControls }
-      ).__TEST_CONTROLS__
+        window as Window & { TEST_CONTROLS?: TestControls }
+      ).TEST_CONTROLS
       if (testControls) {
         testControls.disconnect = disconnect
         testControls.connect = connect

--- a/tests/playwright/experimental-page.spec.ts
+++ b/tests/playwright/experimental-page.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect, Page } from '@playwright/test';
+import { waitForPageReady } from './lib/waits';
+
+/**
+ * Starts a mock workout session by sending a 'WORK' phase message.
+ * @param page The Playwright page object.
+ */
+const startMockWorkout = async (page: Page) => {
+  await page.evaluate(() => {
+    window.__TEST_CONTROLS__?.sendMockTimerMessage({
+      timer: 30,
+      currentPhase: 'WORK',
+      cycle: 1,
+      totalCycles: 5,
+    });
+  });
+};
+
+test.describe('Experimental Analytics Page', () => {
+  test('should display live data during a session and stored data after', async ({ browser }) => {
+    // 1. Open the connect page to establish a WebSocket connection and start a workout
+    const connectPage = await browser.newPage();
+    await connectPage.goto('/client/connect');
+    await waitForPageReady(connectPage);
+
+    // Start a mock workout. This will trigger the useLocalWorkoutBuffer to start recording.
+    await startMockWorkout(connectPage);
+
+    // 2. Open the experimental page in a new tab
+    const experimentalPage = await browser.newPage();
+    await experimentalPage.goto('/client/experimental');
+    await waitForPageReady(experimentalPage);
+
+    // 3. Verify "Status: Live" is shown
+    await expect(experimentalPage.getByText('Status: Live')).toBeVisible();
+
+    // 4. Simulate disconnecting by closing the original connect page
+    await connectPage.close();
+
+    // 5. Reload the experimental page
+    await experimentalPage.reload();
+    await waitForPageReady(experimentalPage);
+
+    // 6. Verify it now shows "Status: Stored"
+    await expect(experimentalPage.getByText('Status: Stored')).toBeVisible();
+
+    // 7. Verify that some data has persisted by checking for the presence of the chart canvas
+    await expect(experimentalPage.locator('canvas')).toBeVisible();
+
+    // Clean up
+    await experimentalPage.close();
+  });
+});

--- a/tests/playwright/experimental-page.spec.ts
+++ b/tests/playwright/experimental-page.spec.ts
@@ -7,7 +7,7 @@ import { waitForPageReady } from './lib/waits'
  */
 const startMockWorkout = async (page: Page) => {
   await page.evaluate(() => {
-    window.__TEST_CONTROLS__?.sendMockTimerMessage({
+    window.TEST_CONTROLS?.sendMockTimerMessage({
       timer: 30,
       currentPhase: 'WORK',
       cycle: 1,

--- a/tests/playwright/experimental-page.spec.ts
+++ b/tests/playwright/experimental-page.spec.ts
@@ -1,5 +1,5 @@
-import { test, expect, Page } from '@playwright/test';
-import { waitForPageReady } from './lib/waits';
+import { test, expect, Page } from '@playwright/test'
+import { waitForPageReady } from './lib/waits'
 
 /**
  * Starts a mock workout session by sending a 'WORK' phase message.
@@ -12,42 +12,44 @@ const startMockWorkout = async (page: Page) => {
       currentPhase: 'WORK',
       cycle: 1,
       totalCycles: 5,
-    });
-  });
-};
+    })
+  })
+}
 
 test.describe('Experimental Analytics Page', () => {
-  test('should display live data during a session and stored data after', async ({ browser }) => {
+  test('should display live data during a session and stored data after', async ({
+    browser,
+  }) => {
     // 1. Open the connect page to establish a WebSocket connection and start a workout
-    const connectPage = await browser.newPage();
-    await connectPage.goto('/client/connect');
-    await waitForPageReady(connectPage);
+    const connectPage = await browser.newPage()
+    await connectPage.goto('/client/connect')
+    await waitForPageReady(connectPage)
 
     // Start a mock workout. This will trigger the useLocalWorkoutBuffer to start recording.
-    await startMockWorkout(connectPage);
+    await startMockWorkout(connectPage)
 
     // 2. Open the experimental page in a new tab
-    const experimentalPage = await browser.newPage();
-    await experimentalPage.goto('/client/experimental');
-    await waitForPageReady(experimentalPage);
+    const experimentalPage = await browser.newPage()
+    await experimentalPage.goto('/client/experimental')
+    await waitForPageReady(experimentalPage)
 
     // 3. Verify "Status: Live" is shown
-    await expect(experimentalPage.getByText('Status: Live')).toBeVisible();
+    await expect(experimentalPage.getByText('Status: Live')).toBeVisible()
 
     // 4. Simulate disconnecting by closing the original connect page
-    await connectPage.close();
+    await connectPage.close()
 
     // 5. Reload the experimental page
-    await experimentalPage.reload();
-    await waitForPageReady(experimentalPage);
+    await experimentalPage.reload()
+    await waitForPageReady(experimentalPage)
 
     // 6. Verify it now shows "Status: Stored"
-    await expect(experimentalPage.getByText('Status: Stored')).toBeVisible();
+    await expect(experimentalPage.getByText('Status: Stored')).toBeVisible()
 
     // 7. Verify that some data has persisted by checking for the presence of the chart canvas
-    await expect(experimentalPage.locator('canvas')).toBeVisible();
+    await expect(experimentalPage.locator('canvas')).toBeVisible()
 
     // Clean up
-    await experimentalPage.close();
-  });
-});
+    await experimentalPage.close()
+  })
+})


### PR DESCRIPTION
## Description

This change makes the experimental workout viewer a persistent, standalone page, allowing users to view workout data at any time, even after the live session has ended.

Fixes #5043

No specific dependencies are required for this change.

## Change Type: ✨ New feature (non-breaking change adding functionality)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [x] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [x] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

This change makes the experimental workout viewer a persistent, standalone page, allowing users to view workout data at any time, even after the live session has ended.

Fixes #5043

---
*PR created automatically by Jules for task [1479649175433724472](https://jules.google.com/task/1479649175433724472) started by @arii*
</details>