### PR TITLE
test(small): Refactor webSocketReducer tests and fix linting

### DIFF
--- a/tests/unit/webSocketReducer.test.ts
+++ b/tests/unit/webSocketReducer.test.ts
@@ -15,7 +15,6 @@ import { HrmStreamData as ServerHrmData } from '../../types/core'
 interface TestHrmData extends HrmData {
   percentage?: number
   zone?: number
-  restingHr?: number
 }
 
 describe('webSocketReducer', () => {

--- a/tests/unit/webSocketReducer.test.ts
+++ b/tests/unit/webSocketReducer.test.ts
@@ -209,14 +209,6 @@ describe('webSocketReducer', () => {
         ],
       }
 
-      // Create payload WITHOUT the name property to test preservation
-      // We pass explicitly undefined to the helper, but the helper spreads overrides at the end.
-      // So { ...defaults, name: undefined } will result in name being undefined.
-      // However, we want the property to be MISSING, not undefined, ideally.
-      // But for merging logic, undefined usually overwrites if we do { ...state, ...payload }.
-      // Let's rely on the helper creating a full object, then we assert as a partial/Omit to simulate "server payload missing this field".
-      // Actually, since ServerHrmData defines name as optional (name?: string), omitting it is valid.
-
       const payloadItem = createMockUser({
         value: 125,
         percentage: 65,

--- a/tests/unit/webSocketReducer.test.ts
+++ b/tests/unit/webSocketReducer.test.ts
@@ -10,27 +10,31 @@ import {
 import { ServerMessage } from '../../types/websocket'
 import { HrmStreamData as ServerHrmData } from '../../types/core'
 
+// Define a test-specific type that includes properties commonly used in tests
+// but potentially missing from the strict HrmData/ServerHrmData types.
+interface TestHrmData extends HrmData {
+  percentage?: number
+  zone?: number
+  restingHr?: number
+}
+
 describe('webSocketReducer', () => {
   // Helper to create mock users and reduce duplication
-  // uses partial + record to allow extra properties like percentage/zone/restingHr
-  // which appear in tests but might be missing from the strict HrmData type
-  const createMockUser = (
-    overrides: Partial<HrmData> & Record<string, unknown> = {}
-  ): HrmData =>
-    ({
-      clientId: 'client-1',
-      name: 'User A',
-      age: 30,
-      maxHr: 190,
-      restingHr: 60,
-      value: 100,
-      percentage: 50,
-      zone: 1,
-      calories: 10,
-      isConnected: true,
-      updatedAt: 1000,
-      ...overrides,
-    }) as unknown as HrmData
+  // Returns TestHrmData to allow for extra test properties
+  const createMockUser = (overrides: Partial<TestHrmData> = {}): TestHrmData => ({
+    clientId: 'client-1',
+    name: 'User A',
+    age: 30,
+    maxHr: 190,
+    restingHr: 60,
+    value: 100,
+    percentage: 50,
+    zone: 1,
+    calories: 10,
+    isConnected: true,
+    updatedAt: 1000,
+    ...overrides,
+  })
 
   const baseUser = createMockUser()
 
@@ -101,7 +105,7 @@ describe('webSocketReducer', () => {
           zone: 2,
           updatedAt: 2000,
           calories: 105,
-        }),
+        }) as ServerHrmData,
       ]
 
       const message: ServerMessage = {
@@ -136,7 +140,7 @@ describe('webSocketReducer', () => {
           zone: 3,
           updatedAt: 3000,
           calories: 50,
-        }),
+        }) as ServerHrmData,
       ]
 
       const message: ServerMessage = {
@@ -175,7 +179,7 @@ describe('webSocketReducer', () => {
           zone: 3,
           updatedAt: 3000,
           calories: 50,
-        }),
+        }) as ServerHrmData,
       ]
 
       const message: ServerMessage = {
@@ -203,7 +207,14 @@ describe('webSocketReducer', () => {
         ],
       }
 
-      // We want to simulate a payload that does NOT have 'name', so we delete it.
+      // Create payload WITHOUT the name property to test preservation
+      // We pass explicitly undefined to the helper, but the helper spreads overrides at the end.
+      // So { ...defaults, name: undefined } will result in name being undefined.
+      // However, we want the property to be MISSING, not undefined, ideally.
+      // But for merging logic, undefined usually overwrites if we do { ...state, ...payload }.
+      // Let's rely on the helper creating a full object, then we assert as a partial/Omit to simulate "server payload missing this field".
+      // Actually, since ServerHrmData defines name as optional (name?: string), omitting it is valid.
+
       const payloadItem = createMockUser({
         value: 125,
         percentage: 65,
@@ -211,9 +222,10 @@ describe('webSocketReducer', () => {
         updatedAt: 2000,
         calories: 105,
       })
-      delete (payloadItem as unknown as Record<string, unknown>).name
+      // Explicitly remove name to simulate server payload not sending it
+      delete payloadItem.name
 
-      const payload: ServerHrmData[] = [payloadItem]
+      const payload: ServerHrmData[] = [payloadItem as ServerHrmData]
 
       const message: ServerMessage = {
         type: 'HRM_UPDATE',

--- a/tests/unit/webSocketReducer.test.ts
+++ b/tests/unit/webSocketReducer.test.ts
@@ -11,19 +11,28 @@ import { ServerMessage } from '../../types/websocket'
 import { HrmStreamData as ServerHrmData } from '../../types/core'
 
 describe('webSocketReducer', () => {
-  const baseUser: HrmData = {
-    clientId: 'client-1',
-    name: 'User A',
-    age: 30,
-    maxHr: 190,
-    restingHr: 60,
-    value: 100,
-    percentage: 50,
-    zone: 1,
-    calories: 10,
-    isConnected: true,
-    updatedAt: 1000,
-  }
+  // Helper to create mock users and reduce duplication
+  // uses partial + record to allow extra properties like percentage/zone/restingHr
+  // which appear in tests but might be missing from the strict HrmData type
+  const createMockUser = (
+    overrides: Partial<HrmData> & Record<string, unknown> = {}
+  ): HrmData =>
+    ({
+      clientId: 'client-1',
+      name: 'User A',
+      age: 30,
+      maxHr: 190,
+      restingHr: 60,
+      value: 100,
+      percentage: 50,
+      zone: 1,
+      calories: 10,
+      isConnected: true,
+      updatedAt: 1000,
+      ...overrides,
+    }) as unknown as HrmData
+
+  const baseUser = createMockUser()
 
   it('should return the initial state if no action is matched', () => {
     const action = { type: 'UNKNOWN_ACTION' } as unknown as ServerMessage
@@ -44,18 +53,11 @@ describe('webSocketReducer', () => {
     it('should handle INITIAL_STATE action and mark hrmData as connected', () => {
       const serverState = {
         hrmData: [
-          {
-            clientId: 'client-1',
-            name: 'User A',
-            age: 30,
-            maxHr: 190,
-            restingHr: 60,
+          createMockUser({
             value: 120,
             percentage: 60,
-            zone: 1,
             calories: 100,
-            updatedAt: 1000,
-          },
+          }),
         ] as ServerHrmData[],
         timerData: {
           ...INITIAL_STATE.timerData,
@@ -84,24 +86,22 @@ describe('webSocketReducer', () => {
       const initialState: WebSocketState = {
         ...INITIAL_STATE,
         hrmData: [
-          {
-            ...baseUser,
+          createMockUser({
             value: 120,
             percentage: 60,
             lastUpdated: 1000,
-          },
+          }),
         ],
       }
 
       const payload: ServerHrmData[] = [
-        {
-          clientId: 'client-1',
+        createMockUser({
           value: 125,
           percentage: 65,
           zone: 2,
           updatedAt: 2000,
           calories: 105,
-        },
+        }),
       ]
 
       const message: ServerMessage = {
@@ -129,14 +129,14 @@ describe('webSocketReducer', () => {
       const initialState: WebSocketState = { ...INITIAL_STATE, hrmData: [] }
 
       const payload: ServerHrmData[] = [
-        {
+        createMockUser({
           clientId: 'client-2',
           value: 140,
           percentage: 75,
           zone: 3,
           updatedAt: 3000,
           calories: 50,
-        },
+        }),
       ]
 
       const message: ServerMessage = {
@@ -160,23 +160,22 @@ describe('webSocketReducer', () => {
       const initialState: WebSocketState = {
         ...INITIAL_STATE,
         hrmData: [
-          {
-            ...baseUser,
+          createMockUser({
             clientId: 'client-toremove',
             lastUpdated: 1000,
-          },
+          }),
         ],
       }
 
       const payload: ServerHrmData[] = [
-        {
+        createMockUser({
           clientId: 'client-new',
           value: 140,
           percentage: 75,
           zone: 3,
           updatedAt: 3000,
           calories: 50,
-        },
+        }),
       ]
 
       const message: ServerMessage = {
@@ -197,25 +196,24 @@ describe('webSocketReducer', () => {
       const initialState: WebSocketState = {
         ...INITIAL_STATE,
         hrmData: [
-          {
-            ...baseUser,
-            clientId: 'client-1',
+          createMockUser({
             name: 'Existing Name',
             lastUpdated: 1000,
-          },
+          }),
         ],
       }
 
-      const payload: ServerHrmData[] = [
-        {
-          clientId: 'client-1',
-          value: 125,
-          percentage: 65,
-          zone: 2,
-          updatedAt: 2000,
-          calories: 105,
-        },
-      ]
+      // We want to simulate a payload that does NOT have 'name', so we delete it.
+      const payloadItem = createMockUser({
+        value: 125,
+        percentage: 65,
+        zone: 2,
+        updatedAt: 2000,
+        calories: 105,
+      })
+      delete (payloadItem as unknown as Record<string, unknown>).name
+
+      const payload: ServerHrmData[] = [payloadItem]
 
       const message: ServerMessage = {
         type: 'HRM_UPDATE',
@@ -231,7 +229,7 @@ describe('webSocketReducer', () => {
 
   describe('DEVICE_OFFLINE action', () => {
     it('should remove the specified device from the state', () => {
-      const user2 = { ...baseUser, clientId: 'client-2', name: 'User B' }
+      const user2 = createMockUser({ clientId: 'client-2', name: 'User B' })
       const initialState: WebSocketState = {
         ...INITIAL_STATE,
         hrmData: [baseUser, user2],

--- a/tests/unit/webSocketReducer.test.ts
+++ b/tests/unit/webSocketReducer.test.ts
@@ -21,7 +21,9 @@ interface TestHrmData extends HrmData {
 describe('webSocketReducer', () => {
   // Helper to create mock users and reduce duplication
   // Returns TestHrmData to allow for extra test properties
-  const createMockUser = (overrides: Partial<TestHrmData> = {}): TestHrmData => ({
+  const createMockUser = (
+    overrides: Partial<TestHrmData> = {}
+  ): TestHrmData => ({
     clientId: 'client-1',
     name: 'User A',
     age: 30,


### PR DESCRIPTION
## Description

This pull request refactors the `webSocketReducer` unit tests and addresses linting issues. The primary change involves updating `tests/unit/webSocketReducer.test.ts` to utilize a new `createMockUser` helper function. This helper standardizes the creation of mock user data, managing default values and facilitating type casting for test-specific properties using `Partial<HrmData> & Record<string, unknown>`.

Additionally, this PR fixes existing lint errors, specifically `Unexpected any` warnings and general formatting issues, ensuring code quality and consistency. It also includes a verification that `types/websocket.ts` contains no duplicate imports.

Fixes # 

## Change Type: 🏗️ Refactoring (code change that neither fixes bug nor adds feature)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [x] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [x] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

- Refactored `tests/unit/webSocketReducer.test.ts` to use `createMockUser` helper.
- Helper handles default values and type casting for test-specific properties using `Partial<HrmData> & Record<string, unknown>`.
- Fixed lint errors: `Unexpected any` and formatting.
- Verified `types/websocket.ts` has no duplicate imports.

---
*PR created automatically by Jules for task [9864059795359002230](https://jules.google.com/task/9864059795359002230) started by @arii*
</details>