### PR TITLE
test(small): Fix lint, build, and test errors

### DIFF
--- a/hooks/useBluetoothHRM.ts
+++ b/hooks/useBluetoothHRM.ts
@@ -280,8 +280,7 @@ const useBluetoothHRM = (props: UseBluetoothHRMProps = {}) => {
 
       reconnectAttempts.current++
       // Exponential backoff, capped at maxReconnectDelayMs
-      const exponentialDelay =
-        Math.pow(2, reconnectAttempts.current - 1) * 1000 // 1s, 2s, 4s, 8s...
+      const exponentialDelay = Math.pow(2, reconnectAttempts.current - 1) * 1000 // 1s, 2s, 4s, 8s...
       const delay = Math.min(exponentialDelay, maxReconnectDelayMs)
       logger.info(
         {

--- a/tests/unit/app/client/control/__snapshots__/ControlPanel.test.tsx.snap
+++ b/tests/unit/app/client/control/__snapshots__/ControlPanel.test.tsx.snap
@@ -82,7 +82,7 @@ exports[`ControlPanel Component should match snapshot 1`] = `
               Stopwatch
             </button>
             <div
-              style="position: absolute; top: 4px; left: calc(50% - 4px); width: calc(50% - 4px); height: calc(100% - 8px); background: linear-gradient(135deg, #d32f2f 0%, #c62828 100%); z-index: 0; border-radius: 20px;"
+              style="position: absolute; top: 4px; left: calc(50% - 4px); width: calc(50% - 4px); height: calc(100% - 8px); background: linear-gradient(135deg, #d32f2f 0%, #c62828 100%); z-index: 0; border-radius: 20px; opacity: 1;"
             />
           </div>
         </div>

--- a/tests/unit/hooks/useBluetoothHRM.test.ts
+++ b/tests/unit/hooks/useBluetoothHRM.test.ts
@@ -448,7 +448,6 @@ describe('useBluetoothHRM', () => {
   })
 
   describe('Watchdog and Reconnection', () => {
-    const WATCHDOG_INTERVAL_MS = HEARTBEAT_INTERVAL_MS * 2 // Watchdog runs every 2nd heartbeat
     let onDisconnectedCallback: () => void = () => {}
     let setTimeoutSpy: jest.SpyInstance
 


### PR DESCRIPTION
## Description

This PR fixes the current linting and testing errors in the codebase.

It addresses:
1. A formatting issue in `hooks/useBluetoothHRM.ts`.
2. An unused variable warning in `tests/unit/hooks/useBluetoothHRM.test.ts`.
3. A snapshot mismatch in `tests/unit/app/client/control/ControlPanel.test.tsx`.

Verified with `pnpm run lint`, `pnpm run build`, and `pnpm run test:unit`.

Fixes #

## Change Type: 🐛 Bug fix (non-breaking change fixing an issue)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [x] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [x] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

This PR fixes the current linting and testing errors in the codebase.
It addresses:
1. A formatting issue in `hooks/useBluetoothHRM.ts`.
2. An unused variable warning in `tests/unit/hooks/useBluetoothHRM.test.ts`.
3. A snapshot mismatch in `tests/unit/app/client/control/ControlPanel.test.tsx`.

Verified with `pnpm run lint`, `pnpm run build`, and `pnpm run test:unit`.

---
*PR created automatically by Jules for task [4645856584634200261](https://jules.google.com/task/4645856584634200261) started by @arii*
</details>