### PR TITLE
feat(small): Fix: Clock skew in HR tile persistence & optimize rendering

### DIFF
--- a/components/HrTileWrapper.tsx
+++ b/components/HrTileWrapper.tsx
@@ -2,6 +2,7 @@
 import { useHrZone } from '@/hooks/useHrZone'
 import HrTile from '@/components/HrTile'
 import { ClientHrmData } from '@/context/webSocketReducer'
+import { memo } from 'react'
 
 interface HrTileWrapperProps {
   user: ClientHrmData
@@ -25,4 +26,20 @@ const HrTileWrapper = ({ user, isDataStale }: HrTileWrapperProps) => {
   )
 }
 
-export default HrTileWrapper
+const arePropsEqual = (
+  prevProps: HrTileWrapperProps,
+  nextProps: HrTileWrapperProps
+) => {
+  return (
+    prevProps.isDataStale === nextProps.isDataStale &&
+    prevProps.user.value === nextProps.user.value &&
+    prevProps.user.maxHr === nextProps.user.maxHr &&
+    prevProps.user.name === nextProps.user.name &&
+    prevProps.user.calories === nextProps.user.calories &&
+    prevProps.user.isConnected === nextProps.user.isConnected &&
+    prevProps.user.isAlerting === nextProps.user.isAlerting &&
+    prevProps.user.alertMessage === nextProps.user.alertMessage
+  )
+}
+
+export default memo(HrTileWrapper, arePropsEqual)

--- a/context/webSocketReducer.ts
+++ b/context/webSocketReducer.ts
@@ -66,12 +66,13 @@ export const reducer = (
       return INITIAL_STATE
     case 'INITIAL_STATE': {
       // When the initial state is loaded, ensure all HRM data is marked as connected.
-      // We rely on the server-provided updatedAt timestamp for lastUpdated.
+      // We use the client's current time for lastUpdated to prevent clock skew issues.
+      const now = Date.now()
       const hrmDataWithConnection =
         message.payload.hrmData?.map((d) => ({
           ...d,
           isConnected: true,
-          lastUpdated: d.updatedAt,
+          lastUpdated: now,
         })) || []
       return {
         ...state,
@@ -81,6 +82,7 @@ export const reducer = (
     }
     case 'HRM_UPDATE': {
       const payload = message.payload as ServerHrmData[]
+      const now = Date.now()
 
       // Simplify: The HRM_UPDATE payload from the server is the single source of truth.
       // We map the payload to our local HrmData structure, preserving existing local state
@@ -94,7 +96,7 @@ export const reducer = (
           ...existingUser,
           ...newUser,
           isConnected: true,
-          lastUpdated: newUser.updatedAt || existingUser?.lastUpdated,
+          lastUpdated: now,
         }
       })
 

--- a/tests/unit/context/webSocketReducer.test.ts
+++ b/tests/unit/context/webSocketReducer.test.ts
@@ -106,6 +106,9 @@ describe('webSocketReducer', () => {
     })
 
     it('should update an existing user and their lastUpdated timestamp', () => {
+      const mockNow = 1234567890
+      const dateSpy = jest.spyOn(Date, 'now').mockReturnValue(mockNow)
+
       const initialState: WebSocketState = {
         ...INITIAL_STATE,
         hrmData: [{ ...baseUser, isConnected: true, lastUpdated: 12345 }],
@@ -125,7 +128,9 @@ describe('webSocketReducer', () => {
       expect(state.hrmData[0].value).toBe(150)
       expect(state.hrmData[0].zone).toBe('aerobic')
       expect(state.hrmData[0].isConnected).toBe(true)
-      expect(state.hrmData[0].lastUpdated).toBe(2000000)
+      expect(state.hrmData[0].lastUpdated).toBe(mockNow)
+
+      dateSpy.mockRestore()
     })
 
     it('should remove users that are not in the payload immediately', () => {


### PR DESCRIPTION
## Description

This PR addresses the "ghost tile" issue and clock skew vulnerability by switching to Client Reception Time for HR data TTL. It also includes performance optimizations for the dashboard by memoizing tile wrappers to handle 1Hz updates efficiently.

The relevant changes include:
- **`context/webSocketReducer.ts`**: Uses `Date.now()` for `lastUpdated` to mitigate clock skew issues.
- **`components/HrTileWrapper.tsx`**: Adds `React.memo` with `arePropsEqual` to optimize rendering for 1Hz updates.
- **`tests/unit/context/webSocketReducer.test.ts`**: Updates unit tests to properly account for mocked `Date.now()` usage.

No specific external dependencies are required for this change.

Fixes # (issue)

## Change Type: 🐛 Bug fix (non-breaking change fixing an issue)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [x] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [x] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

This PR addresses the "ghost tile" issue and clock skew vulnerability by switching to Client Reception Time for HR data TTL. It also includes performance optimizations for the dashboard by memoizing tile wrappers to handle 1Hz updates efficiently.

## Changes
- **`context/webSocketReducer.ts`**: Use `Date.now()` for `lastUpdated`.
- **`components/HrTileWrapper.tsx`**: Add `React.memo` with `arePropsEqual`.
- **`tests/unit/context/webSocketReducer.test.ts`**: Update tests to use mocked `Date.now()`.

## Verification
- `pnpm run build`: Passed
- `pnpm run lint`: Passed
- `pnpm run test:unit`: Passed

---
*PR created automatically by Jules for task [13131209639633355529](https://jules.google.com/task/13131209639633355529) started by @arii*
</details>