### PR TITLE
feat(small): Add data-testid to HR Time Series Chart for VRT masking

### DIFF
--- a/app/client/experimental/components/HeartRateTimeSeries.tsx
+++ b/app/client/experimental/components/HeartRateTimeSeries.tsx
@@ -24,7 +24,7 @@ const HeartRateTimeSeries = ({ hrHistory }: HeartRateTimeSeriesProps) => {
         <Typography variant="h5" gutterBottom>
           Heart Rate Over Time
         </Typography>
-        <Box sx={{ height: 300 }}>
+        <Box sx={{ height: 300 }} data-testid="hr-time-series-chart">
           <ResponsiveContainer width="100%" height="100%">
             <LineChart data={hrHistory} syncId="anyId">
               <CartesianGrid strokeDasharray="3 3" />

--- a/tests/unit/app/client/experimental/components/HeartRateTimeSeries.test.tsx
+++ b/tests/unit/app/client/experimental/components/HeartRateTimeSeries.test.tsx
@@ -1,0 +1,31 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import HeartRateTimeSeries from '@/app/client/experimental/components/HeartRateTimeSeries'
+import { HrDataPoint } from '@/lib/workout-session-storage'
+
+// Mock ResizeObserver for Recharts
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+describe('HeartRateTimeSeries', () => {
+  const mockHrHistory: HrDataPoint[] = [
+    { time: new Date('2023-01-01T10:00:00').getTime(), hr: 60 },
+    { time: new Date('2023-01-01T10:00:05').getTime(), hr: 65 },
+  ]
+
+  it('renders the title', () => {
+    render(<HeartRateTimeSeries hrHistory={mockHrHistory} />)
+    expect(screen.getByText('Heart Rate Over Time')).toBeInTheDocument()
+  })
+
+  it('renders with the correct data-testid', () => {
+    render(<HeartRateTimeSeries hrHistory={mockHrHistory} />)
+    expect(screen.getByTestId('hr-time-series-chart')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Description

This PR addresses the issue of missing `data-testid` on the HR Time Series Chart, which was preventing VRT masks from working correctly. This change ensures that Visual Regression Tests (VRT) can properly mask the component.

**Changes:**
- Added `data-testid="hr-time-series-chart"` to the wrapping `Box` in `app/client/experimental/components/HeartRateTimeSeries.tsx`.
- Added a new unit test `tests/unit/app/client/experimental/components/HeartRateTimeSeries.test.tsx` to verify the component renders and has the correct `data-testid`.

**Verification:**
- Ran `pnpm run lint` - Passed.
- Ran `pnpm run build` - Passed.
- Ran `pnpm run test:unit tests/unit/app/client/experimental/components/HeartRateTimeSeries.test.tsx` - Passed.

Fixes # 13200803373747795531

## Change Type: 🐛 Bug fix (non-breaking change fixing an issue)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [x] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [x] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

This PR addresses the issue of missing `data-testid` on the HR Time Series Chart, which was preventing VRT masks from working correctly.

Changes:
- Added `data-testid="hr-time-series-chart"` to the wrapping `Box` in `app/client/experimental/components/HeartRateTimeSeries.tsx`.
- Added a new unit test `tests/unit/app/client/experimental/components/HeartRateTimeSeries.test.tsx` to verify the component renders and has the correct `data-testid`.

Verification:
- Ran `pnpm run lint` - Passed.
- Ran `pnpm run build` - Passed.
- Ran `pnpm run test:unit tests/unit/app/client/experimental/components/HeartRateTimeSeries.test.tsx` - Passed.

---
*PR created automatically by Jules for task [13200803373747795531](https://jules.google.com/task/13200803373747795531) started by @arii*
</details>