### PR TITLE
test(small): Fix unit test warnings and assertions

### DIFF
--- a/tests/unit/components/ExperimentalAnalyticsPage.test.tsx
+++ b/tests/unit/components/ExperimentalAnalyticsPage.test.tsx
@@ -7,6 +7,7 @@ import { render } from '@testing-library/react'
 import ExperimentalAnalyticsPage from '@/app/client/experimental/components/ExperimentalAnalyticsPage'
 import { useUserSettings } from '@/context/UserSettingsContext'
 import { useWebSocket } from '@/context/WebSocketContext'
+import { useWorkoutSessionManager } from '@/hooks/useWorkoutSessionManager'
 
 // Mock the HeartRateTimeSeries component by mocking the dynamic import
 jest.mock('next/dynamic', () => () => {
@@ -18,10 +19,12 @@ jest.mock('next/dynamic', () => () => {
 // Mock hooks
 jest.mock('@/context/UserSettingsContext')
 jest.mock('@/context/WebSocketContext')
+jest.mock('@/hooks/useWorkoutSessionManager')
 
 describe('ExperimentalAnalyticsPage', () => {
   const mockUseUserSettings = useUserSettings as jest.Mock
   const mockUseWebSocket = useWebSocket as jest.Mock
+  const mockUseWorkoutSessionManager = useWorkoutSessionManager as jest.Mock
 
   beforeEach(() => {
     mockUseUserSettings.mockReturnValue([
@@ -31,6 +34,17 @@ describe('ExperimentalAnalyticsPage', () => {
     mockUseWebSocket.mockReturnValue({
       hrmData: [],
       timerData: { currentPhase: 'IDLE' },
+    })
+    mockUseWorkoutSessionManager.mockReturnValue({
+      session: null,
+      status: 'idle',
+      isInitialized: false,
+      duration: 0,
+      startWorkout: jest.fn(),
+      resumeWorkout: jest.fn(),
+      endWorkout: jest.fn(),
+      resetWorkout: jest.fn(),
+      addHrData: jest.fn(),
     })
   })
 

--- a/tests/unit/hooks/useCookie.test.ts
+++ b/tests/unit/hooks/useCookie.test.ts
@@ -55,6 +55,7 @@ describe('useCookie', () => {
     ;(Cookies.get as jest.Mock).mockReturnValue('{ not json }')
     const { result } = renderHook(() => useCookie(TEST_KEY, INITIAL_VALUE))
     expect(result.current[0]).toEqual(INITIAL_VALUE)
+    expect(consoleErrorSpy).toHaveBeenCalled()
     consoleErrorSpy.mockRestore()
   })
 


### PR DESCRIPTION
## Description

This PR addresses specific unit test warnings that were polluting the test output, ensuring a cleaner and more reliable test suite execution.

Changes:
- `tests/unit/components/ExperimentalAnalyticsPage.test.tsx`: Mocked `useWorkoutSessionManager` (setting `isInitialized: false`) to prevent the real hook from triggering an asynchronous `useEffect` that updated state after the test finished, causing React `act(...)` warnings.
- `tests/unit/hooks/useCookie.test.ts`: Added an explicit `expect(consoleErrorSpy).toHaveBeenCalled()` assertion to the malformed JSON test case. This confirms that the error logging mechanism is working as intended, even if the error message is still printed to the console by the test runner.

No dependencies are required for this change.

Fixes #

## Change Type: 🐛 Bug fix (non-breaking change fixing an issue)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [x] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [x] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

This PR addresses specific unit test warnings that were polluting the test output.

Changes:
- `tests/unit/components/ExperimentalAnalyticsPage.test.tsx`: Mocked `useWorkoutSessionManager` (setting `isInitialized: false`) to prevent the real hook from triggering an asynchronous `useEffect` that updated state after the test finished, causing React `act(...)` warnings.
- `tests/unit/hooks/useCookie.test.ts`: Added an explicit `expect(consoleErrorSpy).toHaveBeenCalled()` assertion to the malformed JSON test case. This confirms that the error logging mechanism is working as intended, even if the error message is still printed to the console by the test runner.

These changes ensure a cleaner and more reliable test suite execution.

---
*PR created automatically by Jules for task [8095943504394401931](https://jules.google.com/task/8095943504394401931) started by @arii*
</details>