### PR TITLE
test(small): Refactor webSocketReducer tests to reduce duplication

### DIFF
--- a/tests/unit/webSocketReducer.test.ts
+++ b/tests/unit/webSocketReducer.test.ts
@@ -11,19 +11,26 @@ import { ServerMessage } from '../../types/websocket'
 import { HrmStreamData as ServerHrmData } from '../../types/core'
 
 describe('webSocketReducer', () => {
-  const baseUser: HrmData = {
-    clientId: 'client-1',
-    name: 'User A',
-    age: 30,
-    maxHr: 190,
-    restingHr: 60,
-    value: 100,
-    percentage: 50,
-    zone: 1,
-    calories: 10,
-    isConnected: true,
-    updatedAt: 1000,
-  }
+  // Helper to create mock users and reduce duplication
+  // uses "as any" to allow extra properties like percentage/zone/restingHr
+  // which appear in tests but might be missing from the strict HrmData type
+  const createMockUser = (overrides: Record<string, any> = {}): HrmData =>
+    ({
+      clientId: 'client-1',
+      name: 'User A',
+      age: 30,
+      maxHr: 190,
+      restingHr: 60,
+      value: 100,
+      percentage: 50,
+      zone: 1,
+      calories: 10,
+      isConnected: true,
+      updatedAt: 1000,
+      ...overrides,
+    } as unknown as HrmData)
+
+  const baseUser = createMockUser()
 
   it('should return the initial state if no action is matched', () => {
     const action = { type: 'UNKNOWN_ACTION' } as unknown as ServerMessage
@@ -44,18 +51,11 @@ describe('webSocketReducer', () => {
     it('should handle INITIAL_STATE action and mark hrmData as connected', () => {
       const serverState = {
         hrmData: [
-          {
-            clientId: 'client-1',
-            name: 'User A',
-            age: 30,
-            maxHr: 190,
-            restingHr: 60,
+          createMockUser({
             value: 120,
             percentage: 60,
-            zone: 1,
             calories: 100,
-            updatedAt: 1000,
-          },
+          }),
         ] as ServerHrmData[],
         timerData: {
           ...INITIAL_STATE.timerData,
@@ -84,24 +84,22 @@ describe('webSocketReducer', () => {
       const initialState: WebSocketState = {
         ...INITIAL_STATE,
         hrmData: [
-          {
-            ...baseUser,
+          createMockUser({
             value: 120,
             percentage: 60,
             lastUpdated: 1000,
-          },
+          }),
         ],
       }
 
       const payload: ServerHrmData[] = [
-        {
-          clientId: 'client-1',
+        createMockUser({
           value: 125,
           percentage: 65,
           zone: 2,
           updatedAt: 2000,
           calories: 105,
-        },
+        }),
       ]
 
       const message: ServerMessage = {
@@ -129,14 +127,14 @@ describe('webSocketReducer', () => {
       const initialState: WebSocketState = { ...INITIAL_STATE, hrmData: [] }
 
       const payload: ServerHrmData[] = [
-        {
+        createMockUser({
           clientId: 'client-2',
           value: 140,
           percentage: 75,
           zone: 3,
           updatedAt: 3000,
           calories: 50,
-        },
+        }),
       ]
 
       const message: ServerMessage = {
@@ -160,23 +158,22 @@ describe('webSocketReducer', () => {
       const initialState: WebSocketState = {
         ...INITIAL_STATE,
         hrmData: [
-          {
-            ...baseUser,
+          createMockUser({
             clientId: 'client-toremove',
             lastUpdated: 1000,
-          },
+          }),
         ],
       }
 
       const payload: ServerHrmData[] = [
-        {
+        createMockUser({
           clientId: 'client-new',
           value: 140,
           percentage: 75,
           zone: 3,
           updatedAt: 3000,
           calories: 50,
-        },
+        }),
       ]
 
       const message: ServerMessage = {
@@ -197,25 +194,24 @@ describe('webSocketReducer', () => {
       const initialState: WebSocketState = {
         ...INITIAL_STATE,
         hrmData: [
-          {
-            ...baseUser,
-            clientId: 'client-1',
+          createMockUser({
             name: 'Existing Name',
             lastUpdated: 1000,
-          },
+          }),
         ],
       }
 
-      const payload: ServerHrmData[] = [
-        {
-          clientId: 'client-1',
-          value: 125,
-          percentage: 65,
-          zone: 2,
-          updatedAt: 2000,
-          calories: 105,
-        },
-      ]
+      // We want to simulate a payload that does NOT have 'name', so we delete it.
+      const payloadItem = createMockUser({
+        value: 125,
+        percentage: 65,
+        zone: 2,
+        updatedAt: 2000,
+        calories: 105,
+      })
+      delete (payloadItem as any).name
+
+      const payload: ServerHrmData[] = [payloadItem]
 
       const message: ServerMessage = {
         type: 'HRM_UPDATE',
@@ -231,7 +227,7 @@ describe('webSocketReducer', () => {
 
   describe('DEVICE_OFFLINE action', () => {
     it('should remove the specified device from the state', () => {
-      const user2 = { ...baseUser, clientId: 'client-2', name: 'User B' }
+      const user2 = createMockUser({ clientId: 'client-2', name: 'User B' })
       const initialState: WebSocketState = {
         ...INITIAL_STATE,
         hrmData: [baseUser, user2],


### PR DESCRIPTION
## Description

This pull request refactors the `webSocketReducer` unit tests. The primary change involves updating `tests/unit/webSocketReducer.test.ts` to utilize a new `createMockUser` helper function. This helper standardizes default values and handles type casting for test-specific properties, significantly reducing duplication and improving readability in the test suite.

During the refactoring, a specific test case titled `should preserve existing client state properties` was identified and fixed. This test was previously failing due to an improper mock data setup that arose from the refactor itself.

Additionally, `types/websocket.ts` was verified to ensure there are no duplicate imports, maintaining code cleanliness.

Fixes #

## Change Type: 🏗️ Refactoring (code change that neither fixes bug nor adds feature)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [x] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [x] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

- Refactored `tests/unit/webSocketReducer.test.ts` to use `createMockUser` helper.
- Helper handles default values and type casting for test-specific properties.
- Fixed a specific test case (`should preserve existing client state properties`) which was failing due to improper mock data setup in the refactor.
- Verified `types/websocket.ts` has no duplicate imports.

---
*PR created automatically by Jules for task [9864059795359002230](https://jules.google.com/task/9864059795359002230) started by @arii*
</details>