### PR TITLE
test(small): Refactor WebSocketContext and fix flaky E2E test

### DIFF
--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -120,6 +120,7 @@ export const WebSocketProvider = ({
       process.env.NODE_ENV !== 'production' ||
       process.env.NEXT_PUBLIC_TESTING === 'true'
     ) {
+      // 1. Setup global controls
       ;(
         window as Window & { __TEST_CONTROLS__?: TestControls }
       ).__TEST_CONTROLS__ = {
@@ -127,13 +128,8 @@ export const WebSocketProvider = ({
         disconnect: () => {},
         connect: () => {},
       }
-    }
 
-    // Allow injecting messages via postMessage for E2E testing
-    if (
-      process.env.NODE_ENV !== 'production' ||
-      process.env.NEXT_PUBLIC_TESTING === 'true'
-    ) {
+      // 2. Setup message listener
       const handleMessage = (event: MessageEvent) => {
         if (event.source !== window || !event.data) return
 

--- a/tests/playwright/stale-tile.spec.ts
+++ b/tests/playwright/stale-tile.spec.ts
@@ -13,7 +13,10 @@ test.describe('Snapshot Synchronization', () => {
     await page.goto('/')
 
     // Wait for the page to be hydrated and listener attached
-    await page.waitForTimeout(1000)
+    await page.waitForFunction(
+      () =>
+        (window as unknown as { __TEST_CONTROLS__: unknown }).__TEST_CONTROLS__
+    )
 
     // 1. Simulate active data
     await dispatch(page, {


### PR DESCRIPTION
## Description

This PR refactors `WebSocketContext.tsx` and fixes a flaky E2E test, addressing directives to remove "AI slop" and improve E2E test reliability.

Specifically, it:
1.  **`context/WebSocketContext.tsx`**: Combines two identical `if (process.env.NODE_ENV !== 'production' ...)` blocks into a single block that sets up both global test controls and the `message` event listener.
2.  **`tests/playwright/stale-tile.spec.ts`**: Replaces `await page.waitForTimeout(1000)` with `await page.waitForFunction(() => (window as unknown as { __TEST_CONTROLS__: unknown }).__TEST_CONTROLS__)` to eliminate race conditions and ensure the test waits for the application to be fully initialized and ready to receive test commands.

Fixes # (issue)

## Change Type: 🐛 Bug fix (non-breaking change fixing an issue)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [x] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [x] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

This PR addresses the directives to remove "AI slop" and improve E2E test reliability.

Changes:
1.  **`context/WebSocketContext.tsx`**: Combined two identical `if (process.env.NODE_ENV !== 'production' ...)` blocks into a single block that sets up both global test controls and the `message` event listener.
2.  **`tests/playwright/stale-tile.spec.ts`**: Replaced `await page.waitForTimeout(1000)` with `await page.waitForFunction(() => (window as unknown as { __TEST_CONTROLS__: unknown }).__TEST_CONTROLS__)`. This eliminates race conditions by ensuring the test waits for the application to be fully initialized and ready to receive test commands.


---
*PR created automatically by Jules for task [3982628409866286911](https://jules.google.com/task/3982628409866286911) started by @arii*
</details>