### PR TITLE
ci(small): Fix E2E workflow failures on leader branch checks

### DIFF
--- a/.github/workflows/e2e-ci-tests.yml
+++ b/.github/workflows/e2e-ci-tests.yml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
 
       - name: Create Test Branch and PR
         id: create_pr
@@ -57,7 +58,7 @@ jobs:
           set -e
           git fetch origin $BRANCH_NAME
           git checkout $BRANCH_NAME
-          COMMIT_COUNT=$(git rev-list --count HEAD ^leader)
+          COMMIT_COUNT=$(git rev-list --count HEAD ^origin/leader)
           if [ "$COMMIT_COUNT" -eq 1 ]; then
             echo "✅ Squash successful: Branch has 1 commit."
           else
@@ -180,6 +181,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
 
       - name: Create Test Branch and PR
         id: create_pr
@@ -224,7 +226,7 @@ jobs:
           set -e
           git fetch origin $BRANCH_NAME
           git checkout $BRANCH_NAME
-          COMMIT_COUNT=$(git rev-list --count HEAD ^leader)
+          COMMIT_COUNT=$(git rev-list --count HEAD ^origin/leader)
           if [ "$COMMIT_COUNT" -eq 1 ]; then
             echo "✅ Squash and rebase successful: Branch has 1 commit."
           else
@@ -232,7 +234,7 @@ jobs:
             exit 1
           fi
           # Verify that the branch is rebased on top of leader
-          if git merge-base --is-ancestor leader HEAD; then
+          if git merge-base --is-ancestor origin/leader HEAD; then
             echo "✅ Branch is rebased on top of leader."
           else
             echo "❌ Branch is not rebased on top of leader."


### PR DESCRIPTION
## Description
Fixed E2E CI test failures on the `leader` branch. This change ensures that the E2E workflow fetches the full git history (`fetch-depth: 0`) and correctly uses `origin/leader` for branch verification checks in `.github/workflows/e2e-ci-tests.yml`.

This addresses the problem of E2E tests failing intermittently or incorrectly on the `leader` branch due to insufficient git history for branch comparisons.

Fixes #

## Change Type: 🐛 Bug fix (non-breaking change fixing an issue)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [x] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [ ] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

Fixed E2E CI test failures by ensuring full git history is fetched (`fetch-depth: 0`) and using `origin/leader` for branch verification checks in `.github/workflows/e2e-ci-tests.yml`.

---
*PR created automatically by Jules for task [7531411133180967857](https://jules.google.com/task/7531411133180967857) started by @arii*
</details>