### PR TITLE
test(medium): Refactor Spotify Polling service for better architectural separation

### DIFF
--- a/services/spotifyPlayerManager.ts
+++ b/services/spotifyPlayerManager.ts
@@ -5,6 +5,15 @@ import logger from '../utils/logger.server.js'
 import { isEmptyResponseError } from './spotifyUtils.js'
 import { Track, Episode } from '@spotify/web-api-ts-sdk'
 
+export interface ParsedPlaybackState {
+  trackId: string
+  trackName: string
+  artist: string
+  albumName: string
+  albumArtUrl: string
+  isPlaying: boolean
+}
+
 export class SpotifyPlayerManager {
   private sdk: SafeSpotifyApi
   private broadcastUpdate: (message: ServerMessage) => void
@@ -27,7 +36,7 @@ export class SpotifyPlayerManager {
     this.setState = setState
   }
 
-  public async fetchPlaybackState(): Promise<Partial<SpotifyData> | null> {
+  public async fetchPlaybackState(): Promise<ParsedPlaybackState | null> {
     const playbackState = await this.sdk.player.getCurrentlyPlayingTrack()
 
     if (!playbackState || !playbackState.item) {

--- a/services/spotifyPlayerManager.ts
+++ b/services/spotifyPlayerManager.ts
@@ -2,6 +2,8 @@ import { SpotifyCommandParameters } from '../types/core'
 import { ServerMessage, SpotifyCommand, SpotifyData } from '../types/websocket'
 import { SafeSpotifyApi } from './safeSpotifyApi'
 import logger from '../utils/logger.server.js'
+import { isEmptyResponseError } from './spotifyUtils.js'
+import { Track, Episode } from '@spotify/web-api-ts-sdk'
 
 export class SpotifyPlayerManager {
   private sdk: SafeSpotifyApi
@@ -23,6 +25,44 @@ export class SpotifyPlayerManager {
     this.broadcastUpdate = broadcastUpdate
     this.getState = getState
     this.setState = setState
+  }
+
+  public async fetchPlaybackState(): Promise<Partial<SpotifyData> | null> {
+    const playbackState = await this.sdk.player.getCurrentlyPlayingTrack()
+
+    if (!playbackState || !playbackState.item) {
+      return null
+    }
+
+    const item = playbackState.item
+    const isPlaying = playbackState.is_playing
+
+    const trackId = item.id
+    const trackName = item.name
+    let artist = ''
+    let albumName = ''
+    let albumArtUrl = ''
+
+    if (item.type === 'track') {
+      const track = item as Track
+      artist = track.artists.map((a) => a.name).join(', ')
+      albumName = track.album.name
+      albumArtUrl = track.album.images?.[0]?.url ?? ''
+    } else if (item.type === 'episode') {
+      const episode = item as Episode
+      artist = episode.show.publisher
+      albumName = episode.show.name
+      albumArtUrl = episode.show.images?.[0]?.url ?? ''
+    }
+
+    return {
+      trackId,
+      trackName,
+      artist,
+      albumName,
+      albumArtUrl,
+      isPlaying,
+    }
   }
 
   public async executeSpotifyCommand(
@@ -112,7 +152,7 @@ export class SpotifyPlayerManager {
     try {
       await apiCall()
     } catch (error) {
-      if (this.isEmptyResponseError(error)) {
+      if (isEmptyResponseError(error)) {
         logger.debug(
           { command: commandName, ...logContext },
           'Spotify command successful (204 No Content)'
@@ -121,12 +161,5 @@ export class SpotifyPlayerManager {
       }
       throw error
     }
-  }
-
-  private isEmptyResponseError(error: unknown): boolean {
-    if (!(error instanceof SyntaxError)) {
-      return false
-    }
-    return /unexpected end of/i.test(error.message)
   }
 }

--- a/services/spotifyPolling.ts
+++ b/services/spotifyPolling.ts
@@ -1,9 +1,4 @@
-import {
-  AccessToken,
-  SpotifyApi,
-  Track,
-  Episode,
-} from '@spotify/web-api-ts-sdk'
+import { AccessToken, SpotifyApi } from '@spotify/web-api-ts-sdk'
 import { ServerMessage, SpotifyData } from '../types/websocket'
 import { SpotifyCommandParameters } from '../types/core'
 import {
@@ -77,13 +72,14 @@ export class SpotifyPolling implements SpotifyService {
 
   private getCurrentlyPlaying = async () => {
     try {
-      if (!this.sdk) {
+      if (!this.sdk || !this.playerManager) {
         logger.debug('Spotify SDK not initialized, skipping poll')
         return
       }
-      const playbackState = await this.sdk.player.getCurrentlyPlayingTrack()
 
-      if (!playbackState || !playbackState.item) {
+      const playbackState = await this.playerManager.fetchPlaybackState()
+
+      if (!playbackState) {
         if (this.lastPlaybackState !== false) {
           this.lastPlaybackState = false
           this.setState({
@@ -103,42 +99,23 @@ export class SpotifyPolling implements SpotifyService {
         return
       }
 
-      const item = playbackState.item
-      const isPlaying = playbackState.is_playing
+      const { trackId, trackName, artist, albumName, albumArtUrl, isPlaying } = playbackState
 
       if (
-        item.id !== this.lastTrackId ||
+        trackId !== this.lastTrackId ||
         isPlaying !== this.lastPlaybackState
       ) {
-        this.lastTrackId = item.id
-        this.lastPlaybackState = isPlaying
-
-        const trackName = item.name
-        const trackId = item.id
-        let artistName = ''
-        let albumName = ''
-        let albumArtUrl = ''
-
-        if (item.type === 'track') {
-          const track = item as Track
-          artistName = track.artists.map((a) => a.name).join(', ')
-          albumName = track.album.name
-          albumArtUrl = track.album.images?.[0]?.url ?? ''
-        } else if (item.type === 'episode') {
-          const episode = item as Episode
-          artistName = episode.show.publisher
-          albumName = episode.show.name
-          albumArtUrl = episode.show.images?.[0]?.url ?? ''
-        }
+        this.lastTrackId = trackId!
+        this.lastPlaybackState = isPlaying!
 
         this.setState({
           ...this.state,
-          trackId,
-          trackName,
-          artist: artistName,
-          albumName,
-          albumArtUrl,
-          isPlaying,
+          trackId: trackId!,
+          trackName: trackName!,
+          artist: artist!,
+          albumName: albumName!,
+          albumArtUrl: albumArtUrl!,
+          isPlaying: isPlaying!,
         })
 
         this.broadcastUpdate({

--- a/services/spotifyPolling.ts
+++ b/services/spotifyPolling.ts
@@ -99,23 +99,24 @@ export class SpotifyPolling implements SpotifyService {
         return
       }
 
-      const { trackId, trackName, artist, albumName, albumArtUrl, isPlaying } = playbackState
+      const { trackId, trackName, artist, albumName, albumArtUrl, isPlaying } =
+        playbackState
 
       if (
         trackId !== this.lastTrackId ||
         isPlaying !== this.lastPlaybackState
       ) {
-        this.lastTrackId = trackId!
-        this.lastPlaybackState = isPlaying!
+        this.lastTrackId = trackId
+        this.lastPlaybackState = isPlaying
 
         this.setState({
           ...this.state,
-          trackId: trackId!,
-          trackName: trackName!,
-          artist: artist!,
-          albumName: albumName!,
-          albumArtUrl: albumArtUrl!,
-          isPlaying: isPlaying!,
+          trackId,
+          trackName,
+          artist,
+          albumName,
+          albumArtUrl,
+          isPlaying,
         })
 
         this.broadcastUpdate({

--- a/services/spotifyUtils.ts
+++ b/services/spotifyUtils.ts
@@ -1,0 +1,6 @@
+export function isEmptyResponseError(error: unknown): boolean {
+  if (!(error instanceof SyntaxError)) {
+    return false
+  }
+  return /unexpected end of/i.test(error.message)
+}

--- a/tests/unit/services/spotifyPlayerManager.test.ts
+++ b/tests/unit/services/spotifyPlayerManager.test.ts
@@ -3,7 +3,7 @@ import { SpotifyPlayerManager } from '../../../services/spotifyPlayerManager'
 import { mockPlayer } from '../spotify-test-utils'
 import { SafeSpotifyApi } from '../../../services/safeSpotifyApi'
 import { createSafeSpotifyApi } from '../../../services/safeSpotifyApi'
-import { SpotifyApi } from '@spotify/web-api-ts-sdk'
+import { SpotifyApi, PlaybackState } from '@spotify/web-api-ts-sdk'
 
 // Mock the logger to prevent logs from appearing in test output
 jest.mock('../../../utils/logger.server.js', () => ({
@@ -172,7 +172,7 @@ describe('SpotifyPlayerManager', () => {
     it('should return null when no item in playback state', async () => {
       mockPlayer.getCurrentlyPlayingTrack.mockResolvedValue({
         item: null,
-      } as any)
+      } as unknown as PlaybackState)
       const result = await playerManager.fetchPlaybackState()
       expect(result).toBeNull()
     })
@@ -191,7 +191,7 @@ describe('SpotifyPlayerManager', () => {
       mockPlayer.getCurrentlyPlayingTrack.mockResolvedValue({
         item: mockTrack,
         is_playing: true,
-      } as any)
+      } as unknown as PlaybackState)
 
       const result = await playerManager.fetchPlaybackState()
 
@@ -219,7 +219,7 @@ describe('SpotifyPlayerManager', () => {
       mockPlayer.getCurrentlyPlayingTrack.mockResolvedValue({
         item: mockEpisode,
         is_playing: false,
-      } as any)
+      } as unknown as PlaybackState)
 
       const result = await playerManager.fetchPlaybackState()
 

--- a/tests/unit/services/spotifyPlayerManager.test.ts
+++ b/tests/unit/services/spotifyPlayerManager.test.ts
@@ -161,4 +161,76 @@ describe('SpotifyPlayerManager', () => {
       ).rejects.toThrow('API is down')
     })
   })
+
+  describe('fetchPlaybackState', () => {
+    it('should return null when no playback state returned', async () => {
+      mockPlayer.getCurrentlyPlayingTrack.mockResolvedValue(null)
+      const result = await playerManager.fetchPlaybackState()
+      expect(result).toBeNull()
+    })
+
+    it('should return null when no item in playback state', async () => {
+      mockPlayer.getCurrentlyPlayingTrack.mockResolvedValue({
+        item: null,
+      } as any)
+      const result = await playerManager.fetchPlaybackState()
+      expect(result).toBeNull()
+    })
+
+    it('should return parsed track data', async () => {
+      const mockTrack = {
+        id: 'track1',
+        name: 'Track Name',
+        type: 'track',
+        artists: [{ name: 'Artist 1' }, { name: 'Artist 2' }],
+        album: {
+          name: 'Album Name',
+          images: [{ url: 'http://image.url' }],
+        },
+      }
+      mockPlayer.getCurrentlyPlayingTrack.mockResolvedValue({
+        item: mockTrack,
+        is_playing: true,
+      } as any)
+
+      const result = await playerManager.fetchPlaybackState()
+
+      expect(result).toEqual({
+        trackId: 'track1',
+        trackName: 'Track Name',
+        artist: 'Artist 1, Artist 2',
+        albumName: 'Album Name',
+        albumArtUrl: 'http://image.url',
+        isPlaying: true,
+      })
+    })
+
+    it('should return parsed episode data', async () => {
+      const mockEpisode = {
+        id: 'episode1',
+        name: 'Episode Name',
+        type: 'episode',
+        show: {
+          publisher: 'Publisher Name',
+          name: 'Show Name',
+          images: [{ url: 'http://episode.image.url' }],
+        },
+      }
+      mockPlayer.getCurrentlyPlayingTrack.mockResolvedValue({
+        item: mockEpisode,
+        is_playing: false,
+      } as any)
+
+      const result = await playerManager.fetchPlaybackState()
+
+      expect(result).toEqual({
+        trackId: 'episode1',
+        trackName: 'Episode Name',
+        artist: 'Publisher Name',
+        albumName: 'Show Name',
+        albumArtUrl: 'http://episode.image.url',
+        isPlaying: false,
+      })
+    })
+  })
 })


### PR DESCRIPTION
## Description

This PR refactors the `SpotifyPolling` service to improve separation of concerns by moving the `getCurrentlyPlaying` implementation details into `SpotifyPlayerManager`. It also introduces a shared utility for error checking and ensures all changes are covered by unit tests. This addresses the feedback from PR #6093.

Fixes # 

## Change Type: 🏗️ Refactoring (code change that neither fixes bug nor adds feature)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [x] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [x] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

This PR refactors the `SpotifyPolling` service to improve separation of concerns by moving the `getCurrentlyPlaying` implementation details into `SpotifyPlayerManager`. It also introduces a shared utility for error checking and ensures all changes are covered by unit tests. This addresses the feedback from PR #6093.

---
*PR created automatically by Jules for task [18352674082257778548](https://jules.google.com/task/18352674082257778548) started by @arii*
</details>