### PR TITLE
test(small): Fix HRM build failure and test stability

### DIFF
--- a/hooks/useBluetoothHRM.ts
+++ b/hooks/useBluetoothHRM.ts
@@ -470,6 +470,7 @@ const useBluetoothHRM = (props: UseBluetoothHRMProps = {}) => {
 
         // Attach disconnect listener immediately after successful GATT connection
         // This ensures we catch disconnections that might occur during service discovery
+        device.removeEventListener('gattserverdisconnected', onDisconnected)
         device.addEventListener('gattserverdisconnected', onDisconnected)
 
         const service = await server!.getPrimaryService(HR_SERVICE_UUID)

--- a/hooks/useBluetoothHRM.ts
+++ b/hooks/useBluetoothHRM.ts
@@ -94,6 +94,9 @@ const useBluetoothHRM = (props: UseBluetoothHRMProps = {}) => {
   const lastSentMetadataRef = useRef<HrmMetadataUpdateData | null>(null)
   const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const isConnecting = useRef(false)
+  const activeDisconnectListenerRef = useRef<((event: Event) => void) | null>(
+    null
+  )
 
   // Centralized function to update the signal period history and state
   const updateSignalPeriod = useCallback((newPeriod: number) => {
@@ -168,37 +171,6 @@ const useBluetoothHRM = (props: UseBluetoothHRMProps = {}) => {
   useEffect(() => {
     statusRef.current = status
   }, [status])
-
-  // Cleanup
-  useEffect(() => {
-    isManualDisconnect.current = false
-
-    if (
-      typeof window !== 'undefined' &&
-      process.env.NEXT_PUBLIC_TESTING === 'true'
-    ) {
-      window.TEST_CONTROLS = {
-        ...window.TEST_CONTROLS,
-        setHrmStatus: setStatus,
-        setCustomHrmStatusMessage: setCustomStatusMessage,
-      }
-    }
-
-    return () => {
-      // This allows auto-reconnect to work properly on component remount
-      if (reconnectTimeoutRef.current) clearTimeout(reconnectTimeoutRef.current)
-
-      if (
-        typeof window !== 'undefined' &&
-        process.env.NEXT_PUBLIC_TESTING === 'true'
-      ) {
-        if (window.TEST_CONTROLS) {
-          delete window.TEST_CONTROLS.setHrmStatus
-          delete window.TEST_CONTROLS.setCustomHrmStatusMessage
-        }
-      }
-    }
-  }, [])
 
   useEffect(() => {
     let checkCounter = 0
@@ -379,6 +351,46 @@ const useBluetoothHRM = (props: UseBluetoothHRMProps = {}) => {
     [reconnect]
   )
 
+  // Cleanup
+  useEffect(() => {
+    isManualDisconnect.current = false
+
+    if (
+      typeof window !== 'undefined' &&
+      process.env.NEXT_PUBLIC_TESTING === 'true'
+    ) {
+      window.TEST_CONTROLS = {
+        ...window.TEST_CONTROLS,
+        setHrmStatus: setStatus,
+        setCustomHrmStatusMessage: setCustomStatusMessage,
+      }
+    }
+
+    return () => {
+      // Clean up the disconnected listener to prevent leaks across remounts
+      if (deviceRef.current && activeDisconnectListenerRef.current) {
+        deviceRef.current.removeEventListener(
+          'gattserverdisconnected',
+          activeDisconnectListenerRef.current
+        )
+        activeDisconnectListenerRef.current = null
+      }
+
+      // This allows auto-reconnect to work properly on component remount
+      if (reconnectTimeoutRef.current) clearTimeout(reconnectTimeoutRef.current)
+
+      if (
+        typeof window !== 'undefined' &&
+        process.env.NEXT_PUBLIC_TESTING === 'true'
+      ) {
+        if (window.TEST_CONTROLS) {
+          delete window.TEST_CONTROLS.setHrmStatus
+          delete window.TEST_CONTROLS.setCustomHrmStatusMessage
+        }
+      }
+    }
+  }, [onDisconnected])
+
   const connectToGatt = useCallback(
     async (device: BluetoothDevice, isReconnect = false) => {
       // Abort any existing connection attempts.
@@ -470,8 +482,14 @@ const useBluetoothHRM = (props: UseBluetoothHRMProps = {}) => {
 
         // Attach disconnect listener immediately after successful GATT connection
         // This ensures we catch disconnections that might occur during service discovery
-        device.removeEventListener('gattserverdisconnected', onDisconnected)
+        if (activeDisconnectListenerRef.current) {
+          device.removeEventListener(
+            'gattserverdisconnected',
+            activeDisconnectListenerRef.current
+          )
+        }
         device.addEventListener('gattserverdisconnected', onDisconnected)
+        activeDisconnectListenerRef.current = onDisconnected
 
         const service = await server!.getPrimaryService(HR_SERVICE_UUID)
         const characteristic = await service.getCharacteristic(

--- a/hooks/useBluetoothHRM.ts
+++ b/hooks/useBluetoothHRM.ts
@@ -483,10 +483,22 @@ const useBluetoothHRM = (props: UseBluetoothHRMProps = {}) => {
         // Attach disconnect listener immediately after successful GATT connection
         // This ensures we catch disconnections that might occur during service discovery
         if (activeDisconnectListenerRef.current) {
-          device.removeEventListener(
-            'gattserverdisconnected',
-            activeDisconnectListenerRef.current
-          )
+          // If we are connecting to a new device, we should remove the listener from the OLD device (deviceRef.current)
+          // or the current device if it's a reconnect. To be safe, try removing from both if they differ.
+          const oldDevice = deviceRef.current
+          if (oldDevice) {
+            oldDevice.removeEventListener(
+              'gattserverdisconnected',
+              activeDisconnectListenerRef.current
+            )
+          }
+          // Also try removing from the new device just in case
+          if (device !== oldDevice) {
+            device.removeEventListener(
+              'gattserverdisconnected',
+              activeDisconnectListenerRef.current
+            )
+          }
         }
         device.addEventListener('gattserverdisconnected', onDisconnected)
         activeDisconnectListenerRef.current = onDisconnected

--- a/hooks/useBluetoothHRM.ts
+++ b/hooks/useBluetoothHRM.ts
@@ -389,7 +389,7 @@ const useBluetoothHRM = (props: UseBluetoothHRMProps = {}) => {
         }
       }
     }
-  }, [onDisconnected])
+  }, [])
 
   const connectToGatt = useCallback(
     async (device: BluetoothDevice, isReconnect = false) => {

--- a/hooks/useWorkoutSessionManager.ts
+++ b/hooks/useWorkoutSessionManager.ts
@@ -9,7 +9,6 @@ import {
 import { HrZoneName } from '../lib/shared/hr-zones'
 import { v4 as uuidv4 } from 'uuid'
 import { calculateHrZone } from '../lib/hrm/zones'
-import { HrZoneName } from '../lib/shared/hr-zones'
 import { estimateMaxHr } from '../lib/hrm/utils'
 
 // --- State, Actions, and Reducer ---

--- a/tests/unit/hooks/useBluetoothHRM.test.ts
+++ b/tests/unit/hooks/useBluetoothHRM.test.ts
@@ -211,54 +211,60 @@ describe('useBluetoothHRM', () => {
         MockAbortController as unknown as typeof AbortController
     }
 
-    // Make the connect call a promise that we can control
-    let connectResolver: (value: MockBluetoothRemoteGATTServer) => void
-    const connectPromise = new Promise<MockBluetoothRemoteGATTServer>(
-      (resolve, _reject) => {
-        connectResolver = resolve
-        // If the signal aborts while we are waiting, we should reject?
-        // The cancellablePromise utility wraps this, so the underlying promise doesn't STRICTLY need to handle abort,
-        // but it's good practice.
+    try {
+      // Make the connect call a promise that we can control
+      let connectResolver: (value: MockBluetoothRemoteGATTServer) => void
+      const connectPromise = new Promise<MockBluetoothRemoteGATTServer>(
+        (resolve, _reject) => {
+          connectResolver = resolve
+          // If the signal aborts while we are waiting, we should reject?
+          // The cancellablePromise utility wraps this, so the underlying promise doesn't STRICTLY need to handle abort,
+          // but it's good practice.
+        }
+      )
+      mockGatt.connect.mockReturnValue(connectPromise)
+
+      const { result } = renderHook(() => useBluetoothHRM())
+
+      // 1. Start the first connection attempt
+      // We do NOT await this, as we want it to be "in-flight"
+      await act(async () => {
+        result.current.connectAndStream().catch(() => {})
+      })
+
+      // 2. Wait for the hook to update state to "Connecting"
+      await waitFor(() => {
+        expect(result.current.deviceStatus).toMatch(/connecting/i)
+      })
+
+      // 3. Start the second connection attempt
+      // Ensure the silent connect finds a device so it proceeds to connectToGatt
+      jest.spyOn(cookieUtils, 'getCookie').mockReturnValue('test-device-id')
+      mockBluetooth.getDevices.mockResolvedValue([mockDevice])
+
+      await act(async () => {
+        // This should trigger the abort of the first one
+        result.current
+          .connectAndStream(undefined, undefined, { silent: true })
+          .catch(() => {})
+      })
+
+      // 4. Verify abort was called
+      // We expect it to be called once (cancelling the FIRST connection)
+      expect(mockAbort).toHaveBeenCalledTimes(1)
+
+      // Cleanup: Resolve the pending promise to let the test finish gracefully
+      await act(async () => {
+        connectResolver(mockGatt)
+      })
+    } finally {
+      // Restore original AbortController
+      global.AbortController = OriginalAbortController
+      if (typeof window !== 'undefined') {
+        window.AbortController =
+          OriginalAbortController as unknown as typeof AbortController
       }
-    )
-    mockGatt.connect.mockReturnValue(connectPromise)
-
-    const { result } = renderHook(() => useBluetoothHRM())
-
-    // 1. Start the first connection attempt
-    // We do NOT await this, as we want it to be "in-flight"
-    await act(async () => {
-      result.current.connectAndStream().catch(() => {})
-    })
-
-    // 2. Wait for the hook to update state to "Connecting"
-    await waitFor(() => {
-      expect(result.current.deviceStatus).toMatch(/connecting/i)
-    })
-
-    // 3. Start the second connection attempt
-    // Ensure the silent connect finds a device so it proceeds to connectToGatt
-    jest.spyOn(cookieUtils, 'getCookie').mockReturnValue('test-device-id')
-    mockBluetooth.getDevices.mockResolvedValue([mockDevice])
-
-    await act(async () => {
-      // This should trigger the abort of the first one
-      result.current
-        .connectAndStream(undefined, undefined, { silent: true })
-        .catch(() => {})
-    })
-
-    // 4. Verify abort was called
-    // We expect it to be called once (cancelling the FIRST connection)
-    expect(mockAbort).toHaveBeenCalledTimes(1)
-
-    // Cleanup: Resolve the pending promise to let the test finish gracefully
-    await act(async () => {
-      connectResolver(mockGatt)
-    })
-
-    // Restore original AbortController
-    global.AbortController = OriginalAbortController
+    }
   })
 
   describe('Signal Quality Calculation', () => {


### PR DESCRIPTION
## Description

This PR addresses critical issues identified in the HRM logic. It fixes a build-breaking duplicate import in `useWorkoutSessionManager.ts`. It also improves the reliability of the unit test suite by ensuring the global `AbortController` is properly restored after mocking in `useBluetoothHRM.test.ts`. Finally, it enhances the robustness of the Bluetooth connection logic by explicitly removing the disconnection event listener before adding a new one, preventing potential duplicate listeners.

Fixes # 

## Change Type: 🐛 Bug fix (non-breaking change fixing an issue)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [x] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [x] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

This PR addresses critical issues identified in the HRM logic. It fixes a build-breaking duplicate import in `useWorkoutSessionManager.ts`. It also improves the reliability of the unit test suite by ensuring the global `AbortController` is properly restored after mocking in `useBluetoothHRM.test.ts`. Finally, it enhances the robustness of the Bluetooth connection logic by explicitly removing the disconnection event listener before adding a new one, preventing potential duplicate listeners.

---
*PR created automatically by Jules for task [8015791021550742698](https://jules.google.com/task/8015791021550742698) started by @arii*
</details>