### PR TITLE
Fix: Empty diff causing Gemini review to skip when last_non_empty_commit is not set

### DIFF
--- a/.github/workflows/gemini-orchestrator.yml
+++ b/.github/workflows/gemini-orchestrator.yml
@@ -94,62 +94,48 @@ jobs:
           git diff --quiet "$MERGE_BASE" HEAD -- .
           HAS_DIFF=$?
 
+          HAS_CHANGES="false"
+          LAST_NON_EMPTY_COMMIT=""
+
           if [ $HAS_DIFF -eq 0 ]; then
-            # No changes found in the entire PR
-            echo "has_changes=false" >> $GITHUB_OUTPUT
-            echo "::notice::No file changes detected between $MERGE_BASE and HEAD"
-
-            # Find the last commit with file changes in the PR
-            for sha in $(git rev-list "$MERGE_BASE"..HEAD 2>/dev/null | head -100); do
-              if git cat-file -e $sha^ &>/dev/null 2>/dev/null; then
-                if ! git diff --quiet $sha^ $sha -- . ; then
-                  echo "last_non_empty_commit=$sha" >> $GITHUB_OUTPUT
-                  break
-                fi
-              fi
-            done
+            HAS_CHANGES="false"
+            echo "::notice::No file changes detected in the PR diff."
           else
-            # Changes found in the PR
-            echo "has_changes=true" >> $GITHUB_OUTPUT
-            echo "::notice::File changes detected between $MERGE_BASE and HEAD"
-
-            # Quick check: Is the HEAD commit itself empty?
-            # If so, find the last non-empty commit efficiently
-            if git diff-tree --quiet --root HEAD 2>/dev/null; then
-              echo "::notice::HEAD commit is empty, finding last non-empty commit"
-
-              # Check recent commits first (fast path, no network needed)
-              FOUND_NON_EMPTY=false
-              for i in {1..10}; do
-                PARENT_SHA=$(git rev-parse HEAD~$i 2>/dev/null)
-                if [ -z "$PARENT_SHA" ]; then
-                  break
-                fi
-                if ! git diff-tree --quiet --root $PARENT_SHA 2>/dev/null; then
-                  echo "last_non_empty_commit=$PARENT_SHA" >> $GITHUB_OUTPUT
-                  echo "::notice::Found last non-empty commit at HEAD~$i: $PARENT_SHA"
-                  FOUND_NON_EMPTY=true
-                  break
-                fi
-              done
-
-              # If not found in recent commits, do a deeper search
-              if [ "$FOUND_NON_EMPTY" = false ]; then
-                for sha in $(git rev-list "$MERGE_BASE"..HEAD 2>/dev/null | head -100); do
-                  if git cat-file -e $sha^ &>/dev/null 2>/dev/null; then
-                    if ! git diff --quiet $sha^ $sha -- . ; then
-                      echo "last_non_empty_commit=$sha" >> $GITHUB_OUTPUT
-                      echo "::notice::Found last non-empty commit in PR: $sha"
-                      break
-                    fi
-                  fi
-                done
-              fi
-            else
-              # HEAD has changes, use it as the last non-empty commit
-              echo "last_non_empty_commit=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-            fi
+            HAS_CHANGES="true"
+            echo "::notice::File changes detected in the PR diff."
           fi
