### PR TITLE
chore(small): Refine Knip Configuration to Resolve False Positives

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -19,8 +19,6 @@ const config: KnipConfig = {
     'stories/**/*.tsx',
     '.storybook/**/*.ts',
     '.storybook/**/*.tsx',
-    'server.ts',
-    'proxy.ts',
   ],
   project: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.cjs', '**/*.mjs'],
   ignore: [
@@ -34,13 +32,17 @@ const config: KnipConfig = {
     'storybook-static',
     'ecosystem.config.cjs',
     'scripts/get-available-port.mjs',
+    'public/assets',
+    'public/screenshots',
+    'public/**/*.wav',
+    'public/**/*.svg',
+    'public/**/*.json',
     'public/mockServiceWorker.js',
     'next.config.js',
     'jest.config.cjs',
     'commitlint.config.cjs',
     'playwright.config.ts',
     'eslint.config.mjs',
-    // This mock is dynamically imported in tests, so Knip cannot detect its usage.
     'tests/unit/mocks/webBluetooth.ts',
   ],
   ignoreDependencies: [
@@ -51,6 +53,13 @@ const config: KnipConfig = {
     'dotenv',
   ],
   ignoreBinaries: ['scripts/test-json-with-server.sh', 'python3'],
+  next: {
+    entry: ['server.ts', 'proxy.ts'],
+  },
+  jest: {
+    config: ['jest.config.cjs', 'jest.config.components.cjs', 'jest.config.integration.cjs'],
+    entry: ['tests/**/*.ts', 'tests/**/*.tsx'],
+  },
 }
 
 export default config


### PR DESCRIPTION
## Description

This change refines the Knip configuration to improve the accuracy of its analysis and resolve several false positives, including server entry points, public directory assets, and Jest-related dependencies.

The motivation for this change is to enhance the reliability of Knip's analysis by eliminating incorrect warnings and improving the development experience. No specific dependencies are required for this configuration refinement.

Fixes #3519

## Change Type: 🐛 Bug fix (non-breaking change fixing an issue)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [ ] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [ ] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [ ] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [ ] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [ ] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [ ] Changes are **backward compatible** (or breaking changes are documented)
- [ ] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

This change refines the Knip configuration to improve the accuracy of its analysis and resolve several false positives, including server entry points, public directory assets, and Jest-related dependencies.

Fixes #3519

---
*PR created automatically by Jules for task [12654973646447566119](https://jules.google.com/task/12654973646447566119) started by @arii*
</details>