### PR TITLE
fix(ui): apply principal engineer feedback on HeartRateTimeSeries and types

### DIFF
--- a/app/client/experimental/components/HeartRateTimeSeries.tsx
+++ b/app/client/experimental/components/HeartRateTimeSeries.tsx
@@ -18,12 +18,8 @@ interface HeartRateTimeSeriesProps {
 }
 
 const timeFormatter = new Intl.DateTimeFormat(undefined, {
-  hour: 'numeric',
-  minute: 'numeric',
-  second: 'numeric',
+  timeStyle: 'medium',
 })
-
-const formatTime = (time: number) => timeFormatter.format(time)
 
 const HeartRateTimeSeries = ({ hrHistory }: HeartRateTimeSeriesProps) => {
   const theme = useTheme()
@@ -36,12 +32,12 @@ const HeartRateTimeSeries = ({ hrHistory }: HeartRateTimeSeriesProps) => {
         </Typography>
         <Box sx={{ height: 300 }} data-testid="hr-time-series-chart">
           <ResponsiveContainer width="100%" height="100%">
-            <LineChart data={hrHistory}>
+            <LineChart data={hrHistory} syncId="workout-metrics">
               <CartesianGrid
                 stroke={theme.palette.divider}
                 strokeDasharray="3 3"
               />
-              <XAxis dataKey="time" tickFormatter={formatTime} />
+              <XAxis dataKey="time" tickFormatter={timeFormatter.format} />
               <YAxis domain={['auto', 'auto']} />
               <Tooltip />
               <Legend />

--- a/tests/unit/app/client/experimental/components/HeartRateTimeSeries.test.tsx
+++ b/tests/unit/app/client/experimental/components/HeartRateTimeSeries.test.tsx
@@ -15,6 +15,48 @@ global.ResizeObserver = class ResizeObserver {
   disconnect() {}
 }
 
+// Mock Recharts to test props
+jest.mock('recharts', () => {
+  const OriginalModule = jest.requireActual('recharts')
+  return {
+    ...OriginalModule,
+    LineChart: ({
+      children,
+      syncId,
+      data,
+    }: {
+      children: React.ReactNode
+      syncId: string
+      data: unknown[]
+    }) => (
+      <div
+        data-testid="line-chart"
+        data-sync-id={syncId}
+        data-points={data.length}
+      >
+        {children}
+      </div>
+    ),
+    XAxis: ({
+      tickFormatter,
+      dataKey,
+    }: {
+      tickFormatter: (val: number) => string
+      dataKey: string
+    }) => (
+      <div data-testid="x-axis" data-key={dataKey}>
+        {/* Render a sample tick to verify formatter */}
+        {tickFormatter
+          ? tickFormatter(new Date('2023-01-01T10:00:00').getTime())
+          : null}
+      </div>
+    ),
+    ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+      <div>{children}</div>
+    ),
+  }
+})
+
 describe('HeartRateTimeSeries', () => {
   const mockHrHistory: HrDataPoint[] = [
     { time: new Date('2023-01-01T10:00:00').getTime(), hr: 60 },
@@ -30,8 +72,19 @@ describe('HeartRateTimeSeries', () => {
     expect(screen.getByText('Heart Rate Over Time')).toBeInTheDocument()
   })
 
-  it('renders with the correct data-testid', () => {
+  it('passes syncId="workout-metrics" to LineChart', () => {
     renderWithTheme(<HeartRateTimeSeries hrHistory={mockHrHistory} />)
-    expect(screen.getByTestId('hr-time-series-chart')).toBeInTheDocument()
+    const chart = screen.getByTestId('line-chart')
+    expect(chart).toHaveAttribute('data-sync-id', 'workout-metrics')
+  })
+
+  it('uses the correct time format in XAxis', () => {
+    renderWithTheme(<HeartRateTimeSeries hrHistory={mockHrHistory} />)
+    // The formatter uses { timeStyle: 'medium' }, which should output something like "10:00:00 AM" depending on locale.
+    // Since node environment locale might vary, we check if it renders *something* formatted.
+    // However, the test environment (jsdom) usually defaults to en-US.
+    // "10:00:00 AM" or "10:00:00"
+    const axis = screen.getByTestId('x-axis')
+    expect(axis).toHaveTextContent(/:00/) // Simple check for time format
   })
 })

--- a/types/mui.d.ts
+++ b/types/mui.d.ts
@@ -15,10 +15,6 @@ declare module '@mui/material/styles' {
     custom?: Partial<Palette['custom']>
   }
 
-  // NOTE: In MUI v5+, Theme['typography'] is defined as TypographyVariants
-  // We must extend TypographyVariants to add properties to theme.typography,
-  // even if they are just strings (not full variant objects).
-  // Although extending Typography is preferred, it's not exported by default in this version of MUI.
   interface TypographyVariants {
     fontFamilyMono: string
   }


### PR DESCRIPTION
## Description

This pull request addresses feedback from a Principal Engineer review (PR #6096).

Specifically, it involves:
- Removing verbose comments from `types/mui.d.ts` to improve code clarity.
- Refactoring the `HeartRateTimeSeries.tsx` component to utilize `Intl.DateTimeFormat` for a more concise date formatting solution.
- Restoring the `syncId='workout-metrics'` property in `HeartRateTimeSeries.tsx` to ensure proper cross-chart synchronization.

The motivation is to improve code maintainability and correctness based on expert feedback.

Fixes # (issue)

## Change Type: 🐛 Bug fix (non-breaking change fixing an issue)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [ ] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [ ] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

Addressed feedback from Principal Engineer review (PR #6096):
- Removed verbose comments from `types/mui.d.ts`.
- Refactored `HeartRateTimeSeries.tsx` to use `Intl.DateTimeFormat` (concise one-liner) and restored `syncId='workout-metrics'` for cross-chart synchronization.
- Verified build and lint checks.

---
*PR created automatically by Jules for task [14248543885355207589](https://jules.google.com/task/14248543885355207589) started by @arii*
</details>