### PR TITLE
chore(small): Fix Bluetooth Auto-Connect Race Condition

### DIFF
--- a/hooks/useBluetoothHRM.race.test.ts
+++ b/hooks/useBluetoothHRM.race.test.ts
@@ -4,6 +4,7 @@
 import { renderHook, act } from '@testing-library/react'
 import useBluetoothHRM from './useBluetoothHRM'
 import { mockBluetooth } from '@/tests/unit/mocks/webBluetooth'
+import * as cookieUtils from '@/utils/cookies'
 
 // Mock the WebSocket context
 jest.mock('@/context/WebSocketContext', () => ({
@@ -12,6 +13,14 @@ jest.mock('@/context/WebSocketContext', () => ({
     connectionStatus: 'Connected',
   }),
 }))
+
+// Mock cookie utilities
+jest.mock('@/utils/cookies', () => ({
+  getCookie: jest.fn(),
+  setCookie: jest.fn(),
+}))
+
+const mockedCookieUtils = cookieUtils as jest.Mocked<typeof cookieUtils>
 
 describe('useBluetoothHRM Race Conditions', () => {
   const originalNavigator = global.navigator
@@ -149,6 +158,45 @@ describe('useBluetoothHRM Race Conditions', () => {
     expect(mockGattConnect).toHaveBeenCalledTimes(2)
     // Abort should still be called as the hook cleans up previous attempts
     expect(mockAbort).toHaveBeenCalledTimes(1)
+    // The final status should be connected
+    expect(result.current.isConnected).toBe(true)
+  })
+
+  it('should only attempt to connect once when autoConnect is called multiple times concurrently', async () => {
+    // Simulate that a device has been previously connected and its ID is saved
+    mockedCookieUtils.getCookie.mockReturnValue('test-device-id')
+
+    // Simulate that the device is available to be re-connected to
+    const mockSavedDevice = {
+      id: 'test-device-id',
+      name: 'Saved HRM',
+      gatt: {
+        connect: mockGattConnect,
+      },
+    }
+    Object.defineProperty(global.navigator, 'bluetooth', {
+      value: {
+        ...mockBluetooth,
+        getDevices: jest.fn().mockResolvedValue([mockSavedDevice]),
+      },
+      writable: true,
+    })
+
+    const { result } = renderHook(() => useBluetoothHRM())
+
+    // Act: Call autoConnect multiple times in parallel to simulate a race condition
+    await act(async () => {
+      const autoConnectPromises = [
+        result.current.autoConnect(),
+        result.current.autoConnect(),
+        result.current.autoConnect(),
+      ]
+      // We don't care about the result of the promises, just that they complete
+      await Promise.allSettled(autoConnectPromises)
+    })
+
+    // Assert: Check that gatt.connect was only called once, proving the lock works
+    expect(mockGattConnect).toHaveBeenCalledTimes(1)
     // The final status should be connected
     expect(result.current.isConnected).toBe(true)
   })

--- a/hooks/useBluetoothHRM.ts
+++ b/hooks/useBluetoothHRM.ts
@@ -753,7 +753,12 @@ const useBluetoothHRM = (props: UseBluetoothHRMProps = {}) => {
   const autoConnect = useCallback(async (): Promise<void> => {
     // Try to auto-connect to a saved device. This is a critical function for user experience.
     // We want it to succeed silently if possible, but still provide feedback if it fails.
+    if (isConnecting.current) {
+      logger.info('Auto-connect call ignored, connection already in progress.')
+      return
+    }
     try {
+      isConnecting.current = true // Set lock immediately after guard
       logger.info('Starting auto-connect to saved device...')
       setStatus(BluetoothConnectionStatus.CONNECTING)
       setCustomStatusMessage(BLUETOOTH_MESSAGES.connectingToSavedDevice)
@@ -769,6 +774,8 @@ const useBluetoothHRM = (props: UseBluetoothHRMProps = {}) => {
       // Set status back to allow manual connection
       setStatus(BluetoothConnectionStatus.DISCONNECTED)
       setCustomStatusMessage(BLUETOOTH_MESSAGES.autoConnectFailed)
+    } finally {
+      isConnecting.current = false // Ensure lock is always released
     }
   }, [connectAndStream])
 


### PR DESCRIPTION
## Description

This PR fixes a race condition in the Bluetooth HRM auto-connect feature that occurred on page refresh. The fix prevents multiple concurrent connection attempts and eliminates the associated console warnings.

Fixes #5286

## Change Type: 🐛 Bug fix (non-breaking change fixing an issue)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [ ] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [ ] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [ ] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [ ] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [ ] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [ ] Changes are **backward compatible** (or breaking changes are documented)
- [ ] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

This PR fixes a race condition in the Bluetooth HRM auto-connect feature that occurred on page refresh. The fix prevents multiple concurrent connection attempts and eliminates the associated console warnings.

Fixes #5286

---
*PR created automatically by Jules for task [13025364572181848363](https://jules.google.com/task/13025364572181848363) started by @arii*
</details>