### PR TITLE
feat(medium): Fix stale HR tiles visible on dashboard

### DIFF
--- a/components/HrTileWrapper.tsx
+++ b/components/HrTileWrapper.tsx
@@ -16,7 +16,7 @@ const HrTileWrapper = ({ user }: HrTileWrapperProps) => {
       bpm={user.value}
       percentMax={hrZoneProps.percentage}
       calories={user.calories}
-      isConnected={user.value !== null}
+      isConnected={user.isConnected}
       isAlerting={user.isAlerting}
       {...(user.alertMessage && { alertMessage: user.alertMessage })}
     />

--- a/components/HrTileWrapper.tsx
+++ b/components/HrTileWrapper.tsx
@@ -2,7 +2,7 @@
 'use client'
 import { useHrZone } from '@/hooks/useHrZone'
 import HrTile from '@/components/HrTile'
-import { HrmData } from '@/types/websocket'
+import { HrmData } from '@/context/WebSocketContext'
 
 interface HrTileWrapperProps {
   user: HrmData & { isAlerting: boolean; alertMessage?: string }

--- a/components/HrmConnectionPanel.tsx
+++ b/components/HrmConnectionPanel.tsx
@@ -11,12 +11,13 @@ const HrmConnectionPanel = () => {
   const { hrmData, connectionStatus, activeAlerts } = useWebSocket()
 
   const tileData = useMemo(() => {
-    // Filter out users with placeholder names or no identity
+    // Filter out users with placeholder names, no identity, or 0 BPM
     return hrmData
       .filter((user) => {
+        const isZero = user.value === 0
         const isPlaceholderName = !!user.name && /new user/i.test(user.name)
         const hasNoIdentity = user.name == null
-        return !(isPlaceholderName || hasNoIdentity)
+        return !(isZero || isPlaceholderName || hasNoIdentity)
       })
       .map((user) => {
         const matchingAlert = activeAlerts.find(

--- a/components/HrmTiles.tsx
+++ b/components/HrmTiles.tsx
@@ -43,6 +43,7 @@ const HrmTiles = () => {
               bpm={user.value}
               percentMax={hrZoneProps.percentage}
               calories={user.calories || 0} // Pass calories
+              isConnected={user.isConnected}
               isAlerting={!!matchingAlert}
               // Conditionally add alertMessage to avoid passing `undefined`
               {...(matchingAlert && { alertMessage: matchingAlert.message })}

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -13,7 +13,6 @@ import {
   useMemo,
 } from 'react'
 import { ClientCommandMessage, ServerMessage } from '../types/websocket'
-import { HrmStreamData as ServerHrmData } from '../types/core'
 import { getWebSocketURL } from '../utils/urls'
 
 // Define a type for the test controls to avoid using 'any'
@@ -22,12 +21,8 @@ interface TestControls {
   disconnect: () => void
   connect: () => void
 }
-import { INITIAL_STATE, WebSocketState } from './webSocketReducer'
-
-// Client-side extension of HrmData to include connection status
-export interface HrmData extends ServerHrmData {
-  isConnected: boolean
-}
+import { INITIAL_STATE, WebSocketState, reducer } from './webSocketReducer'
+export type { HrmData } from './webSocketReducer'
 
 export interface WebSocketContextType extends WebSocketState {
   connectionStatus: string
@@ -37,86 +32,6 @@ export interface WebSocketContextType extends WebSocketState {
 }
 
 export const WebSocketContext = createContext<WebSocketContextType | null>(null)
-
-// Unified State Object managed by a reducer
-export const reducer = (
-  state: WebSocketState,
-  message: ServerMessage | { type: 'RESET_STATE' }
-): WebSocketState => {
-  switch (message.type) {
-    case 'RESET_STATE':
-      return INITIAL_STATE
-    case 'INITIAL_STATE': {
-      // When the initial state is loaded, all users present in the hrmData have their
-      // connection status explicitly set to true. This ensures that the UI correctly
-      // reflects their status.
-      const hrmDataWithConnection =
-        message.payload.hrmData?.map((d) => ({ ...d, isConnected: true })) || []
-      return {
-        ...state,
-        ...message.payload,
-        hrmData: hrmDataWithConnection,
-      }
-    }
-    case 'HRM_UPDATE': {
-      const payload = message.payload as ServerHrmData[]
-      // Create a new state array by merging existing and new data
-      // The previous logic used a Set of incoming client IDs to determine who was connected,
-      // but this was flawed. By using the payload as the single source of truth, we ensure
-      // that only users who are actively sending data are marked as connected.
-      const mergedHrmData = state.hrmData.map((existingUser) => {
-        const updatedUser = payload.find(
-          (newUser) => newUser.clientId === existingUser.clientId
-        )
-        if (updatedUser) {
-          // CRITICAL FIX: The order of spread operators is essential.
-          // By spreading existingUser first, then updatedUser, we ensure
-          // that any fields NOT present in the (potentially partial) `updatedUser`
-          // payload are preserved from the existing state.
-          return {
-            ...existingUser,
-            ...updatedUser,
-            isConnected: true,
-          }
-        }
-        return { ...existingUser, isConnected: false }
-      })
-
-      // Add any brand-new users from the payload who were not in the previous state
-      payload.forEach((newUser) => {
-        if (
-          !state.hrmData.some(
-            (existingUser) => existingUser.clientId === newUser.clientId
-          )
-        ) {
-          mergedHrmData.push({ ...newUser, isConnected: true })
-        }
-      })
-
-      return { ...state, hrmData: mergedHrmData }
-    }
-    case 'TIMER_UPDATE':
-      return {
-        ...state,
-        timerData: { ...state.timerData, ...message.payload },
-      }
-    case 'SPOTIFY_UPDATE':
-      return {
-        ...state,
-        spotifyData: { ...state.spotifyData, ...message.payload },
-      }
-    case 'ACTIVE_ALERTS_UPDATE':
-      return { ...state, activeAlerts: message.payload }
-    case 'SPOTIFY_SERVICE_INIT_UPDATE':
-      return { ...state, spotifyServiceInitialized: message.payload }
-    case 'EXECUTE_SPOTIFY':
-      // This message type is handled by useSpotifyRemoteExecution hook
-      // We don't need to update state here, just pass it through
-      return state
-    default:
-      return state
-  }
-}
 
 export const WebSocketProvider = ({
   children,

--- a/context/webSocketReducer.ts
+++ b/context/webSocketReducer.ts
@@ -5,6 +5,7 @@ import {
   ActiveAlert,
 } from '../types/websocket'
 import { HrmStreamData as ServerHrmData } from '../types/core'
+import logger from '../utils/logger'
 
 // Client-side extension of HrmData to include connection status
 export interface HrmData extends ServerHrmData {
@@ -57,8 +58,13 @@ export const reducer = (
       return INITIAL_STATE
     case 'INITIAL_STATE': {
       // When the initial state is loaded, ensure all HRM data is marked as connected.
+      const now = Date.now()
       const hrmDataWithConnection =
-        message.payload.hrmData?.map((d) => ({ ...d, isConnected: true })) || []
+        message.payload.hrmData?.map((d) => ({
+          ...d,
+          isConnected: true,
+          lastUpdated: now,
+        })) || []
       return {
         ...state,
         ...message.payload,
@@ -85,7 +91,8 @@ export const reducer = (
               }
             : { ...existingUser, isConnected: true, lastUpdated: now }
         }
-        return existingUser // Keep existing user as is for now
+        // If not in payload, mark as disconnected but keep in state for grace period removal
+        return { ...existingUser, isConnected: false }
       })
 
       // Add new users
@@ -112,6 +119,7 @@ export const reducer = (
     }
     case 'DEVICE_OFFLINE': {
       const { deviceId } = message.payload
+      logger.info({ deviceId }, 'Device going offline, removing from state.')
       return {
         ...state,
         hrmData: state.hrmData.filter((device) => device.clientId !== deviceId),

--- a/tests/unit/context/webSocketReducer.test.ts
+++ b/tests/unit/context/webSocketReducer.test.ts
@@ -85,6 +85,34 @@ describe('webSocketReducer', () => {
       expect(state.timerData.isRunning).toBe(true)
       expect(state.spotifyData.trackName).toBe('Test Track')
     })
+
+    it('should initialize lastUpdated with a recent timestamp for all users', () => {
+      const serverState = {
+        hrmData: [
+          {
+            clientId: '1',
+            userName: 'Test',
+            userAge: 30,
+            maxHr: 190,
+            restingHr: 60,
+            hrm: 120,
+            zone: 'aerobic',
+            calories: 100,
+          },
+        ] as HrmStreamData[],
+        timerData: INITIAL_STATE.timerData,
+        spotifyData: INITIAL_STATE.spotifyData,
+      }
+
+      const action: ServerMessage = {
+        type: 'INITIAL_STATE',
+        payload: serverState,
+      }
+      const state = reducer(INITIAL_STATE, action)
+
+      expect(state.hrmData[0].lastUpdated).toBeDefined()
+      expect(state.hrmData[0].lastUpdated).toBeGreaterThan(Date.now() - 5000)
+    })
   })
 
   describe('HRM_UPDATE action', () => {
@@ -119,7 +147,7 @@ describe('webSocketReducer', () => {
       expect(state.hrmData[0].lastUpdated).not.toBe(12345)
     })
 
-    it('should remove users that have not been updated in the last 3 minutes', () => {
+    it('should remove users that have not been updated in the last 35 seconds', () => {
       const now = Date.now()
       const staleUser = {
         ...baseUser,
@@ -130,7 +158,7 @@ describe('webSocketReducer', () => {
         ...INITIAL_STATE,
         hrmData: [
           { ...baseUser, isConnected: true, lastUpdated: now },
-          { ...staleUser, isConnected: true, lastUpdated: now - 180001 },
+          { ...staleUser, isConnected: true, lastUpdated: now - 35001 },
         ],
       }
       const action: ServerMessage = {


### PR DESCRIPTION
## Description

Fixed stale HR tiles remaining on dashboard by unifying WebSocket reducer logic, adding missing DEVICE_OFFLINE handling, and improving UI filtering for 0 BPM values.
The motivation for this change is to ensure that the dashboard accurately reflects real-time heart rate data, preventing misleading or incorrect information from being displayed to the user. This improves the overall reliability and user experience of the HR tile feature.

Fixes #6579

## Change Type: 🐛 Bug fix (non-breaking change fixing an issue)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [x] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [x] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

Fixed stale HR tiles remaining on dashboard by unifying WebSocket reducer logic, adding missing DEVICE_OFFLINE handling, and improving UI filtering for 0 BPM values.

Fixes #6579

---
*PR created automatically by Jules for task [7904977666330536094](https://jules.google.com/task/7904977666330536094) started by @arii*
</details>