### PR TITLE
feat(small): Enable Automatic Workout Data Persistence on /client/connect Page

### DIFF
--- a/app/client/connect/page.tsx
+++ b/app/client/connect/page.tsx
@@ -6,6 +6,7 @@ import { useWebSocket } from '@/context/WebSocketContext'
 import { formatDuration } from '@/lib/utils'
 import ConnectView from './ConnectView'
 import { useWorkoutSession } from '@/hooks/useWorkoutSession'
+import { useWorkoutSessionManager } from '@/hooks/useWorkoutSessionManager'
 import { MeasurementSystem } from '../../../types/core'
 import { toKg, toDisplay } from '../../../utils/units'
 import { useCalorieCalculator } from '@/hooks/useCalorieCalculator'
@@ -126,6 +127,33 @@ export default function ConnectPage() {
     totalCalories: calories,
   })
 
+  // Add the workout session manager for data persistence
+  const {
+    addHrData,
+    startWorkout: startPersistentWorkout,
+    endWorkout: endPersistentWorkout,
+    resetWorkout: resetPersistentWorkout,
+  } = useWorkoutSessionManager()
+
+  // Create wrapper functions that sync both hooks
+  const handleStartWorkout = useCallback(() => {
+    startWorkout()
+    if (userAge && userWeight) {
+      startPersistentWorkout(userAge, userWeight)
+    }
+  }, [startWorkout, startPersistentWorkout, userAge, userWeight])
+
+  const handleEndWorkout = useCallback(() => {
+    endWorkout()
+    endPersistentWorkout()
+  }, [endWorkout, endPersistentWorkout])
+
+  const handleResetWorkout = useCallback(() => {
+    resetWorkoutSession()
+    resetCalculator()
+    resetPersistentWorkout()
+  }, [resetWorkoutSession, resetCalculator, resetPersistentWorkout])
+
   // Callback for raw heart rate updates from the Bluetooth hook
   const handleHeartRateUpdate = useCallback(
     (heartRate: number) => {
@@ -134,11 +162,19 @@ export default function ConnectPage() {
         'handleHeartRateUpdate called, updating local state'
       )
       setCurrentHR(heartRate)
+
+      // Process for calorie calculation
       if (workoutStatus === 'running') {
         processHeartRate(heartRate)
+
+        // CRITICAL: Persist HR data to IndexedDB
+        addHrData({
+          time: Date.now(),
+          hr: heartRate,
+        })
       }
     },
-    [processHeartRate, workoutStatus, setCurrentHR]
+    [processHeartRate, workoutStatus, setCurrentHR, addHrData]
   )
   const {
     connectAndStream,
@@ -155,7 +191,7 @@ export default function ConnectPage() {
     userName,
     userAge: userAge || 0,
     onHeartRateUpdate: handleHeartRateUpdate,
-    onConnect: startWorkout,
+    onConnect: handleStartWorkout, // Use the wrapped function
   })
 
   useEffect(() => {
@@ -201,10 +237,7 @@ export default function ConnectPage() {
   }
   const maxHr = userAge ? 220 - userAge : 190
   const hrZoneProps = useHrZone(currentHR, maxHr)
-  const resetWorkout = () => {
-    resetWorkoutSession()
-    resetCalculator()
-  }
+
   return (
     <ConnectView
       duration={formatDuration(workoutDuration, {
@@ -251,11 +284,11 @@ export default function ConnectPage() {
       connectionStatus={connectionStatus}
       bluetoothConnected={isConnected}
       hasStarted={hasStarted}
-      onReset={resetWorkout}
+      onReset={handleResetWorkout}
       workoutStatus={workoutStatus}
-      onStartWorkout={startWorkout}
+      onStartWorkout={handleStartWorkout}
       onPauseWorkout={pauseWorkout}
-      onEndWorkout={endWorkout}
+      onEndWorkout={handleEndWorkout}
     />
   )
 }


### PR DESCRIPTION
## Description

This change integrates the `useWorkoutSessionManager` hook into the `/client/connect` page to automatically persist workout data to IndexedDB. This ensures that when a user starts a workout on the `/client/connect` page, the heart rate data is saved in real-time, allowing the user to navigate to the `/client/experimental` page at any time and see their complete workout data.

Fixes #5652

## Change Type: ✨ New feature (non-breaking change adding functionality)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [ ] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [ ] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [ ] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

This change integrates the `useWorkoutSessionManager` hook into the `/client/connect` page to automatically persist workout data to IndexedDB. This ensures that when a user starts a workout on the `/client/connect` page, the heart rate data is saved in real-time, allowing the user to navigate to the `/client/experimental` page at any time and see their complete workout data.

Fixes #5652

---
*PR created automatically by Jules for task [8429807275082536520](https://jules.google.com/task/8429807275082536520) started by @arii*
</details>