### PR TITLE
test(small): fix: remove debug artifacts and improve test reliability

### DIFF
--- a/tests/playwright/hr-zone-distribution.spec.ts
+++ b/tests/playwright/hr-zone-distribution.spec.ts
@@ -20,6 +20,7 @@ test.describe('HR Zone Distribution Interactivity', () => {
   })
 
   test('should display zone distribution and show tooltip on hover', async () => {
+    test.setTimeout(60000)
     await dashboardPage.goto('/client/experimental')
     await waitForPageReady(dashboardPage)
     await waitForPageReady(mockPage)
@@ -53,9 +54,6 @@ test.describe('HR Zone Distribution Interactivity', () => {
     const zoneCard = dashboardPage.getByTestId('zone-distribution-card')
     await expect(zoneCard).toBeVisible({ timeout: 15000 })
 
-    // Debug: take screenshot of dashboard
-    await dashboardPage.screenshot({ path: 'dashboard-debug.png' })
-
     // Assert legend contains Peak zone
     const peakRow = dashboardPage.getByTestId('zone-row-Peak')
     await expect(peakRow).toBeVisible({ timeout: 10000 })
@@ -64,7 +62,7 @@ test.describe('HR Zone Distribution Interactivity', () => {
     // Pause workout and stop streaming to stabilize the chart for hover
     await dashboardPage.getByRole('button', { name: 'Pause' }).click()
     await mockPage.getByTestId('streaming-stop-button').click()
-    await dashboardPage.waitForTimeout(1000)
+    await expect(dashboardPage.getByRole('button', { name: 'Resume' })).toBeVisible()
 
     // Verify chart is rendered (has sectors)
     const sectors = dashboardPage
@@ -77,8 +75,5 @@ test.describe('HR Zone Distribution Interactivity', () => {
       name: /heart rate zone distribution chart/i,
     })
     await expect(chartRegion).toBeVisible()
-
-    // Take verification screenshot
-    await dashboardPage.screenshot({ path: 'final-verification.png' })
   })
 })


### PR DESCRIPTION
## Description

Refactored `tests/playwright/hr-zone-distribution.spec.ts` to remove debugging screenshots and replace flaky implicit timeouts with robust web-first assertions (checking for 'Resume' button visibility). This change aims to improve test reliability and stability.

Also verified unit tests for `ZoneDistribution` passed and confirmed that the allegedly redundant comments in `ZoneDistribution.test.tsx` were already absent.

Increased Playwright test timeout to 60s to accommodate slower CI environments, further enhancing test robustness.

Fixes # 

## Change Type: 🐛 Bug fix (non-breaking change fixing an issue)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [x] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [x] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

Refactored `tests/playwright/hr-zone-distribution.spec.ts` to remove debugging screenshots and replace flaky implicit timeouts with robust web-first assertions (checking for 'Resume' button visibility).

Also verified unit tests for `ZoneDistribution` passed and confirmed that the allegedly redundant comments in `ZoneDistribution.test.tsx` were already absent.

Increased Playwright test timeout to 60s to accommodate slower CI environments.

---
*PR created automatically by Jules for task [589191935327200183](https://jules.google.com/task/589191935327200183) started by @arii*
</details>