### PR TITLE
test(small): Repair PR #5994: Fix regression in unit tests and remove scope creep

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -144,7 +144,6 @@ export default defineConfig({
       NEXTAUTH_URL: baseURL,
       SPOTIFY_CLIENT_ID: 'test_client_id',
       SPOTIFY_CLIENT_SECRET: 'test_client_secret',
-      IS_DEPLOYMENT: 'true',
     },
   },
 

--- a/tests/unit/utils/units.test.ts
+++ b/tests/unit/utils/units.test.ts
@@ -1,5 +1,12 @@
 // tests/unit/utils/units.test.ts
-import { formatZoneDuration } from '../../../utils/units'
+import {
+  formatZoneDuration,
+  toKg,
+  toDisplay,
+  feetAndInchesToCm,
+  cmToFeetAndInches,
+  KG_TO_LBS,
+} from '../../../utils/units'
 
 describe('formatZoneDuration', () => {
   it('should format durations less than a minute correctly', () => {
@@ -26,5 +33,59 @@ describe('formatZoneDuration', () => {
 
   it('should handle zero seconds', () => {
     expect(formatZoneDuration(0)).toBe('0:00')
+  })
+})
+
+describe('Weight Conversions', () => {
+  describe('toKg', () => {
+    it('should convert lbs to kg correctly (Imperial)', () => {
+      const lbs = 150
+      const expected = lbs / KG_TO_LBS
+      expect(toKg(lbs, 'IMPERIAL')).toBeCloseTo(expected)
+    })
+
+    it('should return value as is for Metric', () => {
+      const kg = 70
+      expect(toKg(kg, 'METRIC')).toBe(kg)
+    })
+  })
+
+  describe('toDisplay', () => {
+    it('should convert kg to lbs correctly (Imperial)', () => {
+      const kg = 70
+      const expected = parseFloat((kg * KG_TO_LBS).toFixed(1))
+      expect(toDisplay(kg, 'IMPERIAL')).toBe(expected)
+    })
+
+    it('should return kg rounded to 1 decimal for Metric', () => {
+      const kg = 70.123
+      expect(toDisplay(kg, 'METRIC')).toBe(70.1)
+    })
+  })
+})
+
+describe('Height Conversions', () => {
+  describe('feetAndInchesToCm', () => {
+    it('should convert feet and inches to cm correctly', () => {
+      const feet = 5
+      const inches = 10
+      // (5 * 12 + 10) * 2.54 = 70 * 2.54 = 177.8
+      expect(feetAndInchesToCm(feet, inches)).toBeCloseTo(177.8)
+    })
+  })
+
+  describe('cmToFeetAndInches', () => {
+    it('should convert cm to feet and inches correctly', () => {
+      const cm = 178
+      // 178 / 2.54 = 70.0787... -> 70 inches -> 5'10"
+      const result = cmToFeetAndInches(cm)
+      expect(result).toEqual({ feet: 5, inches: 10 })
+    })
+
+    it('should handle zero/negative/invalid input', () => {
+      expect(cmToFeetAndInches(0)).toEqual({ feet: 0, inches: 0 })
+      expect(cmToFeetAndInches(-10)).toEqual({ feet: 0, inches: 0 })
+      expect(cmToFeetAndInches(NaN)).toEqual({ feet: 0, inches: 0 })
+    })
   })
 })


### PR DESCRIPTION
## Description

This pull request aims to repair issues introduced or related to PR #5994 by addressing a regression in unit tests and removing scope creep.

Specifically:
- Restored missing unit tests for `toKg`, `toDisplay`, and other utilities in `tests/unit/utils/units.test.ts`.
- Removed an unrelated `IS_DEPLOYMENT: 'true'` configuration change from `playwright.config.ts`.

The motivation is to ensure the integrity and completeness of the unit test suite and to keep changes focused on their stated objective, preventing unnecessary modifications. The changes were verified with unit tests and linting.

Fixes #5994

## Change Type: 🐛 Bug fix (non-breaking change fixing an issue)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [x] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [x] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

- Restored missing unit tests for `toKg`, `toDisplay`, and other utilities in `tests/unit/utils/units.test.ts`.
- Removed unrelated `IS_DEPLOYMENT: 'true'` change from `playwright.config.ts`.
- Verified with unit tests and linting.

---
*PR created automatically by Jules for task [9204857798224583913](https://jules.google.com/task/9204857798224583913) started by @arii*
</details>