### PR TITLE
feat(small): refactor: deduplicate bluetooth mocks and revert variable hoisting

### DIFF
--- a/app/client/connect/ConnectView.tsx
+++ b/app/client/connect/ConnectView.tsx
@@ -117,8 +117,6 @@ export default function ConnectView({
 }: ConnectViewProps) {
   const [isResetting, setIsResetting] = useState(false)
 
-  const showUserDetails = hasStarted || isConnected
-
   useEffect(() => {
     if (isConnected) {
       logger.debug(
@@ -192,6 +190,8 @@ export default function ConnectView({
       </Container>
     )
   }
+
+  const showUserDetails = hasStarted || isConnected
 
   return (
     <>

--- a/tests/playwright/lib/bluetooth-mocks.ts
+++ b/tests/playwright/lib/bluetooth-mocks.ts
@@ -8,12 +8,47 @@ export const injectBluetoothMocks = async (page: Page) => {
     let _connectedDevice: MockBluetoothDevice | null = null
 
     // 1. Mock Classes
-    class MockBluetoothRemoteGATTCharacteristic implements MockBluetoothRemoteGATTCharacteristic {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    type MockListener = (event: any) => void
+
+    class MockEventEmitter {
+      listeners: { [key: string]: MockListener[] }
+
+      constructor() {
+        this.listeners = {}
+      }
+
+      addEventListener(type: string, listener: MockListener) {
+        if (!this.listeners[type]) this.listeners[type] = []
+        this.listeners[type].push(listener)
+      }
+
+      removeEventListener(type: string, listener: MockListener) {
+        if (this.listeners[type]) {
+          const index = this.listeners[type].indexOf(listener)
+          if (index > -1) {
+            this.listeners[type].splice(index, 1)
+          }
+        }
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      dispatchEvent(type: string, event: any) {
+        if (this.listeners && this.listeners[type]) {
+          this.listeners[type].forEach((l) => l(event))
+        }
+      }
+    }
+
+    class MockBluetoothRemoteGATTCharacteristic
+      extends MockEventEmitter
+      implements MockBluetoothRemoteGATTCharacteristic
+    {
       service: MockBluetoothRemoteGATTService
       value: DataView | null = null
-      listeners: { [key: string]: MockEventListener[] } = {}
 
       constructor(service: MockBluetoothRemoteGATTService) {
+        super()
         this.service = service
       }
 
@@ -25,20 +60,6 @@ export const injectBluetoothMocks = async (page: Page) => {
         return this
       }
 
-      addEventListener(type: string, listener: MockEventListener) {
-        if (!this.listeners[type]) this.listeners[type] = []
-        this.listeners[type].push(listener)
-      }
-
-      removeEventListener(type: string, listener: MockEventListener) {
-        if (this.listeners[type]) {
-          const index = this.listeners[type].indexOf(listener)
-          if (index > -1) {
-            this.listeners[type].splice(index, 1)
-          }
-        }
-      }
-
       // Helper to simulate data arriving
       emitValue(uint8Value: number) {
         const buffer = new ArrayBuffer(2)
@@ -48,9 +69,7 @@ export const injectBluetoothMocks = async (page: Page) => {
         this.value = view
 
         const event = { target: { value: this.value } }
-        if (this.listeners['characteristicvaluechanged']) {
-          this.listeners['characteristicvaluechanged'].forEach((l) => l(event))
-        }
+        this.dispatchEvent('characteristicvaluechanged', event)
       }
     }
 
@@ -93,11 +112,9 @@ export const injectBluetoothMocks = async (page: Page) => {
         this.connected = false
         _connectedDevice = null
         // Trigger disconnection listener on device
-        if (this.device.listeners['gattserverdisconnected']) {
-          this.device.listeners['gattserverdisconnected'].forEach((l) =>
-            l({ target: this.device } as unknown as Event)
-          )
-        }
+        this.device.dispatchEvent('gattserverdisconnected', {
+          target: this.device,
+        })
       }
 
       async getPrimaryService(uuid: string) {
@@ -106,31 +123,20 @@ export const injectBluetoothMocks = async (page: Page) => {
       }
     }
 
-    class MockBluetoothDevice implements MockBluetoothDevice {
+    class MockBluetoothDevice
+      extends MockEventEmitter
+      implements MockBluetoothDevice
+    {
       id: string
       name: string
       gatt: MockBluetoothRemoteGATTServer
-      listeners: { [key: string]: ((event: Event) => void)[] } = {}
       _shouldFailConnection = false
 
       constructor(id: string, name: string) {
+        super()
         this.id = id
         this.name = name
         this.gatt = new MockBluetoothRemoteGATTServer(this)
-      }
-
-      addEventListener(type: string, listener: (event: Event) => void) {
-        if (!this.listeners[type]) this.listeners[type] = []
-        this.listeners[type].push(listener)
-      }
-
-      removeEventListener(type: string, listener: (event: Event) => void) {
-        if (this.listeners[type]) {
-          const index = this.listeners[type].indexOf(listener)
-          if (index > -1) {
-            this.listeners[type].splice(index, 1)
-          }
-        }
       }
 
       async forget() {

--- a/tests/playwright/lib/bluetooth-mocks.ts
+++ b/tests/playwright/lib/bluetooth-mocks.ts
@@ -8,36 +8,9 @@ export const injectBluetoothMocks = async (page: Page) => {
     let _connectedDevice: MockBluetoothDevice | null = null
 
     // 1. Mock Classes
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    type MockListener = (event: any) => void
-
-    class MockEventEmitter {
-      listeners: { [key: string]: MockListener[] } = {}
-
-      addEventListener(type: string, listener: MockListener) {
-        if (!this.listeners[type]) this.listeners[type] = []
-        this.listeners[type].push(listener)
-      }
-
-      removeEventListener(type: string, listener: MockListener) {
-        if (this.listeners[type]) {
-          const index = this.listeners[type].indexOf(listener)
-          if (index > -1) {
-            this.listeners[type].splice(index, 1)
-          }
-        }
-      }
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      dispatchEvent(type: string, event: any) {
-        if (this.listeners[type]) {
-          this.listeners[type].forEach((l) => l(event))
-        }
-      }
-    }
 
     class MockBluetoothRemoteGATTCharacteristic
-      extends MockEventEmitter
+      extends EventTarget
       implements MockBluetoothRemoteGATTCharacteristic
     {
       service: MockBluetoothRemoteGATTService
@@ -64,8 +37,10 @@ export const injectBluetoothMocks = async (page: Page) => {
         view.setUint8(1, uint8Value) // HR Value
         this.value = view
 
-        const event = { target: { value: this.value } }
-        this.dispatchEvent('characteristicvaluechanged', event)
+        // Native dispatch. 'target' is automatically set to 'this' instance.
+        // We need to attach the value to the event or rely on the listener reading it from the target
+        // The standard Web Bluetooth event is just a generic Event, and listeners read `event.target.value`.
+        this.dispatchEvent(new Event('characteristicvaluechanged'))
       }
     }
 
@@ -108,9 +83,7 @@ export const injectBluetoothMocks = async (page: Page) => {
         this.connected = false
         _connectedDevice = null
         // Trigger disconnection listener on device
-        this.device.dispatchEvent('gattserverdisconnected', {
-          target: this.device,
-        })
+        this.device.dispatchEvent(new Event('gattserverdisconnected'))
       }
 
       async getPrimaryService(uuid: string) {
@@ -120,7 +93,7 @@ export const injectBluetoothMocks = async (page: Page) => {
     }
 
     class MockBluetoothDevice
-      extends MockEventEmitter
+      extends EventTarget
       implements MockBluetoothDevice
     {
       id: string

--- a/tests/playwright/lib/bluetooth-mocks.ts
+++ b/tests/playwright/lib/bluetooth-mocks.ts
@@ -37,9 +37,7 @@ export const injectBluetoothMocks = async (page: Page) => {
         view.setUint8(1, uint8Value) // HR Value
         this.value = view
 
-        // Native dispatch. 'target' is automatically set to 'this' instance.
-        // We need to attach the value to the event or rely on the listener reading it from the target
-        // The standard Web Bluetooth event is just a generic Event, and listeners read `event.target.value`.
+        // Dispatch standard event; listeners access value via event.target.value
         this.dispatchEvent(new Event('characteristicvaluechanged'))
       }
     }

--- a/tests/playwright/lib/bluetooth-mocks.ts
+++ b/tests/playwright/lib/bluetooth-mocks.ts
@@ -12,11 +12,7 @@ export const injectBluetoothMocks = async (page: Page) => {
     type MockListener = (event: any) => void
 
     class MockEventEmitter {
-      listeners: { [key: string]: MockListener[] }
-
-      constructor() {
-        this.listeners = {}
-      }
+      listeners: { [key: string]: MockListener[] } = {}
 
       addEventListener(type: string, listener: MockListener) {
         if (!this.listeners[type]) this.listeners[type] = []
@@ -34,7 +30,7 @@ export const injectBluetoothMocks = async (page: Page) => {
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       dispatchEvent(type: string, event: any) {
-        if (this.listeners && this.listeners[type]) {
+        if (this.listeners[type]) {
           this.listeners[type].forEach((l) => l(event))
         }
       }


### PR DESCRIPTION
## Description

Refactors `tests/playwright/lib/bluetooth-mocks.ts` to use a shared `MockEventEmitter` class, removing duplicated listener logic in `MockBluetoothRemoteGATTCharacteristic` and `MockBluetoothDevice`.
Reverts the hoisting of `showUserDetails` in `app/client/connect/ConnectView.tsx` to reduce code churn and place the variable closer to its usage.
These changes address feedback from the previous audit of PR #6664.

Fixes #6664

## Change Type: 🏗️ Refactoring (code change that neither fixes bug nor adds feature)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [x] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [x] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

Refactors `tests/playwright/lib/bluetooth-mocks.ts` to use a shared `MockEventEmitter` class, removing duplicated listener logic in `MockBluetoothRemoteGATTCharacteristic` and `MockBluetoothDevice`.
Reverts the hoisting of `showUserDetails` in `app/client/connect/ConnectView.tsx` to reduce code churn and place the variable closer to its usage.
These changes address feedback from the previous audit of PR #6664.

---
*PR created automatically by Jules for task [3532372667816938515](https://jules.google.com/task/3532372667816938515) started by @arii*
</details>