### PR TITLE
feat(medium): Refactor and Test useWorkoutSessionManager

### DIFF
--- a/hooks/useWorkoutSessionManager.ts
+++ b/hooks/useWorkoutSessionManager.ts
@@ -11,7 +11,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { calculateHrZone } from '../lib/hrm/zones'
 import { calculateMaxHr } from '@/lib/shared/hr-zones'
 import { useAppSnackbar } from './useAppSnackbar'
-import { isSameDay } from '../lib/date'
+import { isSessionStale } from '../lib/workout-session'
 
 // --- State, Actions, and Reducer ---
 
@@ -154,12 +154,10 @@ export const useWorkoutSessionManager = () => {
       message: string,
       onStale: (message: string) => void
     ) => {
-      const sessionDate = new Date(session.startTime)
-      const currentDate = new Date()
-
-      if (!isSameDay(sessionDate, currentDate)) {
+      if (isSessionStale(session)) {
+        const sessionDate = new Date(session.startTime)
         console.info(
-          `[SessionManager] Stale session from ${sessionDate.toDateString()} detected. Clearing for new day ${currentDate.toDateString()}.`
+          `[SessionManager] Stale session from ${sessionDate.toDateString()} detected. Clearing for new day ${new Date().toDateString()}.`
         )
         await workoutSessionStorage.deleteSession(session.sessionId)
         onStale(message)

--- a/lib/workout-session.ts
+++ b/lib/workout-session.ts
@@ -1,0 +1,15 @@
+// lib/workout-session.ts
+
+import { isSameDay } from './date'
+import { WorkoutSessionData } from './workout-session-storage'
+
+/**
+ * Checks if a workout session is stale (i.e., from a previous day).
+ * @param session The workout session to check.
+ * @returns True if the session is stale, false otherwise.
+ */
+export const isSessionStale = (session: WorkoutSessionData): boolean => {
+  const sessionDate = new Date(session.startTime)
+  const currentDate = new Date()
+  return !isSameDay(sessionDate, currentDate)
+}

--- a/tests/unit/hooks/useWorkoutSessionManager.test.ts
+++ b/tests/unit/hooks/useWorkoutSessionManager.test.ts
@@ -4,10 +4,19 @@ import { renderHook, act, waitFor } from '@testing-library/react'
 import { useWorkoutSessionManager } from '../../../hooks/useWorkoutSessionManager'
 import { workoutSessionStorage } from '../../../lib/workout-session-storage'
 import { useAppSnackbar } from '../../../hooks/useAppSnackbar'
+import { isSameDay } from '../../../lib/date'
+import { WorkoutSessionData } from '../../../lib/workout-session-storage'
+import { HrZoneName } from '../../../lib/shared/hr-zones'
 
 // Mock dependencies
 jest.mock('../../../lib/workout-session-storage')
 jest.mock('../../../hooks/useAppSnackbar')
+// Mock the entire date utility module
+jest.mock('../../../lib/date', () => ({
+  isSameDay: jest.fn(),
+}))
+
+const mockIsSameDay = isSameDay as jest.Mock
 
 const mockShowInfo = jest.fn()
 const mockGetIncompleteSession =
@@ -15,118 +24,248 @@ const mockGetIncompleteSession =
 const mockDeleteSession = workoutSessionStorage.deleteSession as jest.Mock
 
 describe('useWorkoutSessionManager', () => {
+  let mockDateNow: jest.SpyInstance
+
   beforeEach(() => {
     // Reset mocks before each test
     jest.clearAllMocks()
     ;(useAppSnackbar as jest.Mock).mockReturnValue({ showInfo: mockShowInfo })
+    mockGetIncompleteSession.mockResolvedValue(null) // Default to no incomplete session
+    mockIsSameDay.mockReturnValue(true) // Default to same day
+
+    // Mock Date.now() to control time-based calculations
+    mockDateNow = jest.spyOn(Date, 'now').mockReturnValue(1000000)
   })
 
-  it('should clear an incomplete session from a previous day on startup', async () => {
-    // Arrange
-    const yesterday = new Date()
-    yesterday.setDate(yesterday.getDate() - 1)
-
-    const staleSession = {
-      sessionId: 'stale-session-id',
-      startTime: yesterday.getTime(),
-      status: 'running',
-    }
-
-    mockGetIncompleteSession.mockResolvedValue(staleSession)
-
-    // Act
-    const { result } = renderHook(() => useWorkoutSessionManager())
-
-    await waitFor(() => {
-      expect(result.current.isInitialized).toBe(true)
-    })
-
-    // Assert
-    expect(mockGetIncompleteSession).toHaveBeenCalledTimes(1)
-    expect(mockDeleteSession).toHaveBeenCalledWith('stale-session-id')
-    expect(mockShowInfo).toHaveBeenCalledWith(
-      'New day detected. Your previous session was cleared.'
-    )
-    expect(result.current.session).toBeNull()
-    expect(result.current.isInitialized).toBe(true)
+  afterEach(() => {
+    mockDateNow.mockRestore()
   })
 
-  it('should not clear a session from the same day', async () => {
-    // Arrange
-    const todaySession = {
-      sessionId: 'today-session-id',
-      startTime: new Date().getTime(),
-      status: 'paused',
-    }
+  describe('Session Lifecycle', () => {
+    it('should start, pause, resume, and finish a workout session', async () => {
+      const { result } = renderHook(() => useWorkoutSessionManager())
+      await waitFor(() => expect(result.current.isInitialized).toBe(true))
 
-    mockGetIncompleteSession.mockResolvedValue(todaySession)
+      // Start
+      act(() => {
+        result.current.startWorkout(30, 80)
+      })
+      expect(result.current.status).toBe('running')
+      expect(result.current.session).not.toBeNull()
+      expect(result.current.session?.startTime).toBe(1000000)
+      expect(result.current.session?.status).toBe('running')
 
-    // Act
-    const { result } = renderHook(() => useWorkoutSessionManager())
+      // Pause
+      act(() => {
+        result.current.endWorkout()
+      })
+      expect(result.current.status).toBe('paused')
+      expect(result.current.session?.status).toBe('paused')
+      expect(result.current.session?.endTime).toBeNull()
 
-    await waitFor(() => {
-      expect(result.current.isInitialized).toBe(true)
+      // Resume
+      act(() => {
+        result.current.resumeWorkout()
+      })
+      expect(result.current.status).toBe('running')
+      expect(result.current.session?.status).toBe('running')
+
+      // Pause again before finishing
+      act(() => {
+        result.current.endWorkout()
+      })
+      expect(result.current.status).toBe('paused')
+
+      // Finish
+      mockDateNow.mockReturnValue(1005000) // Advance time
+      act(() => {
+        result.current.endWorkout()
+      })
+      expect(result.current.status).toBe('finished')
+      expect(result.current.session?.status).toBe('finished')
+      expect(result.current.session?.endTime).toBe(1005000)
     })
 
-    // Assert
-    expect(mockDeleteSession).not.toHaveBeenCalled()
-    expect(mockShowInfo).not.toHaveBeenCalled()
-    expect(result.current.session).toEqual(todaySession)
+    it('should reset the workout session and delete it from storage', async () => {
+      const { result } = renderHook(() => useWorkoutSessionManager())
+      await waitFor(() => expect(result.current.isInitialized).toBe(true))
+
+      // Start a session to have something to reset
+      act(() => {
+        result.current.startWorkout(30, 80)
+      })
+      const sessionId = result.current.session?.sessionId
+      expect(sessionId).toBeDefined()
+
+      // Reset
+      await act(async () => {
+        await result.current.resetWorkout()
+      })
+
+      expect(result.current.session).toBeNull()
+      expect(result.current.status).toBe('idle')
+      expect(mockDeleteSession).toHaveBeenCalledWith(sessionId)
+    })
   })
 
-  it('should clear an active session when the day changes on window focus', async () => {
-    // Arrange
-    const todaySession = {
-      sessionId: 'active-session-id',
-      startTime: new Date().getTime(),
-      status: 'running',
-    }
-    mockGetIncompleteSession.mockResolvedValue(todaySession)
+  describe('HR Data and Calculations', () => {
+    it('should add HR data and correctly calculate metrics', async () => {
+      const { result } = renderHook(() => useWorkoutSessionManager())
+      await waitFor(() => expect(result.current.isInitialized).toBe(true))
 
-    const { result } = renderHook(() => useWorkoutSessionManager())
+      act(() => {
+        result.current.startWorkout(35, 75) // maxHr will be calculated as ~185
+      })
 
-    await waitFor(() => {
-      expect(result.current.isInitialized).toBe(true)
+      // Add first data point (HR 120 -> ~65% -> Zone 2 / Fat Burn)
+      act(() => {
+        result.current.addHrData({ time: 1001000, hr: 120 })
+      })
+      expect(result.current.session?.hrHistory.length).toBe(1)
+      expect(result.current.session?.maxHr).toBe(120)
+      expect(result.current.session?.averageHr).toBe(120)
+      expect(result.current.session?.timeInZones[HrZoneName.FatBurn]).toBe(1)
+
+      // Add second data point (HR 150 -> ~81% -> Zone 3 / Cardio)
+      act(() => {
+        result.current.addHrData({ time: 1002000, hr: 150 })
+      })
+      expect(result.current.session?.hrHistory.length).toBe(2)
+      expect(result.current.session?.maxHr).toBe(150)
+      expect(result.current.session?.averageHr).toBe(135)
+      expect(result.current.session?.timeInZones[HrZoneName.FatBurn]).toBe(1)
+      expect(result.current.session?.timeInZones[HrZoneName.Cardio]).toBe(1)
+
+      // Add third data point (HR 100 -> ~54% -> Zone 1 / Warm-up)
+      act(() => {
+        result.current.addHrData({ time: 1004000, hr: 100 })
+      })
+      expect(result.current.session?.hrHistory.length).toBe(3)
+      expect(result.current.session?.maxHr).toBe(150)
+      expect(result.current.session?.averageHr).toBeCloseTo(123.33)
+      expect(result.current.session?.timeInZones[HrZoneName.Cardio]).toBe(1)
+      expect(result.current.session?.timeInZones[HrZoneName.WarmUp]).toBe(2)
     })
 
-    expect(result.current.session).not.toBeNull()
+    it('should not add HR data if the session is not running', async () => {
+      const { result } = renderHook(() => useWorkoutSessionManager())
+      await waitFor(() => expect(result.current.isInitialized).toBe(true))
 
-    // --- Time Travel: Simulate the date changing ---
-    const realDate = global.Date
-    const tomorrow = new realDate()
-    tomorrow.setDate(tomorrow.getDate() + 1)
+      act(() => {
+        result.current.startWorkout(30, 80)
+      })
 
-    global.Date = class extends realDate {
-      constructor(dateString?: string | number | Date) {
-        // If a date string is provided, use the original constructor
-        if (dateString) {
-          super(dateString)
-        } else {
-          // Otherwise, return 'tomorrow'
-          super(tomorrow)
-        }
+      // Pause the session
+      act(() => {
+        result.current.endWorkout()
+      })
+      expect(result.current.status).toBe('paused')
+
+      // Attempt to add data
+      act(() => {
+        result.current.addHrData({ time: 1001000, hr: 130 })
+      })
+
+      // Assert no changes
+      expect(result.current.session?.hrHistory.length).toBe(0)
+      expect(result.current.session?.maxHr).toBe(0)
+      expect(result.current.session?.averageHr).toBe(0)
+    })
+  })
+
+  describe('Stale Session Handling', () => {
+    it('should clear an incomplete session from a previous day on startup', async () => {
+      // Arrange
+      const staleSession: WorkoutSessionData = {
+        sessionId: 'stale-session-id',
+        startTime: 900000, // A time in the past
+        status: 'running',
+        hrHistory: [],
+        timeInZones: {} as Record<HrZoneName, number>,
+        averageHr: 0,
+        maxHr: 0,
+        calorieHistory: [],
+        totalCaloriesBurned: 0,
+        userSettings: { age: 30, weight: 80, maxHr: 190 },
+        lastSyncTime: 900000,
+        syncStatus: 'pending',
+        endTime: null,
       }
+      mockGetIncompleteSession.mockResolvedValue(staleSession)
+      mockIsSameDay.mockReturnValue(false) // Mock as a different day
 
-      static now() {
-        return tomorrow.getTime()
+      // Act
+      const { result } = renderHook(() => useWorkoutSessionManager())
+
+      await waitFor(() => {
+        expect(result.current.isInitialized).toBe(true)
+      })
+
+      // Assert
+      expect(mockIsSameDay).toHaveBeenCalled()
+      expect(mockDeleteSession).toHaveBeenCalledWith('stale-session-id')
+      expect(mockShowInfo).toHaveBeenCalledWith(
+        'New day detected. Your previous session was cleared.'
+      )
+      expect(result.current.session).toBeNull()
+    })
+
+    it('should not clear a session from the same day on startup', async () => {
+      // Arrange
+      const todaySession: Partial<WorkoutSessionData> = {
+        sessionId: 'today-session-id',
+        startTime: 1000000,
+        status: 'paused',
       }
-    } as jest.MockedClass<typeof Date>
+      mockGetIncompleteSession.mockResolvedValue(todaySession)
+      mockIsSameDay.mockReturnValue(true) // Mock as the same day
 
-    // Act
-    act(() => {
-      // Manually trigger the focus event
-      window.dispatchEvent(new Event('focus'))
+      // Act
+      const { result } = renderHook(() => useWorkoutSessionManager())
+
+      await waitFor(() => {
+        expect(result.current.isInitialized).toBe(true)
+      })
+
+      // Assert
+      expect(mockDeleteSession).not.toHaveBeenCalled()
+      expect(mockShowInfo).not.toHaveBeenCalled()
+      expect(result.current.session).toEqual(todaySession)
     })
 
-    // Assert
-    await waitFor(() => {
-      expect(mockDeleteSession).toHaveBeenCalledWith('active-session-id')
-    })
-    expect(mockShowInfo).toHaveBeenCalledWith(
-      'New day detected. A fresh workout session has started.'
-    )
+    it('should clear an active session when the day changes on window focus', async () => {
+      // Arrange
+      const todaySession: Partial<WorkoutSessionData> = {
+        sessionId: 'active-session-id',
+        startTime: 1000000,
+        status: 'running',
+      }
+      mockGetIncompleteSession.mockResolvedValue(todaySession)
+      mockIsSameDay.mockReturnValue(true) // Initially, it's the same day
 
-    // Restore Date mock
-    global.Date = realDate
+      const { result } = renderHook(() => useWorkoutSessionManager())
+
+      await waitFor(() => {
+        expect(result.current.isInitialized).toBe(true)
+      })
+
+      expect(result.current.session).not.toBeNull()
+
+      // --- Simulate the date changing ---
+      mockIsSameDay.mockReturnValue(false) // Now, it's a different day
+
+      // Act
+      act(() => {
+        window.dispatchEvent(new Event('focus'))
+      })
+
+      // Assert
+      await waitFor(() => {
+        expect(mockDeleteSession).toHaveBeenCalledWith('active-session-id')
+      })
+      expect(mockShowInfo).toHaveBeenCalledWith(
+        'New day detected. A fresh workout session has started.'
+      )
+    })
   })
 })

--- a/tests/unit/lib/workout-session.test.ts
+++ b/tests/unit/lib/workout-session.test.ts
@@ -1,0 +1,49 @@
+// tests/unit/lib/workout-session.test.ts
+import { isSessionStale } from '../../../lib/workout-session'
+import { WorkoutSessionData } from '../../../lib/workout-session-storage'
+import { HrZoneName } from '../../../lib/shared/hr-zones'
+
+describe('isSessionStale', () => {
+  it('should return true for a session from a previous day', () => {
+    const yesterday = new Date()
+    yesterday.setDate(yesterday.getDate() - 1)
+
+    const staleSession: WorkoutSessionData = {
+      sessionId: 'stale-session-id',
+      startTime: yesterday.getTime(),
+      status: 'running',
+      hrHistory: [],
+      timeInZones: {} as Record<HrZoneName, number>,
+      averageHr: 0,
+      maxHr: 0,
+      calorieHistory: [],
+      totalCaloriesBurned: 0,
+      userSettings: { age: 30, weight: 80, maxHr: 190 },
+      lastSyncTime: yesterday.getTime(),
+      syncStatus: 'pending',
+      endTime: null,
+    }
+
+    expect(isSessionStale(staleSession)).toBe(true)
+  })
+
+  it('should return false for a session from the same day', () => {
+    const todaySession: WorkoutSessionData = {
+      sessionId: 'today-session-id',
+      startTime: new Date().getTime(),
+      status: 'paused',
+      hrHistory: [],
+      timeInZones: {} as Record<HrZoneName, number>,
+      averageHr: 0,
+      maxHr: 0,
+      calorieHistory: [],
+      totalCaloriesBurned: 0,
+      userSettings: { age: 30, weight: 80, maxHr: 190 },
+      lastSyncTime: new Date().getTime(),
+      syncStatus: 'pending',
+      endTime: null,
+    }
+
+    expect(isSessionStale(todaySession)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Description

This PR refactors the `useWorkoutSessionManager` hook to improve code organization and significantly enhances the unit test coverage. The stale session clearing logic has been extracted into a new utility function, and the unit tests have been expanded to cover the entire component lifecycle and all calculations.

No specific dependencies are required for this change.

Fixes #6065

## Change Type: 🏗️ Refactoring (code change that neither fixes bug nor adds feature)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [x] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [x] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

This PR refactors the `useWorkoutSessionManager` hook to improve code organization and significantly enhances the unit test coverage. The stale session clearing logic has been extracted into a new utility function, and the unit tests have been expanded to cover the entire component lifecycle and all calculations.

Fixes #6065

---
*PR created automatically by Jules for task [487223670660116348](https://jules.google.com/task/487223670660116348) started by @arii*
</details>