+
+          # Always try to find the last non-empty commit, regardless of HAS_DIFF.
+          # This is crucial for PRs that only contain empty commits.
+          # Search from HEAD backwards.
+          for sha in $(git rev-list --first-parent HEAD --max-count=100); do
+              # Check if the commit has a parent. Root commits are checked differently.
+              if git cat-file -e $sha^ &>/dev/null; then
+                  # Not a root commit, diff against parent
+                  if ! git diff --quiet $sha^ $sha -- .; then
+                      LAST_NON_EMPTY_COMMIT=$sha
+                      echo "::notice::Found last non-empty commit: $sha"
+                      break
+                  fi
+              else
+                  # Root commit, check if it has any files
+                  if [ -n "$(git ls-tree -r --name-only $sha)" ]; then
+                      LAST_NON_EMPTY_COMMIT=$sha
+                      echo "::notice::Found last non-empty commit (root): $sha"
+                      break
+                  fi
+              fi
+          done
+
+
+          # If after all checks, no non-empty commit is found, fallback to HEAD.
+          if [ -z "$LAST_NON_EMPTY_COMMIT" ]; then
+            LAST_NON_EMPTY_COMMIT=$(git rev-parse HEAD)
+            echo "::warning::Could not find a non-empty commit. Falling back to HEAD ($LAST_NON_EMPTY_COMMIT)."
+          fi
+
+          echo "has_changes=$HAS_CHANGES" >> $GITHUB_OUTPUT
+          echo "last_non_empty_commit=$LAST_NON_EMPTY_COMMIT" >> $GITHUB_OUTPUT
 
           exit 0
   # 1. Run CI checks on every push to a PR

--- a/.github/workflows/reusable-gemini-review.yml
+++ b/.github/workflows/reusable-gemini-review.yml
@@ -95,24 +95,48 @@ jobs:
       - name: Setup Environment
         uses: ./.github/actions/setup-env
 
+      - name: Validate Commit SHA
+        id: validate-sha
+        run: |
+          HEAD_SHA=${{ inputs.last_non_empty_commit || github.event.pull_request.head.sha }}
+          echo "HEAD_SHA=$HEAD_SHA" >> $GITHUB_ENV
+
+          if [ -z "$HEAD_SHA" ]; then
+            echo "::error::HEAD_SHA is empty. Cannot proceed."
+            exit 1
+          fi
+
+          # The `git cat-file -e` command returns 0 if the object exists, and 1 otherwise.
+          # We redirect stdout and stderr to /dev/null to suppress output.
+          if git cat-file -e "$HEAD_SHA" >/dev/null 2>&1; then
+            echo "✅ Commit SHA ($HEAD_SHA) is valid and exists in the repository."
+          else
+            echo "::error::Commit SHA ($HEAD_SHA) does not exist in the repository."
+            exit 1
+          fi
+
       - name: Get PR Diff
         id: diff
+        needs: validate-sha
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # The PR's base commit SHA, for an accurate diff at the time of branching.
           BASE_SHA=${{ github.event.pull_request.base.sha }}
-          # The PR's head commit SHA. If a last_non_empty_commit is provided, use that instead.
-          HEAD_SHA=${{ inputs.last_non_empty_commit || github.event.pull_request.head.sha }}
+          # The validated HEAD_SHA from the previous step.
+          HEAD_SHA=${{ env.HEAD_SHA }}
 
           echo "🔍 Generating diff between base commit ($BASE_SHA) and head commit ($HEAD_SHA)..."
 
           # Create a diff between the head and the true merge base.
-          # This ensures that the diff only contains changes from the PR,
-          # avoiding the inclusion of recent changes from the base branch (e.g., 'leader').
           git diff ${BASE_SHA}...${HEAD_SHA} > pr.diff
 
-          echo "✅ Diff generated and saved to pr.diff"
+          # -s checks if the file is empty.
+          if [ ! -s pr.diff ]; then
+            echo "::warning::The generated pr.diff file is empty."
+          else
+            echo "✅ Diff generated and saved to pr.diff"
+          fi
 
       - name: Gather PR Context
         id: context


### PR DESCRIPTION
This change fixes a bug in the Gemini review workflow where reviews were being skipped for pull requests with only empty commits. The `last_non_empty_commit` variable was not being set, resulting in an empty diff that caused the review to be skipped. The fix includes adding a fallback to `HEAD` in `gemini-orchestrator.yml` and adding commit SHA validation in `reusable-gemini-review.yml` to prevent the workflow from failing silently.

Fixes #5820

---
*PR created automatically by Jules for task [14571476393107488594](https://jules.google.com/task/14571476393107488594) started by @arii*