### PR TITLE
test(medium): fix: resolve lint, build, and unit test failures

### DIFF
--- a/hooks/useSpotifyControls.ts
+++ b/hooks/useSpotifyControls.ts
@@ -18,8 +18,8 @@ export const useSpotifyControls = () => {
   const { spotifyData, sendData } = useWebSocket()
 
   const spotifyDeviceId = useMemo(
-    () => resolveSpotifyDeviceId(spotifyData.devices || []),
-    [spotifyData.devices]
+    () => resolveSpotifyDeviceId(spotifyData?.devices || []),
+    [spotifyData?.devices]
   )
 
   const sendSpotifyCommand = useCallback(

--- a/tests/unit/components/TimerControls.test.tsx
+++ b/tests/unit/components/TimerControls.test.tsx
@@ -25,6 +25,7 @@ describe('TimerControls', () => {
         timeRemaining: 0,
         currentRound: 0,
         totalRounds: 0,
+        isRunning: false,
       },
       spotifyData: null,
       workoutData: {
@@ -62,6 +63,7 @@ describe('TimerControls', () => {
         timeRemaining: 10,
         currentRound: 1,
         totalRounds: 10,
+        isRunning: true,
       },
       spotifyData: null,
       workoutData: {

--- a/tests/unit/hooks/useBluetoothHRM.test.ts
+++ b/tests/unit/hooks/useBluetoothHRM.test.ts
@@ -209,11 +209,13 @@ describe('useBluetoothHRM', () => {
 
     // Second call, should trigger the abort logic for the first call
     act(() => {
-      result.current.connectAndStream(undefined, undefined, { silent: true })
+      result.current.connectAndStream(undefined, undefined, { silent: false })
     })
 
     // Verify that the abort function was called for the first pending attempt
-    expect(mockAbort).toHaveBeenCalledTimes(1)
+    await waitFor(() => {
+      expect(mockAbort).toHaveBeenCalledTimes(1)
+    })
 
     // Clean up by resolving the promise to avoid open handles
     await act(async () => {
@@ -543,7 +545,7 @@ describe('useBluetoothHRM', () => {
 
       // After max attempts, it should fail
       await act(async () => {
-        jest.runOnlyPendingTimers()
+        jest.advanceTimersByTime(100)
       })
 
       await waitFor(() => {
@@ -560,7 +562,7 @@ describe('useBluetoothHRM', () => {
 
       // It should also forget the device
       await act(async () => {
-        jest.runOnlyPendingTimers() // Run the final timer to forget the device
+        jest.advanceTimersByTime(2000) // Run the final timer to forget the device
       })
       expect(cookieUtils.setCookie).toHaveBeenCalledWith(
         'hrm_device_id',

--- a/tests/unit/hooks/useLocalWorkoutBuffer.test.ts
+++ b/tests/unit/hooks/useLocalWorkoutBuffer.test.ts
@@ -1,4 +1,3 @@
-// tests/unit/hooks/useLocalWorkoutBuffer.test.ts
 /**
  * @jest-environment jsdom
  */


### PR DESCRIPTION
## Description

This PR addresses linting, build, and unit test failures that were present in the `fix-lint-build-test-failures` branch. The changes ensure the project builds successfully, passes lint checks, and all unit tests run without errors.

**Key Changes:**

1.  **Test Environment Configuration Fix:**
    *   Removed a leading comment in `tests/unit/hooks/useLocalWorkoutBuffer.test.ts` that was interfering with the `/** @jest-environment jsdom */` directive. This ensures the test runs in the correct JSDOM environment, resolving "document is not defined" errors.

2.  **Runtime Safety in `useSpotifyControls`:**
    *   Implemented optional chaining (`spotifyData?.devices`) when accessing `spotifyData.devices` in `hooks/useSpotifyControls.ts`. This prevents potential runtime crashes when `spotifyData` is initially `null`, which was a cause of test failures.

3.  **Improved Test Mock Accuracy for `TimerControls`:**
    *   Updated the `useWebSocket` mock in `tests/unit/components/TimerControls.test.tsx` to include the `isRunning` property within `timerData`. This property is crucial for the `TimerControls` component to correctly render the "STOP" button, resolving a related "element not found" test failure.

4.  **Refined Async Test Logic in `useBluetoothHRM`:**
    *   **Abort Test:** Modified the "should abort a pending connection attempt" test by disabling `silent` mode during the second `connectAndStream` call, allowing the connection phase to be reached and enabling the abort logic to be triggered. Assertions are now wrapped in `waitFor` to correctly handle the asynchronous nature of the abort operation.
    *   **Reconnect Test:** Enhanced the "should attempt to reconnect on disconnection" test by using `jest.advanceTimersByTime` with precise values. This allows for accurate assertion of the "failed to reconnect" state *before* the subsequent `forgetDevice` cleanup timer executes and alters the state.

**Verification:**
*   `pnpm run lint` passed.
*   `pnpm run build` passed.
*   `pnpm run test:unit` passed (554/554 tests).

Fixes # N/A (General maintenance and bug fixing)

## Change Type: 🐛 Bug fix (non-breaking change fixing an issue)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [x] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [x] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

This PR addresses linting, build, and test failures in the `fix-lint-build-test-failures` branch.

**Key Changes:**

1.  **Test Environment Configuration:**
    *   Removed a leading comment in `tests/unit/hooks/useLocalWorkoutBuffer.test.ts` that was preventing the `/** @jest-environment jsdom */` directive from working, causing the test to run in the wrong environment (Node.js instead of JSDOM) and fail with `document is not defined`.

2.  **Runtime Safety in Hooks:**
    *   Updated `hooks/useSpotifyControls.ts` to safely access `spotifyData?.devices` using optional chaining. This prevents a potential runtime crash when `spotifyData` is initially `null`, which was causing test failures.

3.  **Test Mock Accuracy:**
    *   Updated the `useWebSocket` mock in `tests/unit/components/TimerControls.test.tsx` to include the `isRunning` property in `timerData`. This property is required for the `TimerControls` component to correctly render the "STOP" button, fixing a "element not found" test failure.

4.  **Async Test Logic in `useBluetoothHRM`:**
    *   **Abort Test:** Fixed the "should abort a pending connection attempt" test by ensuring the second connection call (`connectAndStream`) actually proceeds to the connection phase (by disabling `silent` mode), which is required to trigger the abort logic. Also wrapped the assertion in `waitFor` to handle the asynchronous nature of the abort call.
    *   **Reconnect Test:** Improved the "should attempt to reconnect on disconnection" test by using `jest.advanceTimersByTime` with precise values instead of `jest.runOnlyPendingTimers()`. This ensures that we can assert the "failed to reconnect" state *before* the subsequent cleanup timer (`forgetDevice`) executes and changes the state again.

**Verification:**
*   Ran `pnpm run lint` (passed).
*   Ran `pnpm run build` (passed).
*   Ran `pnpm run test:unit` (passed, 554/554 tests).


---
*PR created automatically by Jules for task [17112616955768439328](https://jules.google.com/task/17112616955768439328) started by @arii*
</details>