### PR TITLE
refactor(spotify): remove dead code and redundant state in SpotifyPolling

### DIFF
--- a/services/spotifyPolling.ts
+++ b/services/spotifyPolling.ts
@@ -29,9 +29,6 @@ export class SpotifyPolling implements SpotifyService {
 
   private readonly broadcastUpdate: (message: ServerMessage) => void
 
-  private lastTrackId: string | null = null
-  private lastPlaybackState: boolean | null = null
-
   private state: SpotifyData = {
     trackId: null,
     trackName: 'Awaiting Login...',
@@ -80,8 +77,10 @@ export class SpotifyPolling implements SpotifyService {
       const playbackState = await this.playerManager.fetchPlaybackState()
 
       if (!playbackState) {
-        if (this.lastPlaybackState !== false) {
-          this.lastPlaybackState = false
+        if (
+          this.state.isPlaying ||
+          this.state.trackName !== 'Nothing is currently playing.'
+        ) {
           this.setState({
             ...this.state,
             trackId: null,
@@ -103,12 +102,9 @@ export class SpotifyPolling implements SpotifyService {
         playbackState
 
       if (
-        trackId !== this.lastTrackId ||
-        isPlaying !== this.lastPlaybackState
+        trackId !== this.state.trackId ||
+        isPlaying !== this.state.isPlaying
       ) {
-        this.lastTrackId = trackId
-        this.lastPlaybackState = isPlaying
-
         this.setState({
           ...this.state,
           trackId,
@@ -132,7 +128,6 @@ export class SpotifyPolling implements SpotifyService {
   public _test_ =
     process.env.NODE_ENV === 'test'
       ? {
-          getSdk: this.getSdk.bind(this),
           setSdk: (sdk: SafeSpotifyApi | null) => {
             this.sdk = sdk
           },
@@ -220,13 +215,6 @@ export class SpotifyPolling implements SpotifyService {
       this.playerManager !== null &&
       this.deviceManager !== null
     )
-  }
-
-  private getSdk(): SafeSpotifyApi {
-    if (!this.sdk) {
-      throw new Error('Spotify SDK has not been initialized.')
-    }
-    return this.sdk
   }
 
   public async handleTokenUpdate(tokens: SpotifyTokenPayload): Promise<void> {


### PR DESCRIPTION
## Description

This PR refactors the `SpotifyPolling` service to remove unused `getSdk` method and redundant `lastTrackId`/`lastPlaybackState` properties. The service now uses `this.state` as the single source of truth for change detection, simplifying logic and reducing potential state drift.

Fixes # 

## Change Type: 🏗️ Refactoring (code change that neither fixes bug nor adds feature)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [x] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [x] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

Refactored `SpotifyPolling` service to remove unused `getSdk` method and redundant `lastTrackId`/`lastPlaybackState` properties. The service now uses `this.state` as the single source of truth for change detection, simplifying logic and reducing potential state drift.

---
*PR created automatically by Jules for task [12811330533343814922](https://jules.google.com/task/12811330533343814922) started by @arii*
</details>