### PR TITLE
chore(small): Fix Critical Spotify Polling Thrashing Bug

### DIFF
--- a/services/spotifyPolling.ts
+++ b/services/spotifyPolling.ts
@@ -234,8 +234,11 @@ export class SpotifyPolling implements SpotifyService {
 
   private getCurrentlyPlaying = async () => {
     try {
-      const sdk = this.getSdk()
-      const playbackState = await sdk.player.getCurrentlyPlayingTrack()
+      if (!this.sdk) {
+        logger.debug('Spotify SDK not initialized, skipping poll')
+        return
+      }
+      const playbackState = await this.sdk.player.getCurrentlyPlayingTrack()
 
       if (!playbackState || !playbackState.item) {
         // Nothing playing, 204, or private session

--- a/services/spotifyPolling.ts
+++ b/services/spotifyPolling.ts
@@ -42,21 +42,6 @@ export class SpotifyPolling implements SpotifyService {
    * Test-only properties for inspecting internal state, defined only in 'test' env.
    * See docs/TYPESCRIPT_PATTERNS.md for more info on this pattern.
    */
-  public _test_ =
-    process.env.NODE_ENV === 'test'
-      ? {
-          getPollInterval: () => this.pollInterval,
-          getTokenRefreshInterval: () => this.tokenRefreshInterval,
-          setPollInterval: (interval: NodeJS.Timeout | null) => {
-            this.pollInterval = interval
-          },
-          setTokenRefreshInterval: (interval: NodeJS.Timeout | null) => {
-            this.tokenRefreshInterval = interval
-          },
-          isEmptyResponseError: this.isEmptyResponseError.bind(this),
-        }
-      : undefined
-
   private readonly broadcastUpdate: (message: ServerMessage) => void
 
   private lastTrackId: string | null = null
@@ -89,6 +74,106 @@ export class SpotifyPolling implements SpotifyService {
       env.SPOTIFY_CLIENT_SECRET
     )
   }
+
+  private getCurrentlyPlaying = async () => {
+    try {
+      if (!this.sdk) {
+        logger.debug('Spotify SDK not initialized, skipping poll')
+        return
+      }
+      const playbackState = await this.sdk.player.getCurrentlyPlayingTrack()
+
+      if (!playbackState || !playbackState.item) {
+        // Nothing playing, 204, or private session
+        if (this.lastPlaybackState !== false) {
+          this.lastPlaybackState = false
+          this.state = {
+            ...this.state,
+            trackId: null,
+            trackName: 'Nothing is currently playing.',
+            artist: '',
+            albumName: '',
+            albumArtUrl: '',
+            isPlaying: false,
+          }
+          this.broadcastUpdate({
+            type: 'SPOTIFY_UPDATE',
+            payload: this.getState(),
+          })
+        }
+        return
+      }
+
+      const item = playbackState.item
+      const isPlaying = playbackState.is_playing
+
+      // Only broadcast if track ID or playback state has changed
+      if (
+        item.id !== this.lastTrackId ||
+        isPlaying !== this.lastPlaybackState
+      ) {
+        this.lastTrackId = item.id
+        this.lastPlaybackState = isPlaying
+
+        const trackName = item.name
+        const trackId = item.id
+        let artistName = ''
+        let albumName = ''
+        let albumArtUrl = ''
+
+        if (item.type === 'track') {
+          const track = item as Track
+          artistName = track.artists.map((a) => a.name).join(', ')
+          albumName = track.album.name
+          albumArtUrl = track.album.images?.[0]?.url ?? ''
+        } else if (item.type === 'episode') {
+          const episode = item as Episode
+          artistName = episode.show.publisher
+          albumName = episode.show.name
+          albumArtUrl = episode.show.images?.[0]?.url ?? ''
+        }
+
+        this.state = {
+          ...this.state,
+          trackId,
+          trackName,
+          artist: artistName,
+          albumName,
+          albumArtUrl,
+          isPlaying,
+        }
+
+        this.broadcastUpdate({
+          type: 'SPOTIFY_UPDATE',
+          payload: this.getState(),
+        })
+      }
+    } catch (error) {
+      await handleSpotifyApiError(error, () => this.checkAndRefreshSdkToken())
+    }
+  }
+
+  /**
+   * @internal
+   * This is a public property for testing purposes.
+   * It is only defined in a test environment.
+   */
+  public _test_ =
+    process.env.NODE_ENV === 'test'
+      ? {
+          getPollInterval: () => this.pollInterval,
+          getTokenRefreshInterval: () => this.tokenRefreshInterval,
+          setPollInterval: (interval: NodeJS.Timeout | null) => {
+            this.pollInterval = interval
+          },
+          setTokenRefreshInterval: (interval: NodeJS.Timeout | null) => {
+            this.tokenRefreshInterval = interval
+          },
+          isEmptyResponseError: this.isEmptyResponseError.bind(this),
+          getSdk: this.getSdk.bind(this),
+          getCurrentlyPlaying: this.getCurrentlyPlaying.bind(this),
+        }
+      : undefined
 
   public static async create(
     broadcastUpdate: (message: ServerMessage) => void
@@ -229,84 +314,6 @@ export class SpotifyPolling implements SpotifyService {
       clearInterval(this.tokenRefreshInterval)
       this.tokenRefreshInterval = null
       logger.debug('Token refresh interval cleared.')
-    }
-  }
-
-  private getCurrentlyPlaying = async () => {
-    try {
-      if (!this.sdk) {
-        logger.debug('Spotify SDK not initialized, skipping poll')
-        return
-      }
-      const playbackState = await this.sdk.player.getCurrentlyPlayingTrack()
-
-      if (!playbackState || !playbackState.item) {
-        // Nothing playing, 204, or private session
-        if (this.lastPlaybackState !== false) {
-          this.lastPlaybackState = false
-          this.state = {
-            ...this.state,
-            trackId: null,
-            trackName: 'Nothing is currently playing.',
-            artist: '',
-            albumName: '',
-            albumArtUrl: '',
-            isPlaying: false,
-          }
-          this.broadcastUpdate({
-            type: 'SPOTIFY_UPDATE',
-            payload: this.getState(),
-          })
-        }
-        return
-      }
-
-      const item = playbackState.item
-      const isPlaying = playbackState.is_playing
-
-      // Only broadcast if track ID or playback state has changed
-      if (
-        item.id !== this.lastTrackId ||
-        isPlaying !== this.lastPlaybackState
-      ) {
-        this.lastTrackId = item.id
-        this.lastPlaybackState = isPlaying
-
-        const trackName = item.name
-        const trackId = item.id
-        let artistName = ''
-        let albumName = ''
-        let albumArtUrl = ''
-
-        if (item.type === 'track') {
-          const track = item as Track
-          artistName = track.artists.map((a) => a.name).join(', ')
-          albumName = track.album.name
-          albumArtUrl = track.album.images?.[0]?.url ?? ''
-        } else if (item.type === 'episode') {
-          const episode = item as Episode
-          artistName = episode.show.publisher
-          albumName = episode.show.name
-          albumArtUrl = episode.show.images?.[0]?.url ?? ''
-        }
-
-        this.state = {
-          ...this.state,
-          trackId,
-          trackName,
-          artist: artistName,
-          albumName,
-          albumArtUrl,
-          isPlaying,
-        }
-
-        this.broadcastUpdate({
-          type: 'SPOTIFY_UPDATE',
-          payload: this.getState(),
-        })
-      }
-    } catch (error) {
-      await handleSpotifyApiError(error, () => this.checkAndRefreshSdkToken())
     }
   }
 

--- a/tests/unit/services/spotifyPolling.test.ts
+++ b/tests/unit/services/spotifyPolling.test.ts
@@ -14,9 +14,7 @@ describe('SpotifyPolling', () => {
   })
 
   it('should throw an error when getSdk is called before initialization', () => {
-    // Directly accessing a private method for testing purposes.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect(() => (spotifyPolling as any).getSdk()).toThrow(
+    expect(() => spotifyPolling._test_?.getSdk()).toThrow(
       'Spotify SDK has not been initialized.'
     )
   })
@@ -28,8 +26,7 @@ describe('SpotifyPolling', () => {
     // Act & Assert
     // The method should complete without throwing an error because of the guard clause.
     await expect(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (spotifyPolling as any).getCurrentlyPlaying()
+      spotifyPolling._test_?.getCurrentlyPlaying()
     ).resolves.not.toThrow()
 
     // It should have returned early, so no broadcast should have been sent.

--- a/tests/unit/services/spotifyPolling.test.ts
+++ b/tests/unit/services/spotifyPolling.test.ts
@@ -15,8 +15,22 @@ describe('SpotifyPolling', () => {
 
   it('should throw an error when getSdk is called before initialization', () => {
     // Directly accessing a private method for testing purposes.
-    expect(() => (spotifyPolling as { getSdk: () => void }).getSdk()).toThrow(
+    expect(() => (spotifyPolling as any).getSdk()).toThrow(
       'Spotify SDK has not been initialized.'
     )
+  })
+
+  it('should return early and not throw if getCurrentlyPlaying is called without an initialized SDK', async () => {
+    // Arrange: The beforeEach block creates an instance where the SDK is not initialized
+    // because the mocked SpotifyTokenManager doesn't provide a token.
+
+    // Act & Assert
+    // The method should complete without throwing an error because of the guard clause.
+    await expect(
+      (spotifyPolling as any).getCurrentlyPlaying()
+    ).resolves.not.toThrow()
+
+    // It should have returned early, so no broadcast should have been sent.
+    expect(broadcastUpdate).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/services/spotifyPolling.test.ts
+++ b/tests/unit/services/spotifyPolling.test.ts
@@ -15,6 +15,7 @@ describe('SpotifyPolling', () => {
 
   it('should throw an error when getSdk is called before initialization', () => {
     // Directly accessing a private method for testing purposes.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect(() => (spotifyPolling as any).getSdk()).toThrow(
       'Spotify SDK has not been initialized.'
     )
@@ -27,6 +28,7 @@ describe('SpotifyPolling', () => {
     // Act & Assert
     // The method should complete without throwing an error because of the guard clause.
     await expect(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (spotifyPolling as any).getCurrentlyPlaying()
     ).resolves.not.toThrow()
 


### PR DESCRIPTION
## Description

This change fixes a critical bug where the Spotify polling service would cause continuous error thrashing in server logs on devices without valid Spotify authentication. A guard has been added to the `getCurrentlyPlaying` method to prevent the polling from running when the Spotify SDK is not initialized.

Fixes #5979

## Change Type: 🐛 Bug fix (non-breaking change fixing an issue)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [x] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [x] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

This change fixes a critical bug where the Spotify polling service would cause continuous error thrashing in server logs on devices without valid Spotify authentication. A guard has been added to the `getCurrentlyPlaying` method to prevent the polling from running when the Spotify SDK is not initialized.

Fixes #5979

---
*PR created automatically by Jules for task [2962213645427954098](https://jules.google.com/task/2962213645427954098) started by @arii*
</details>