### PR TITLE
ci(small): Fix Gemini Client JSON Schema Validation for 'labels' Field

### DIFF
--- a/scripts/gemini-client.test.ts
+++ b/scripts/gemini-client.test.ts
@@ -1,4 +1,49 @@
-import { cleanJsonOutput } from './gemini-client'
+import { cleanJsonOutput, JsonProcessor } from './gemini-client'
+
+describe('JsonProcessor', () => {
+  let processor: JsonProcessor
+
+  beforeEach(() => {
+    processor = new JsonProcessor()
+  })
+
+  it('should parse valid JSON and ensure labels field exists', () => {
+    const input = '{"reviewComment": "Looks good"}'
+    const result = processor.process(input)
+    expect(result.success).toBe(true)
+    expect(result.data).toEqual({
+      reviewComment: 'Looks good',
+      labels: [],
+    })
+  })
+
+  it('should not overwrite existing labels field', () => {
+    const input = '{"reviewComment": "Needs work", "labels": ["bug"]}'
+    const result = processor.process(input)
+    expect(result.success).toBe(true)
+    expect(result.data).toEqual({
+      reviewComment: 'Needs work',
+      labels: ['bug'],
+    })
+  })
+
+  it('should handle JSON within a markdown block', () => {
+    const input = '```json\n{"reviewComment": "Great job!"}\n```'
+    const result = processor.process(input)
+    expect(result.success).toBe(true)
+    expect(result.data).toEqual({
+      reviewComment: 'Great job!',
+      labels: [],
+    })
+  })
+
+  it('should return an error for invalid JSON', () => {
+    const input = '{"reviewComment": "Missing quote}'
+    const result = processor.process(input)
+    expect(result.success).toBe(false)
+    expect(result.data).toHaveProperty('error')
+  })
+})
 
 describe('cleanJsonOutput', () => {
   it('should remove markdown code blocks with "json" identifier', () => {

--- a/scripts/gemini-client.ts
+++ b/scripts/gemini-client.ts
@@ -115,15 +115,31 @@ export class JsonProcessor {
     success: boolean
     data: unknown
   } {
+    // Helper function to ensure the parsed JSON object has a 'labels' field.
+    const ensureLabels = (data: unknown) => {
+      // The `labels` field is only relevant for objects, not arrays or primitives.
+      if (typeof data === 'object' && data !== null && !Array.isArray(data)) {
+        // Use 'in' operator for a safe property check.
+        if (!('labels' in data)) {
+          // If 'labels' is missing, add it as an empty array.
+          // We use type assertion here to modify the object.
+          ;(data as { labels?: string[] }).labels = []
+        }
+      }
+      return data
+    }
+
     try {
       // First, try parsing the text directly.
-      return { success: true, data: JSON.parse(text) }
+      const parsedData = JSON.parse(text)
+      return { success: true, data: ensureLabels(parsedData) }
     } catch {
       // If direct parsing fails, try to extract JSON from a markdown code block.
       const jsonBlock = this.extractJsonBlock(text)
       if (jsonBlock) {
         try {
-          return { success: true, data: JSON.parse(jsonBlock) }
+          const parsedData = JSON.parse(jsonBlock)
+          return { success: true, data: ensureLabels(parsedData) }
         } catch (e) {
           console.error('Error parsing JSON block:', e)
           // If parsing the extracted block fails, return a structured error.

--- a/tests/unit/gemini-client.test.ts
+++ b/tests/unit/gemini-client.test.ts
@@ -10,7 +10,7 @@ describe('JsonProcessor', () => {
     const jsonString = '{"key": "value", "number": 123}'
     const result = processor.process(jsonString)
     expect(result.success).toBe(true)
-    expect(result.data).toEqual({ key: 'value', number: 123 })
+    expect(result.data).toEqual({ key: 'value', number: 123, labels: [] })
   })
 
   it('should extract and parse a JSON block from markdown', () => {
@@ -18,7 +18,7 @@ describe('JsonProcessor', () => {
       'Some text before\n```json\n{"key": "value"}\n```\nSome text after'
     const result = processor.process(markdownString)
     expect(result.success).toBe(true)
-    expect(result.data).toEqual({ key: 'value' })
+    expect(result.data).toEqual({ key: 'value', labels: [] })
   })
 
   it('should return an error for invalid JSON', () => {


### PR DESCRIPTION
## Description

This change fixes a bug where the Gemini client's JSON output was missing the required `labels` field, causing downstream schema validation to fail. The `JsonProcessor` class in `scripts/gemini-client.ts` has been updated to ensure the `labels` field is always present in the parsed JSON object. If the field is missing, it is now added with an empty array as its value. Existing unit tests have been updated to reflect this new behavior, and a new, more comprehensive test suite has been added to validate the `JsonProcessor`'s logic thoroughly.

Fixes #6080

## Change Type: 🐛 Bug fix (non-breaking change fixing an issue)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [x] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [x] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

This change fixes a bug where the Gemini client's JSON output was missing the required `labels` field, causing downstream schema validation to fail. The `JsonProcessor` class in `scripts/gemini-client.ts` has been updated to ensure the `labels` field is always present in the parsed JSON object. If the field is missing, it is now added with an empty array as its value. Existing unit tests have been updated to reflect this new behavior, and a new, more comprehensive test suite has been added to validate the `JsonProcessor`'s logic thoroughly.

Fixes #6080

---
*PR created automatically by Jules for task [8682674393866789128](https://jules.google.com/task/8682674393866789128) started by @arii*
</details>