### PR TITLE
test(small): Fix lint, build, and test errors

### DIFF
--- a/tests/unit/hooks/useCookie.test.ts
+++ b/tests/unit/hooks/useCookie.test.ts
@@ -48,19 +48,24 @@ describe('useCookie', () => {
     )
   })
 
-  it('should handle malformed JSON in the cookie and return the initial value', () => {
-    // Spy on console.error to suppress the expected error message
-    const consoleErrorSpy = jest
-      .spyOn(console, 'error')
-      .mockImplementation(() => {})
+  describe('when cookie contains malformed JSON', () => {
+    let consoleErrorSpy: jest.SpyInstance
 
-    try {
+    beforeEach(() => {
+      consoleErrorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      consoleErrorSpy.mockRestore()
+    })
+
+    it('should return the initial value', () => {
       ;(Cookies.get as jest.Mock).mockReturnValue('{ not json }')
       const { result } = renderHook(() => useCookie(TEST_KEY, INITIAL_VALUE))
       expect(result.current[0]).toEqual(INITIAL_VALUE)
-    } finally {
-      consoleErrorSpy.mockRestore()
-    }
+    })
   })
 
   it('should handle functional updates', () => {

--- a/tests/unit/hooks/useSpotifyWebPlayback.test.ts
+++ b/tests/unit/hooks/useSpotifyWebPlayback.test.ts
@@ -71,11 +71,6 @@ describe('useSpotifyWebPlayback', () => {
     const consoleWarnSpy = jest
       .spyOn(console, 'warn')
       .mockImplementation(() => {})
-    const error: networkUtils.AppError = {
-      message: 'Unauthorized',
-      code: 'HTTP_ERROR_401',
-      retryable: false,
-    }
     mockFetchWithRetry.mockResolvedValue({
       ok: false,
       status: 401,


### PR DESCRIPTION
## Description

This PR addresses linting and testing issues found during a routine check.

**Changes:**
1.  **Linting Fix:** Removed an unused variable in `tests/unit/hooks/useSpotifyWebPlayback.test.ts` that was causing linting warnings/errors.
2.  **Test Cleanup:** Refactored `tests/unit/hooks/useCookie.test.ts` to improve how `console.error` is suppressed during tests expecting errors. This resolves confusing stack traces in the test output.

**Verification:**
- `pnpm run lint`: Passed
- `pnpm run build`: Passed
- `pnpm run test:unit`: Passed (95 suites, 566 tests)

Fixes # (issue)

## Change Type: 🐛 Bug fix (non-breaking change fixing an issue)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [x] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [x] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

This PR addresses linting and testing issues found during a routine check.

**Changes:**
1.  **Linting Fix:** Removed an unused variable in `tests/unit/hooks/useSpotifyWebPlayback.test.ts` that was causing linting warnings/errors.
2.  **Test Cleanup:** Refactored `tests/unit/hooks/useCookie.test.ts` to improve how `console.error` is suppressed during tests expecting errors. This resolves confusing stack traces in the test output.

**Verification:**
- `pnpm run lint`: Passed
- `pnpm run build`: Passed
- `pnpm run test:unit`: Passed (95 suites, 566 tests)

---
*PR created automatically by Jules for task [12809091573180237487](https://jules.google.com/task/12809091573180237487) started by @arii*
</details>