### PR TITLE
test(medium): Fix Stale HRM Tiles and Refactor WebSocket Reducer

### DIFF
--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -13,7 +13,6 @@ import {
   useMemo,
 } from 'react'
 import { ClientCommandMessage, ServerMessage } from '../types/websocket'
-import { HrmStreamData as ServerHrmData } from '../types/core'
 import { getWebSocketURL } from '../utils/urls'
 
 // Define a type for the test controls to avoid using 'any'
@@ -22,12 +21,14 @@ interface TestControls {
   disconnect: () => void
   connect: () => void
 }
-import { INITIAL_STATE, WebSocketState } from './webSocketReducer'
+import {
+  INITIAL_STATE,
+  WebSocketState,
+  reducer,
+  HrmData,
+} from './webSocketReducer'
 
-// Client-side extension of HrmData to include connection status
-export interface HrmData extends ServerHrmData {
-  isConnected: boolean
-}
+export type { HrmData }
 
 export interface WebSocketContextType extends WebSocketState {
   connectionStatus: string
@@ -37,86 +38,6 @@ export interface WebSocketContextType extends WebSocketState {
 }
 
 export const WebSocketContext = createContext<WebSocketContextType | null>(null)
-
-// Unified State Object managed by a reducer
-export const reducer = (
-  state: WebSocketState,
-  message: ServerMessage | { type: 'RESET_STATE' }
-): WebSocketState => {
-  switch (message.type) {
-    case 'RESET_STATE':
-      return INITIAL_STATE
-    case 'INITIAL_STATE': {
-      // When the initial state is loaded, all users present in the hrmData have their
-      // connection status explicitly set to true. This ensures that the UI correctly
-      // reflects their status.
-      const hrmDataWithConnection =
-        message.payload.hrmData?.map((d) => ({ ...d, isConnected: true })) || []
-      return {
-        ...state,
-        ...message.payload,
-        hrmData: hrmDataWithConnection,
-      }
-    }
-    case 'HRM_UPDATE': {
-      const payload = message.payload as ServerHrmData[]
-      // Create a new state array by merging existing and new data
-      // The previous logic used a Set of incoming client IDs to determine who was connected,
-      // but this was flawed. By using the payload as the single source of truth, we ensure
-      // that only users who are actively sending data are marked as connected.
-      const mergedHrmData = state.hrmData.map((existingUser) => {
-        const updatedUser = payload.find(
-          (newUser) => newUser.clientId === existingUser.clientId
-        )
-        if (updatedUser) {
-          // CRITICAL FIX: The order of spread operators is essential.
-          // By spreading existingUser first, then updatedUser, we ensure
-          // that any fields NOT present in the (potentially partial) `updatedUser`
-          // payload are preserved from the existing state.
-          return {
-            ...existingUser,
-            ...updatedUser,
-            isConnected: true,
-          }
-        }
-        return { ...existingUser, isConnected: false }
-      })
-
-      // Add any brand-new users from the payload who were not in the previous state
-      payload.forEach((newUser) => {
-        if (
-          !state.hrmData.some(
-            (existingUser) => existingUser.clientId === newUser.clientId
-          )
-        ) {
-          mergedHrmData.push({ ...newUser, isConnected: true })
-        }
-      })
-
-      return { ...state, hrmData: mergedHrmData }
-    }
-    case 'TIMER_UPDATE':
-      return {
-        ...state,
-        timerData: { ...state.timerData, ...message.payload },
-      }
-    case 'SPOTIFY_UPDATE':
-      return {
-        ...state,
-        spotifyData: { ...state.spotifyData, ...message.payload },
-      }
-    case 'ACTIVE_ALERTS_UPDATE':
-      return { ...state, activeAlerts: message.payload }
-    case 'SPOTIFY_SERVICE_INIT_UPDATE':
-      return { ...state, spotifyServiceInitialized: message.payload }
-    case 'EXECUTE_SPOTIFY':
-      // This message type is handled by useSpotifyRemoteExecution hook
-      // We don't need to update state here, just pass it through
-      return state
-    default:
-      return state
-  }
-}
 
 export const WebSocketProvider = ({
   children,
@@ -193,7 +114,10 @@ export const WebSocketProvider = ({
         pendingActions.current = JSON.parse(savedActions)
       }
 
-      if (process.env.NODE_ENV !== 'production') {
+      if (
+        process.env.NODE_ENV !== 'production' ||
+        process.env.NEXT_PUBLIC_TESTING === 'true'
+      ) {
         ;(
           window as Window & { __TEST_CONTROLS__?: TestControls }
         ).__TEST_CONTROLS__ = {

--- a/context/webSocketReducer.ts
+++ b/context/webSocketReducer.ts
@@ -70,25 +70,26 @@ export const reducer = (
       const payload = message.payload as ServerHrmData[]
       const incomingClients = new Set(payload.map((user) => user.clientId))
 
-      // Merge and update existing users
-      const mergedHrmData = state.hrmData.map((existingUser) => {
-        if (incomingClients.has(existingUser.clientId)) {
-          const updatedUser = payload.find(
-            (newUser) => newUser.clientId === existingUser.clientId
-          )
-          return updatedUser
-            ? {
-                ...existingUser,
-                ...updatedUser,
-                isConnected: true,
-                lastUpdated: now,
-              }
-            : { ...existingUser, isConnected: true, lastUpdated: now }
+      // THE FIX: Immediately filter out any devices that are NOT in the incoming payload.
+      // This ensures the client state perfectly mirrors the server's HrmDataStore.
+      const activeHrmData = state.hrmData.filter((existing) =>
+        incomingClients.has(existing.clientId)
+      )
+
+      // Update existing users with new data
+      const mergedHrmData = activeHrmData.map((existingUser) => {
+        const updatedUser = payload.find(
+          (newUser) => newUser.clientId === existingUser.clientId
+        )
+        return {
+          ...existingUser,
+          ...updatedUser,
+          isConnected: true,
+          lastUpdated: now,
         }
-        return existingUser // Keep existing user as is for now
       })
 
-      // Add new users
+      // Add brand-new users from the payload
       payload.forEach((newUser) => {
         if (
           !mergedHrmData.some(
@@ -103,12 +104,7 @@ export const reducer = (
         }
       })
 
-      // Filter out stale users who haven't updated in 35 seconds
-      const filteredHrmData = mergedHrmData.filter(
-        (user) => now - (user.lastUpdated || 0) < 35000
-      )
-
-      return { ...state, hrmData: filteredHrmData }
+      return { ...state, hrmData: mergedHrmData }
     }
     case 'DEVICE_OFFLINE': {
       const { deviceId } = message.payload

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -140,6 +140,7 @@ export default defineConfig({
     env: {
       PORT: port.toString(),
       TESTING: 'true',
+      NEXT_PUBLIC_TESTING: 'true',
       NEXTAUTH_SECRET: 'a-super-long-and-secure-secret-for-ci-tests',
       NEXTAUTH_URL: baseURL,
       SPOTIFY_CLIENT_ID: 'test_client_id',

--- a/tests/playwright/stale-tile.spec.ts
+++ b/tests/playwright/stale-tile.spec.ts
@@ -1,29 +1,52 @@
 import { test, expect } from '@playwright/test'
+import { ServerMessage } from '../../types/websocket'
 
-test('should remove tile after 35 seconds of inactivity', async ({ page }) => {
-  // Install mock clock
-  await page.clock.install({ time: new Date() })
+test('should remove tile immediately when missing from HRM_UPDATE', async ({
+  page,
+}) => {
+  await page.goto('/')
 
-  await page.goto('/client/control')
-  // 1. Simulate active data
-  await page.evaluate(() =>
-    (
-      window as unknown as {
-        postMessage: (message: unknown, targetOrigin: string) => void
+  // Helper to dispatch messages to the reducer
+  const dispatch = async (message: ServerMessage | { type: 'RESET_STATE' }) => {
+    await page.evaluate((msg) => {
+      const win = window as unknown as {
+        __TEST_CONTROLS__: {
+          dispatch: (m: unknown) => void
+        }
       }
-    ).postMessage(
+      const controls = win.__TEST_CONTROLS__
+      if (controls && typeof controls.dispatch === 'function') {
+        controls.dispatch(msg)
+      } else {
+        throw new Error('__TEST_CONTROLS__.dispatch not found')
+      }
+    }, message)
+  }
+
+  // 1. Simulate active data
+  await dispatch({
+    type: 'HRM_UPDATE',
+    payload: [
       {
-        type: 'HRM_UPDATE',
-        payload: [{ clientId: 'test-1', hrm: 75, userName: 'test-1' }],
+        clientId: 'test-1',
+        value: 75,
+        name: 'test-1',
+        age: 30,
+        maxHr: 190,
+        restingHr: 60,
+        zone: 'warmup',
+        calories: 10,
       },
-      '*'
-    )
-  )
+    ],
+  })
   await expect(page.locator('text=test-1')).toBeVisible()
 
-  // 2. Fast-forward time
-  await page.clock.fastForward(35000)
+  // 2. Send update without the user
+  await dispatch({
+    type: 'HRM_UPDATE',
+    payload: [],
+  })
 
-  // 3. Assert removal
+  // 3. Assert immediate removal
   await expect(page.locator('text=test-1')).not.toBeVisible()
 })

--- a/tests/unit/context/webSocketReducer.test.ts
+++ b/tests/unit/context/webSocketReducer.test.ts
@@ -5,20 +5,22 @@ import {
   reducer,
   INITIAL_STATE,
   WebSocketState,
+  HrmData,
 } from '../../../context/webSocketReducer'
 import { ServerMessage } from '../../../types/websocket'
 import { HrmStreamData } from '../../../types/core'
 
 describe('webSocketReducer', () => {
-  const baseUser: HrmStreamData = {
+  const baseUser: HrmData = {
     clientId: '1',
-    userName: 'User A',
-    userAge: 30,
+    name: 'User A',
+    age: 30,
     maxHr: 190,
     restingHr: 60,
-    hrm: 100,
+    value: 100,
     zone: 'warmup',
     calories: 10,
+    isConnected: true,
   }
 
   it('should return the initial state if no action is matched', () => {
@@ -34,11 +36,11 @@ describe('webSocketReducer', () => {
       hrmData: [
         {
           clientId: '1',
-          userName: 'Test',
-          userAge: 30,
+          name: 'Test',
+          age: 30,
           maxHr: 190,
           restingHr: 60,
-          hrm: 120,
+          value: 120,
           zone: 'aerobic',
           calories: 100,
           isConnected: true,
@@ -56,11 +58,11 @@ describe('webSocketReducer', () => {
         hrmData: [
           {
             clientId: '1',
-            userName: 'Test',
-            userAge: 30,
+            name: 'Test',
+            age: 30,
             maxHr: 190,
             restingHr: 60,
-            hrm: 120,
+            value: 120,
             zone: 'aerobic',
             calories: 100,
           },
@@ -106,31 +108,31 @@ describe('webSocketReducer', () => {
         ...INITIAL_STATE,
         hrmData: [{ ...baseUser, isConnected: true, lastUpdated: 12345 }],
       }
-      const updatedUser = { ...baseUser, hrm: 150, zone: 'aerobic' }
+      const updatedUser = { ...baseUser, value: 150, zone: 'aerobic' }
       const action: ServerMessage = {
         type: 'HRM_UPDATE',
         payload: [updatedUser],
       }
       const state = reducer(initialState, action)
       expect(state.hrmData).toHaveLength(1)
-      expect(state.hrmData[0].hrm).toBe(150)
+      expect(state.hrmData[0].value).toBe(150)
       expect(state.hrmData[0].zone).toBe('aerobic')
       expect(state.hrmData[0].isConnected).toBe(true)
       expect(state.hrmData[0].lastUpdated).not.toBe(12345)
     })
 
-    it('should remove users that have not been updated in the last 3 minutes', () => {
+    it('should remove users that are not in the payload immediately', () => {
       const now = Date.now()
       const staleUser = {
         ...baseUser,
         clientId: '2',
-        userName: 'Stale User',
+        name: 'Stale User',
       }
       const initialState: WebSocketState = {
         ...INITIAL_STATE,
         hrmData: [
           { ...baseUser, isConnected: true, lastUpdated: now },
-          { ...staleUser, isConnected: true, lastUpdated: now - 180001 },
+          { ...staleUser, isConnected: true, lastUpdated: now },
         ],
       }
       const action: ServerMessage = {
@@ -146,7 +148,7 @@ describe('webSocketReducer', () => {
 
   describe('DEVICE_OFFLINE action', () => {
     it('should remove the specified device from the state', () => {
-      const user2 = { ...baseUser, clientId: '2', userName: 'User B' }
+      const user2 = { ...baseUser, clientId: '2', name: 'User B' }
       const initialState: WebSocketState = {
         ...INITIAL_STATE,
         hrmData: [

--- a/utils/websocketUtils.ts
+++ b/utils/websocketUtils.ts
@@ -56,12 +56,17 @@ export const sendWebSocketMessage = (
 export const broadcast = (
   wss: WebSocketServer,
   message: ServerMessage,
-  origin?: string
+  origin?: string,
+  targetRole?: 'dashboard' | 'controller'
 ): void => {
   const messageString = JSON.stringify(message)
   wss.clients.forEach((client) => {
     const extClient = client as ExtWebSocket
     if (extClient.readyState === WebSocket.OPEN) {
+      // If a targetRole is specified, skip clients that don't match the role.
+      if (targetRole && extClient.clientType !== targetRole) {
+        return
+      }
       try {
         extClient.send(messageString)
       } catch (error) {


### PR DESCRIPTION
## Description

This PR addresses the issue where heart rate monitor tiles would persist as 'ghost' tiles (grayed out at 0%) even after the server had purged them.

The root cause was twofold:
1. The `webSocketReducer` was explicitly preserving disconnected clients in the state instead of filtering them out when they were missing from the server's periodic `HRM_UPDATE` payload.
2. `WebSocketContext.tsx` contained a duplicate, slightly different reducer implementation that was also buggy.

**Changes:**
- **webSocketReducer.ts**: The `HRM_UPDATE` case now uses the incoming payload as the single source of truth, filtering out any existing clients not present in the payload.
- **WebSocketContext.tsx**: Removed the local `reducer` and now imports the centralized one. Exposed `HrmData` type to fix build errors in dependent components/stories. Added `NEXT_PUBLIC_TESTING` check to expose `__TEST_CONTROLS__` in production-like test environments.
- **websocketUtils.ts**: Added a `targetRole` parameter to the `broadcast` function to allow sending messages specifically to 'dashboard' or 'controller' clients.
- **Testing**: Updated unit tests to enforce immediate client removal. Added a new Playwright spec that dispatches mock messages to verify the UI updates instantly.

**Technical Questions Answered:**
- **DEVICE_OFFLINE handling**: It is handled in the centralized reducer by filtering the `hrmData` array.
- **Broadcast targeting**: The `broadcast` utility now supports an optional `targetRole` argument.

No specific dependencies are required for this change.

Fixes #6580

## Change Type: 🐛 Bug fix (non-breaking change fixing an issue)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [x] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [x] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

This PR addresses the issue where heart rate monitor tiles would persist as 'ghost' tiles (grayed out at 0%) even after the server had purged them. 

The root cause was twofold:
1. The `webSocketReducer` was explicitly preserving disconnected clients in the state instead of filtering them out when they were missing from the server's periodic `HRM_UPDATE` payload.
2. `WebSocketContext.tsx` contained a duplicate, slightly different reducer implementation that was also buggy.

Changes:
- **webSocketReducer.ts**: The `HRM_UPDATE` case now uses the incoming payload as the single source of truth, filtering out any existing clients not present in the payload.
- **WebSocketContext.tsx**: Removed the local `reducer` and now imports the centralized one. Exposed `HrmData` type to fix build errors in dependent components/stories. Added `NEXT_PUBLIC_TESTING` check to expose `__TEST_CONTROLS__` in production-like test environments.
- **websocketUtils.ts**: Added a `targetRole` parameter to the `broadcast` function to allow sending messages specifically to 'dashboard' or 'controller' clients.
- **Testing**: Updated unit tests to enforce immediate client removal. Added a new Playwright spec that dispatches mock messages to verify the UI updates instantly.

Technical Questions Answered:
- **DEVICE_OFFLINE handling**: It is handled in the centralized reducer by filtering the `hrmData` array.
- **Broadcast targeting**: The `broadcast` utility now supports an optional `targetRole` argument.

Fixes #6580

---
*PR created automatically by Jules for task [1665063572118501096](https://jules.google.com/task/1665063572118501096) started by @arii*
</details>