### PR TITLE
chore(small): Refactor UserHrZones type to prevent shadowing

### DIFF
--- a/types/heart-rate.ts
+++ b/types/heart-rate.ts
@@ -1,4 +1,4 @@
-import { HrZoneName, UserHrZones } from '../lib/shared/hr-zones'
+import type { HrZoneName, UserHrZones } from '../lib/shared/hr-zones'
 
 export interface HrZone {
   zoneName: HrZoneName

--- a/types/heart-rate.ts
+++ b/types/heart-rate.ts
@@ -1,5 +1,4 @@
-// types/heart-rate.ts
-import { HrZoneName } from '../lib/shared/hr-zones'
+import { HrZoneName, UserHrZones } from '../lib/shared/hr-zones'
 
 export interface HrZone {
   zoneName: HrZoneName
@@ -7,13 +6,7 @@ export interface HrZone {
   bpm: number
 }
 
-export interface UserHrZones {
-  warmUp: { min: number }
-  fatBurn: { min: number }
-  cardio: { min: number }
-  peak: { min: number }
-  max: { min: number }
-}
+export type { UserHrZones }
 
 export interface HrData {
   bpm: number


### PR DESCRIPTION
## Description

This PR addresses the type definition shadowing issue where `UserHrZones` was defined in both `lib/shared/hr-zones.ts` and `types/heart-rate.ts`.

**Changes:**
- Removed the local `interface UserHrZones` definition from `types/heart-rate.ts`.
- Imported `UserHrZones` from `lib/shared/hr-zones.ts` into `types/heart-rate.ts`.
- Re-exported `UserHrZones` from `types/heart-rate.ts` to maintain backward compatibility for potential consumers.

**Motivation and Context:**
This establishes `lib/shared/hr-zones.ts` as the single source of truth for this type, preventing divergence and reducing maintenance overhead. Verified with `pnpm run build` and `pnpm run test:unit`.

Fixes # 

## Change Type: 🏗️ Refactoring (code change that neither fixes bug nor adds feature)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [x] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [x] **Tests** are added/updated for new functionality
- [x] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

This PR addresses the type definition shadowing issue where `UserHrZones` was defined in both `lib/shared/hr-zones.ts` and `types/heart-rate.ts`.

Changes:
- Removed the local `interface UserHrZones` definition from `types/heart-rate.ts`.
- Imported `UserHrZones` from `lib/shared/hr-zones.ts` into `types/heart-rate.ts`.
- Re-exported `UserHrZones` from `types/heart-rate.ts` to maintain backward compatibility for potential consumers.

This establishes `lib/shared/hr-zones.ts` as the single source of truth for this type, preventing divergence and reducing maintenance overhead. Verified with `pnpm run build` and `pnpm run test:unit`.

---
*PR created automatically by Jules for task [10881359625983001710](https://jules.google.com/task/10881359625983001710) started by @arii*
</details>