### PR TITLE
ci(small): Fix AI Slop Detector CI failure and improve execution logic

### DIFF
--- a/.github/workflows/reusable-gemini-review.yml
+++ b/.github/workflows/reusable-gemini-review.yml
@@ -149,29 +149,36 @@ jobs:
             BASE_SHA=${{ github.event.pull_request.base.sha }}
             HEAD_SHA=${{ inputs.last_non_empty_commit || github.event.pull_request.head.sha }}
 
-            # Add a check to ensure the git diff command succeeds
-            if ! CHANGED_FILES=$(git diff --name-only -z "${BASE_SHA}...${HEAD_SHA}" 2> /dev/null); then
+            # Create temp files
+            FILE_LIST=$(mktemp)
+            TEMP_OUT=$(mktemp)
+
+            # Generate list of changed files
+            if ! git diff --name-only -z "${BASE_SHA}...${HEAD_SHA}" > "$FILE_LIST" 2>/dev/null; then
               SLOP_REPORT="❌ ERROR: Failed to generate a list of changed files. This can happen in shallow clone environments."
-            elif [ -z "$CHANGED_FILES" ]; then
+            elif [ ! -s "$FILE_LIST" ]; then
               SLOP_REPORT="No analysis performed as no files were changed."
             else
-              # Use a temp file to capture all script output (stdout and stderr).
-              TEMP_OUT=$(mktemp)
-              printf "%s" "$CHANGED_FILES" | xargs -0 "$SCRIPT_PATH" > "$TEMP_OUT" 2>&1
+              # Run script on changed files
+              # xargs -0 will read null-delimited filenames from FILE_LIST and pass them to SCRIPT_PATH
+              # Exit code 123 from xargs means "command failed" (which happens if find_slop.sh exits 1)
+              xargs -0 "$SCRIPT_PATH" < "$FILE_LIST" > "$TEMP_OUT" 2>&1
               EXIT_CODE=$?
 
               if [ $EXIT_CODE -eq 0 ]; then
                 # Exit code 0: Success, no slop found.
                 SLOP_REPORT=$(<"$TEMP_OUT")
-              elif [ $EXIT_CODE -eq 1 ]; then
-                # Exit code 1: Slop was found, which is an expected "failure".
+              elif [ $EXIT_CODE -eq 1 ] || [ $EXIT_CODE -eq 123 ]; then
+                # Exit code 1 or 123: Slop was found, which is an expected "failure".
                 SLOP_REPORT=$(<"$TEMP_OUT")
               else
                 # Any other exit code indicates an unexpected script error.
                 SLOP_REPORT="❌ ERROR: Slop detector script failed with unexpected exit code $EXIT_CODE.\n\n$(<"$TEMP_OUT")"
               fi
-              rm "$TEMP_OUT"
             fi
+
+            # Cleanup
+            rm -f "$FILE_LIST" "$TEMP_OUT"
           fi
 
           # Use a random delimiter to prevent injection attacks

--- a/scripts/find_slop.sh
+++ b/scripts/find_slop.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # Configuration
 WORDLIST="ai_slop_words.txt"
-SEARCH_DIR="."
 EXIT_ON_FAIL=1
 # ANSI Colors
 RED='\033[0;31m'
@@ -14,6 +13,14 @@ if [ ! -f "$WORDLIST" ]; then
 echo -e "${RED}Error: Wordlist file '$WORDLIST' not found.${NC}"
 exit 1
 fi
+
+# Determine search targets
+if [ "$#" -eq 0 ]; then
+    TARGETS=(".")
+else
+    TARGETS=("$@")
+fi
+
 echo -e "${BLUE}========================================================${NC}"
 echo -e "${BLUE}   AI Slop Detection Report                             ${NC}"
 echo -e "${BLUE}   Scanning for low-density, filler content...          ${NC}"
@@ -35,7 +42,7 @@ fi
 # -n: show line number
 # -i: case insensitive
 # Exclude node_modules, .git, and common binary/lock files
-matches=$(grep -rni "$term" "$SEARCH_DIR" \
+matches=$(grep -rni "$term" "${TARGETS[@]}" \
     --exclude-dir={node_modules,.git,.next,dist,build,coverage,.vercel} \
     --exclude={"ai_slop_words.txt","find_slop.sh","*.svg","*.lock","pnpm-lock.yaml","*.png","*.ico","*.json","*.map"} \
 )


### PR DESCRIPTION
## Description

This PR fixes a CI failure in the "Run AI Slop Detector" step of the Gemini Review workflow. The changes improve the robustness and correctness of the slop detection process within the continuous integration environment.

**Motivation and Context:**
Prior to this change, the AI Slop Detector CI step was failing due to several issues:
1.  **Null Byte Warning:** `git diff --name-only -z` output, which can contain null bytes, was being captured into a bash variable. Bash variables cannot contain null bytes, leading to warnings and potential corruption of the file list being passed to the slop detector.
2.  **Exit Code 123 Handling:** The `xargs` command, used to pass files to `find_slop.sh`, returns exit code 123 if the invoked command (`find_slop.sh`) returns a non-zero exit code (specifically 1, indicating slop was found). The workflow was treating exit code 123 as an unexpected error instead of a legitimate "slop found" outcome.
3.  **Targeted Scanning Limitation:** The `find_slop.sh` script was not correctly utilizing arguments and always scanned the current directory, regardless of the specific files passed to it. This made the `git diff` part of the workflow ineffective for targeted scanning.

**Changes implemented to address these issues:**
-   The workflow now uses a temporary file to store the `git diff --name-only -z` output and pipes it to `xargs` directly, avoiding null byte issues with bash variables.
-   The workflow explicitly handles exit code 123 from `xargs` as a success condition, indicating that slop was found as expected.
-   The `scripts/find_slop.sh` script has been updated to correctly accept and process a list of files as arguments (using `"$@"`) or default to scanning the current directory (`.`) if no arguments are provided.

Fixes # (issue)

## Change Type: 🐛 Bug fix (non-breaking change fixing an issue)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [x] **Tests cover the specific change scope:** The CI workflow itself acts as the test for this fix, ensuring the slop detector runs correctly.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [x] **Tests** are added/updated for new functionality (the CI workflow fix constitutes an update to the testing process)
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

This PR fixes a CI failure in the "Run AI Slop Detector" step of the Gemini Review workflow. 

**Issues Addressed:**
1.  **Null Byte Warning:** The workflow was capturing `git diff --name-only -z` output into a bash variable. Since bash variables cannot contain null bytes, this caused a warning and likely corrupted the file list. The fix uses a temporary file to store the diff output and pipes it to `xargs`.
2.  **Exit Code 123:** `xargs` returns exit code 123 if the invoked command returns a non-zero exit code (1-125). The `find_slop.sh` script exits with 1 when slop is found. The workflow was treating exit code 123 as an unexpected error. The fix now explicitly handles 123 as a "slop found" outcome.
3.  **Targeted Scanning:** The `find_slop.sh` script was previously ignoring arguments and always scanning the current directory. It has been updated to accept a list of files (passed by `xargs`) or default to `.` if no arguments are provided.

**Changes:**
- `scripts/find_slop.sh`: Updated to use `"$@"` as search targets if provided.
- `.github/workflows/reusable-gemini-review.yml`: Refactored the slop detector step to use temp files and handle exit code 123.

---
*PR created automatically by Jules for task [1989515254365457634](https://jules.google.com/task/1989515254365457634) started by @arii*
</details>