### PR TITLE
test(medium): Refactor SpotifyPolling services and fix duplicated types/mocks

### DIFF
--- a/services/spotifyPlayerManager.ts
+++ b/services/spotifyPlayerManager.ts
@@ -7,13 +7,17 @@ export class SpotifyPlayerManager {
   private sdk: SafeSpotifyApi
   private broadcastUpdate: (message: ServerMessage) => void
   private getState: () => SpotifyData
-  private setState: (newState: SpotifyData) => void
+  private setState: (
+    update: SpotifyData | ((prevState: SpotifyData) => SpotifyData)
+  ) => void
 
   constructor(
     sdk: SafeSpotifyApi,
     broadcastUpdate: (message: ServerMessage) => void,
     getState: () => SpotifyData,
-    setState: (newState: SpotifyData) => void
+    setState: (
+      update: SpotifyData | ((prevState: SpotifyData) => SpotifyData)
+    ) => void
   ) {
     this.sdk = sdk
     this.broadcastUpdate = broadcastUpdate
@@ -86,12 +90,11 @@ export class SpotifyPlayerManager {
             () => sdk.player.setPlaybackVolume(clampedVolume, deviceId),
             { deviceId, volume: clampedVolume }
           )
-          const state = this.getState()
-          this.setState({
-            ...state,
+          this.setState((prevState) => ({
+            ...prevState,
             volume: clampedVolume,
             isMuted: clampedVolume === 0,
-          })
+          }))
           this.broadcastUpdate({
             type: 'SPOTIFY_UPDATE',
             payload: this.getState(),

--- a/services/spotifyPolling.ts
+++ b/services/spotifyPolling.ts
@@ -266,7 +266,11 @@ export class SpotifyPolling implements SpotifyService {
   }
 
   public startPolling() {
-    if (this.pollInterval || !this.deviceManager) return
+    if (this.pollInterval) return
+    if (!this.isReady()) {
+      logger.warn('Cannot start polling: Spotify service is not ready.')
+      return
+    }
 
     const trackIntervalMs = env.SPOTIFY_POLLING_INTERVAL_MS
     this.pollInterval = setInterval(

--- a/services/spotifyTokenManager.ts
+++ b/services/spotifyTokenManager.ts
@@ -1,14 +1,7 @@
 import { AccessToken } from '@spotify/web-api-ts-sdk'
 import fs from 'fs'
 import * as path from 'path'
-
-interface SpotifyTokenResponse {
-  access_token: string
-  token_type: string
-  scope: string
-  expires_in: number
-  refresh_token?: string
-}
+import { SpotifyTokenResponse } from '../types/spotify'
 
 /**
  * Helper for atomic writes to prevent file corruption.

--- a/tests/unit/services/spotifyDeviceManager.test.ts
+++ b/tests/unit/services/spotifyDeviceManager.test.ts
@@ -8,13 +8,8 @@ import { Devices, SpotifyApi } from '@spotify/web-api-ts-sdk'
 // Mock the logger to prevent logs from appearing in test output
 jest.mock('../../../utils/logger.server.js', () => ({
   __esModule: true,
-  default: {
-    debug: jest.fn(),
-    info: jest.fn(),
-    warn: jest.fn(),
-    error: jest.fn(),
-    child: jest.fn().mockReturnThis(),
-  },
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  default: require('../spotify-mocks').mockLogger,
 }))
 
 describe('SpotifyDeviceManager', () => {

--- a/tests/unit/services/spotifyPlayerManager.test.ts
+++ b/tests/unit/services/spotifyPlayerManager.test.ts
@@ -8,13 +8,8 @@ import { SpotifyApi } from '@spotify/web-api-ts-sdk'
 // Mock the logger to prevent logs from appearing in test output
 jest.mock('../../../utils/logger.server.js', () => ({
   __esModule: true,
-  default: {
-    debug: jest.fn(),
-    info: jest.fn(),
-    warn: jest.fn(),
-    error: jest.fn(),
-    child: jest.fn().mockReturnThis(),
-  },
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  default: require('../spotify-mocks').mockLogger,
 }))
 
 describe('SpotifyPlayerManager', () => {
@@ -86,7 +81,10 @@ describe('SpotifyPlayerManager', () => {
       it('should set volume and update state', async () => {
         await playerManager.executeSpotifyCommand('SET_VOLUME', { volume: 75 })
         expect(mockPlayer.setPlaybackVolume).toHaveBeenCalledWith(75, undefined)
-        expect(setStateMock).toHaveBeenCalledWith({
+        expect(setStateMock).toHaveBeenCalledWith(expect.any(Function))
+        const updateFn = setStateMock.mock.calls[0][0]
+        const newState = updateFn({ volume: 50, isMuted: false })
+        expect(newState).toEqual({
           volume: 75,
           isMuted: false,
         })
@@ -102,7 +100,10 @@ describe('SpotifyPlayerManager', () => {
           100,
           undefined
         )
-        expect(setStateMock).toHaveBeenCalledWith({
+        expect(setStateMock).toHaveBeenCalledWith(expect.any(Function))
+        const updateFn = setStateMock.mock.calls[0][0]
+        const newState = updateFn({ volume: 50, isMuted: false })
+        expect(newState).toEqual({
           volume: 100,
           isMuted: false,
         })
@@ -111,7 +112,10 @@ describe('SpotifyPlayerManager', () => {
       it('should clamp volume to 0', async () => {
         await playerManager.executeSpotifyCommand('SET_VOLUME', { volume: -10 })
         expect(mockPlayer.setPlaybackVolume).toHaveBeenCalledWith(0, undefined)
-        expect(setStateMock).toHaveBeenCalledWith({
+        expect(setStateMock).toHaveBeenCalledWith(expect.any(Function))
+        const updateFn = setStateMock.mock.calls[0][0]
+        const newState = updateFn({ volume: 50, isMuted: false })
+        expect(newState).toEqual({
           volume: 0,
           isMuted: true,
         })

--- a/tests/unit/spotify-mocks.ts
+++ b/tests/unit/spotify-mocks.ts
@@ -1,5 +1,4 @@
 import { jest } from '@jest/globals'
-import { SpotifyApi } from '@spotify/web-api-ts-sdk'
 
 // Fully typed mock for the SpotifyApi['player']
 export const mockPlayer = {
@@ -18,12 +17,12 @@ export const mockPlayer = {
   startResumePlayback: jest.fn(),
   togglePlaybackShuffle: jest.fn(),
   transferPlayback: jest.fn(),
-} as unknown as jest.Mocked<SpotifyApi['player']>
+}
 
 // Mock the entire SpotifyApi with a mocked player
-export const mockSpotifyApi: jest.Mocked<SpotifyApi> = {
+export const mockSpotifyApi = {
   player: mockPlayer,
-} as jest.Mocked<SpotifyApi>
+}
 
 export const mockLogger = {
   debug: jest.fn(),

--- a/tests/unit/spotify-mocks.ts
+++ b/tests/unit/spotify-mocks.ts
@@ -1,0 +1,34 @@
+import { jest } from '@jest/globals'
+import { SpotifyApi } from '@spotify/web-api-ts-sdk'
+
+// Fully typed mock for the SpotifyApi['player']
+export const mockPlayer = {
+  addItemToPlaybackQueue: jest.fn(),
+  getAvailableDevices: jest.fn(),
+  getCurrentlyPlayingTrack: jest.fn(),
+  getPlaybackState: jest.fn(),
+  getRecentlyPlayedTracks: jest.fn(),
+  getUsersQueue: jest.fn(),
+  pausePlayback: jest.fn(),
+  seekToPosition: jest.fn(),
+  setPlaybackVolume: jest.fn(),
+  setRepeatMode: jest.fn(),
+  skipToNext: jest.fn(),
+  skipToPrevious: jest.fn(),
+  startResumePlayback: jest.fn(),
+  togglePlaybackShuffle: jest.fn(),
+  transferPlayback: jest.fn(),
+} as unknown as jest.Mocked<SpotifyApi['player']>
+
+// Mock the entire SpotifyApi with a mocked player
+export const mockSpotifyApi: jest.Mocked<SpotifyApi> = {
+  player: mockPlayer,
+} as jest.Mocked<SpotifyApi>
+
+export const mockLogger = {
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  child: jest.fn().mockReturnThis(),
+}

--- a/tests/unit/spotify-test-utils.ts
+++ b/tests/unit/spotify-test-utils.ts
@@ -1,30 +1,7 @@
 import { jest } from '@jest/globals'
 import { SpotifyPolling } from '../../services/spotifyPolling'
-import { SpotifyApi } from '@spotify/web-api-ts-sdk'
 
-// Fully typed mock for the SpotifyApi['player']
-export const mockPlayer = {
-  addItemToPlaybackQueue: jest.fn(),
-  getAvailableDevices: jest.fn(),
-  getCurrentlyPlayingTrack: jest.fn(),
-  getPlaybackState: jest.fn(),
-  getRecentlyPlayedTracks: jest.fn(),
-  getUsersQueue: jest.fn(),
-  pausePlayback: jest.fn(),
-  seekToPosition: jest.fn(),
-  setPlaybackVolume: jest.fn(),
-  setRepeatMode: jest.fn(),
-  skipToNext: jest.fn(),
-  skipToPrevious: jest.fn(),
-  startResumePlayback: jest.fn(),
-  togglePlaybackShuffle: jest.fn(),
-  transferPlayback: jest.fn(),
-} as unknown as jest.Mocked<SpotifyApi['player']>
-
-// Mock the entire SpotifyApi with a mocked player
-export const mockSpotifyApi: jest.Mocked<SpotifyApi> = {
-  player: mockPlayer,
-} as jest.Mocked<SpotifyApi>
+export { mockPlayer, mockSpotifyApi, mockLogger } from './spotify-mocks'
 
 /**
  * Test setup helper for SpotifyPolling service.

--- a/tests/unit/spotifyPolling.test.ts
+++ b/tests/unit/spotifyPolling.test.ts
@@ -25,15 +25,8 @@ jest.mock('../../lib/env.js', () => ({
 
 jest.mock('../../utils/logger.server.js', () => ({
   __esModule: true,
-  default: {
-    debug: jest.fn(),
-    info: jest.fn(),
-    warn: jest.fn(),
-    error: jest.fn(),
-    child: jest.fn(function () {
-      return this
-    }),
-  },
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  default: require('./spotify-mocks').mockLogger,
 }))
 
 // Mock the SpotifyTokenManager module

--- a/types/spotify.ts
+++ b/types/spotify.ts
@@ -45,3 +45,11 @@ export interface UserPlaylistDto {
   owner: string
   public: boolean
 }
+
+export interface SpotifyTokenResponse {
+  access_token: string
+  token_type: string
+  scope: string
+  expires_in: number
+  refresh_token?: string
+}


### PR DESCRIPTION
## Description

This pull request refactors the `SpotifyPolling` services and addresses duplicated types and mocks, improving code structure, test maintainability, and concurrency safety.

Key changes include:
- Refactor `SpotifyPlayerManager` to use functional state updates for concurrency safety.
- Centralize `SpotifyTokenResponse` in `types/spotify.ts` to remove duplication.
- Update `SpotifyPolling.startPolling` to use `isReady()` check and log warnings.
- Consolidate test mocks into `tests/unit/spotify-mocks.ts` and use `require` in `jest.mock` to resolve hoisting issues.
- Remove redundant duplicate code in test files.

This work also incorporates feedback received during PR review.

Fixes #

## Change Type: 🏗️ Refactoring (code change that neither fixes bug nor adds feature)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [x] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [x] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

Addressed PR review feedback (no code changes required).

Refactor SpotifyPolling services and fix duplicated types/mocks

- Refactor `SpotifyPlayerManager` to use functional state updates for concurrency safety.
- Centralize `SpotifyTokenResponse` in `types/spotify.ts` to remove duplication.
- Update `SpotifyPolling.startPolling` to use `isReady()` check and log warnings.
- Consolidate test mocks into `tests/unit/spotify-mocks.ts` and use `require` in `jest.mock` to resolve hoisting issues.
- Remove redundant duplicate code in test files.

---
*PR created automatically by Jules for task [1343316759627410121](https://jules.google.com/task/1343316759627410121) started by @arii*
</details>