### PR TITLE
test(medium): Refactor WebSocket types and tests for safety and clarity

### DIFF
--- a/tests/unit/socketManager.test.ts
+++ b/tests/unit/socketManager.test.ts
@@ -15,7 +15,7 @@ import {
   initSocketManager,
   resetSocketManager,
 } from '../../utils/socketManager'
-import { WebSocket, Server as WebSocketServer } from 'ws'
+import { WebSocket, WebSocketServer } from 'ws'
 import { TLSSocket } from 'tls'
 import TabataTimer from '../../services/tabataTimer'
 import { SpotifyPolling } from '../../services/spotifyPolling'
@@ -61,24 +61,32 @@ jest.mock('../../utils/logger.server.js', () => ({
 }))
 
 jest.mock('ws', () => {
-  const { EventEmitter } = jest.requireActual('events')
-  const { WebSocket: RealWebSocket } = jest.requireActual('ws')
+  const { EventEmitter } = jest.requireActual(
+    'events'
+  ) as typeof import('events')
 
-  class MockWebSocket extends RealWebSocket {
+  class MockWebSocket extends EventEmitter {
+    static CONNECTING = 0
+    static OPEN = 1
+    static CLOSING = 2
+    static CLOSED = 3
+
     clientId: string = ''
     isAlive: boolean = true
     clientType?: 'dashboard' | 'controller'
+    readyState: 0 | 1 | 2 | 3 = 1 // OPEN
+    binaryType: 'nodebuffer' | 'arraybuffer' | 'fragments' = 'nodebuffer'
+    bufferedAmount = 0
+    extensions = ''
+    protocol = ''
+    url = ''
+    onopen = null
+    onclose = null
+    onerror = null
+    onmessage = null
 
-    constructor(address: string) {
-      super(address || 'ws://test')
-      // Suppress connection errors from the underlying real WebSocket
-      this.on('error', () => {})
-      Object.defineProperty(this, 'readyState', {
-        get: () => 1, // OPEN
-        configurable: true,
-      })
-      this.on = jest.fn(this.on)
-      this.emit = jest.fn(this.emit)
+    constructor(_address: string) {
+      super()
     }
 
     send = jest.fn()
@@ -90,8 +98,7 @@ jest.mock('ws', () => {
   return {
     Server: jest.fn().mockImplementation(() => {
       const wss = new EventEmitter()
-      // @ts-expect-error: Assigning MockWebSocket set to WebSocket set (compatible at runtime)
-      wss.clients = new Set<MockWebSocket>()
+      wss.clients = new Set<MockWebSocket>() as unknown as Set<WebSocket>
       jest.spyOn(wss, 'on')
       jest.spyOn(wss, 'emit')
       return wss
@@ -324,7 +331,8 @@ describe('WebSocket Manager', () => {
       expect(mockBroadcast).toHaveBeenCalled()
       const lastCall =
         mockBroadcast.mock.calls[mockBroadcast.mock.calls.length - 1]
-      const finalPayload: HrmData[] = lastCall[1].payload
+      // @ts-expect-error: mocking
+      const finalPayload: HrmData[] = lastCall ? lastCall[1].payload : []
       const clientData = finalPayload.find((c) => c.clientId === 'test-client')
 
       expect(clientData).toBeDefined()
@@ -341,7 +349,8 @@ describe('WebSocket Manager', () => {
       let mockBroadcast = broadcast as jest.Mock
       let lastCall =
         mockBroadcast.mock.calls[mockBroadcast.mock.calls.length - 1]
-      let finalPayload: HrmData[] = lastCall[1].payload
+      // @ts-expect-error: mocking
+      let finalPayload: HrmData[] = lastCall ? lastCall[1].payload : []
       let clientData = finalPayload.find((c) => c.clientId === 'test-client')
       expect(clientData!.calories).toBe(10)
 
@@ -353,7 +362,8 @@ describe('WebSocket Manager', () => {
 
       mockBroadcast = broadcast as jest.Mock
       lastCall = mockBroadcast.mock.calls[mockBroadcast.mock.calls.length - 1]
-      finalPayload = lastCall[1].payload
+      // @ts-expect-error: mocking
+      finalPayload = lastCall ? lastCall[1].payload : []
       clientData = finalPayload.find((c) => c.clientId === 'test-client')
 
       expect(logger.warn).toHaveBeenCalledWith(
@@ -377,7 +387,8 @@ describe('WebSocket Manager', () => {
       const mockBroadcast = broadcast as jest.Mock
       const lastCall =
         mockBroadcast.mock.calls[mockBroadcast.mock.calls.length - 1]
-      const finalPayload: HrmData[] = lastCall[1].payload
+      // @ts-expect-error: mocking
+      const finalPayload: HrmData[] = lastCall ? lastCall[1].payload : []
       const clientData = finalPayload.find((c) => c.clientId === 'test-client')
 
       expect(logger.warn).toHaveBeenCalledWith(
@@ -413,7 +424,8 @@ describe('WebSocket Manager', () => {
       const mockBroadcast = broadcast as jest.Mock
       let lastCall =
         mockBroadcast.mock.calls[mockBroadcast.mock.calls.length - 1]
-      let finalPayload: HrmData[] = lastCall[1].payload
+      // @ts-expect-error: mocking
+      let finalPayload: HrmData[] = lastCall ? lastCall[1].payload : []
       let clientData = finalPayload.find((c) => c.clientId === 'test-client')
       expect(clientData!.calories).toBe(10)
 
@@ -426,7 +438,8 @@ describe('WebSocket Manager', () => {
       )
 
       lastCall = mockBroadcast.mock.calls[mockBroadcast.mock.calls.length - 1]
-      finalPayload = lastCall[1].payload
+      // @ts-expect-error: mocking
+      finalPayload = lastCall ? lastCall[1].payload : []
       clientData = finalPayload.find((c) => c.clientId === 'test-client')
 
       expect(clientData!.calories).toBe(11.5)
@@ -444,7 +457,8 @@ describe('WebSocket Manager', () => {
       const mockBroadcast = broadcast as jest.Mock
       let lastCall =
         mockBroadcast.mock.calls[mockBroadcast.mock.calls.length - 1]
-      let finalPayload: HrmData[] = lastCall[1].payload
+      // @ts-expect-error: mocking
+      let finalPayload: HrmData[] = lastCall ? lastCall[1].payload : []
       let clientData = finalPayload.find((c) => c.clientId === 'test-client')
       expect(clientData!.calories).toBe(25)
 
@@ -457,7 +471,8 @@ describe('WebSocket Manager', () => {
       )
 
       lastCall = mockBroadcast.mock.calls[mockBroadcast.mock.calls.length - 1]
-      finalPayload = lastCall[1].payload
+      // @ts-expect-error: mocking
+      finalPayload = lastCall ? lastCall[1].payload : []
       clientData = finalPayload.find((c) => c.clientId === 'test-client')
 
       expect(clientData!.calories).toBe(25)
@@ -481,6 +496,7 @@ describe('WebSocket Manager', () => {
 
       expect(getSnapshot).toHaveBeenCalled()
       expect(sendWebSocketMessage).toHaveBeenCalled()
+      // @ts-expect-error: mocking
       const sentData = (sendWebSocketMessage as jest.Mock).mock.calls[0][1]
       expect(sentData.type).toBe('INITIAL_STATE')
       expect(sentData.payload).toHaveProperty('timer')
@@ -617,7 +633,8 @@ describe('WebSocket Manager', () => {
       const mockBroadcast = broadcast as jest.Mock
       const lastCall =
         mockBroadcast.mock.calls[mockBroadcast.mock.calls.length - 1]
-      const payload: HrmData[] = lastCall[1].payload
+      // @ts-expect-error: mocking
+      const payload: HrmData[] = lastCall ? lastCall[1].payload : []
 
       expect(payload.length).toBe(1)
       expect(payload[0].clientId).toBe('test-client')
@@ -652,7 +669,8 @@ describe('WebSocket Manager', () => {
       const mockBroadcast = broadcast as jest.Mock
       const lastCall =
         mockBroadcast.mock.calls[mockBroadcast.mock.calls.length - 1]
-      const payload: HrmData[] = lastCall[1].payload
+      // @ts-expect-error: mocking
+      const payload: HrmData[] = lastCall ? lastCall[1].payload : []
 
       expect(payload.find((c) => c.clientId === clientId)).toBeDefined()
       expect(payload.find((c) => c.clientId === 'test-client')).toBeUndefined()

--- a/tests/unit/socketManager.test.ts
+++ b/tests/unit/socketManager.test.ts
@@ -15,7 +15,7 @@ import {
   initSocketManager,
   resetSocketManager,
 } from '../../utils/socketManager'
-import { WebSocket, WebSocketServer } from 'ws'
+import { WebSocket, Server as WebSocketServer } from 'ws'
 import { TLSSocket } from 'tls'
 import TabataTimer from '../../services/tabataTimer'
 import { SpotifyPolling } from '../../services/spotifyPolling'
@@ -24,6 +24,7 @@ import {
   StateSnapshot,
   ClientCommandMessageSchema,
   ExtWebSocket,
+  ServerMessage,
 } from '../../types/websocket'
 import {
   broadcast,
@@ -171,6 +172,20 @@ describe('WebSocket Manager', () => {
     mockWss.clients.clear()
     resetSocketManager()
   })
+
+  // Helper to extract the last broadcast payload safely
+  const getLastBroadcastPayload = (): HrmData[] => {
+    const mockBroadcast = broadcast as jest.Mock
+    const lastCall =
+      mockBroadcast.mock.calls[mockBroadcast.mock.calls.length - 1]
+    if (!lastCall) return []
+    // The second argument to broadcast is the message: { type: '...', payload: ... }
+    const message = lastCall[1] as ServerMessage
+    if (message.type === 'HRM_UPDATE') {
+      return message.payload
+    }
+    return []
+  }
 
   describe('Connection Logging', () => {
     it('should log connection metadata on new connection', () => {
@@ -329,10 +344,7 @@ describe('WebSocket Manager', () => {
 
       const mockBroadcast = broadcast as jest.Mock
       expect(mockBroadcast).toHaveBeenCalled()
-      const lastCall =
-        mockBroadcast.mock.calls[mockBroadcast.mock.calls.length - 1]
-      // @ts-expect-error: mocking
-      const finalPayload: HrmData[] = lastCall ? lastCall[1].payload : []
+      const finalPayload = getLastBroadcastPayload()
       const clientData = finalPayload.find((c) => c.clientId === 'test-client')
 
       expect(clientData).toBeDefined()
@@ -346,11 +358,7 @@ describe('WebSocket Manager', () => {
       })
       mockWs.emit('message', baselineMessage.toString())
 
-      let mockBroadcast = broadcast as jest.Mock
-      let lastCall =
-        mockBroadcast.mock.calls[mockBroadcast.mock.calls.length - 1]
-      // @ts-expect-error: mocking
-      let finalPayload: HrmData[] = lastCall ? lastCall[1].payload : []
+      let finalPayload = getLastBroadcastPayload()
       let clientData = finalPayload.find((c) => c.clientId === 'test-client')
       expect(clientData!.calories).toBe(10)
 
@@ -360,10 +368,7 @@ describe('WebSocket Manager', () => {
       })
       mockWs.emit('message', anomalyMessage.toString())
 
-      mockBroadcast = broadcast as jest.Mock
-      lastCall = mockBroadcast.mock.calls[mockBroadcast.mock.calls.length - 1]
-      // @ts-expect-error: mocking
-      finalPayload = lastCall ? lastCall[1].payload : []
+      finalPayload = getLastBroadcastPayload()
       clientData = finalPayload.find((c) => c.clientId === 'test-client')
 
       expect(logger.warn).toHaveBeenCalledWith(
@@ -384,11 +389,7 @@ describe('WebSocket Manager', () => {
       })
       mockWs.emit('message', initialAnomalyMessage.toString())
 
-      const mockBroadcast = broadcast as jest.Mock
-      const lastCall =
-        mockBroadcast.mock.calls[mockBroadcast.mock.calls.length - 1]
-      // @ts-expect-error: mocking
-      const finalPayload: HrmData[] = lastCall ? lastCall[1].payload : []
+      const finalPayload = getLastBroadcastPayload()
       const clientData = finalPayload.find((c) => c.clientId === 'test-client')
 
       expect(logger.warn).toHaveBeenCalledWith(
@@ -421,11 +422,7 @@ describe('WebSocket Manager', () => {
         })
       )
 
-      const mockBroadcast = broadcast as jest.Mock
-      let lastCall =
-        mockBroadcast.mock.calls[mockBroadcast.mock.calls.length - 1]
-      // @ts-expect-error: mocking
-      let finalPayload: HrmData[] = lastCall ? lastCall[1].payload : []
+      let finalPayload = getLastBroadcastPayload()
       let clientData = finalPayload.find((c) => c.clientId === 'test-client')
       expect(clientData!.calories).toBe(10)
 
@@ -437,9 +434,7 @@ describe('WebSocket Manager', () => {
         })
       )
 
-      lastCall = mockBroadcast.mock.calls[mockBroadcast.mock.calls.length - 1]
-      // @ts-expect-error: mocking
-      finalPayload = lastCall ? lastCall[1].payload : []
+      finalPayload = getLastBroadcastPayload()
       clientData = finalPayload.find((c) => c.clientId === 'test-client')
 
       expect(clientData!.calories).toBe(11.5)
@@ -454,11 +449,7 @@ describe('WebSocket Manager', () => {
         })
       )
 
-      const mockBroadcast = broadcast as jest.Mock
-      let lastCall =
-        mockBroadcast.mock.calls[mockBroadcast.mock.calls.length - 1]
-      // @ts-expect-error: mocking
-      let finalPayload: HrmData[] = lastCall ? lastCall[1].payload : []
+      let finalPayload = getLastBroadcastPayload()
       let clientData = finalPayload.find((c) => c.clientId === 'test-client')
       expect(clientData!.calories).toBe(25)
 
@@ -470,9 +461,7 @@ describe('WebSocket Manager', () => {
         })
       )
 
-      lastCall = mockBroadcast.mock.calls[mockBroadcast.mock.calls.length - 1]
-      // @ts-expect-error: mocking
-      finalPayload = lastCall ? lastCall[1].payload : []
+      finalPayload = getLastBroadcastPayload()
       clientData = finalPayload.find((c) => c.clientId === 'test-client')
 
       expect(clientData!.calories).toBe(25)
@@ -496,12 +485,19 @@ describe('WebSocket Manager', () => {
 
       expect(getSnapshot).toHaveBeenCalled()
       expect(sendWebSocketMessage).toHaveBeenCalled()
-      // @ts-expect-error: mocking
-      const sentData = (sendWebSocketMessage as jest.Mock).mock.calls[0][1]
-      expect(sentData.type).toBe('INITIAL_STATE')
-      expect(sentData.payload).toHaveProperty('timer')
-      expect(sentData.payload).toHaveProperty('spotify')
-      expect(sentData.payload).toHaveProperty('hrmData')
+      // Use explicit casting or assertion for mock calls if needed, but avoid 'as any' where possible
+      const mockSend = sendWebSocketMessage as jest.Mock
+      const lastCall = mockSend.mock.calls[0]
+      const sentData = lastCall ? (lastCall[1] as ServerMessage) : undefined
+
+      expect(sentData).toBeDefined()
+      if (sentData && sentData.type === 'INITIAL_STATE') {
+        expect(sentData.payload).toHaveProperty('timer')
+        expect(sentData.payload).toHaveProperty('spotify')
+        expect(sentData.payload).toHaveProperty('hrmData')
+      } else {
+        throw new Error('Expected INITIAL_STATE message')
+      }
     })
 
     it('should handle invalid JSON gracefully', () => {
@@ -630,11 +626,7 @@ describe('WebSocket Manager', () => {
         'Session expired. Deleting data.'
       )
 
-      const mockBroadcast = broadcast as jest.Mock
-      const lastCall =
-        mockBroadcast.mock.calls[mockBroadcast.mock.calls.length - 1]
-      // @ts-expect-error: mocking
-      const payload: HrmData[] = lastCall ? lastCall[1].payload : []
+      const payload = getLastBroadcastPayload()
 
       expect(payload.length).toBe(1)
       expect(payload[0].clientId).toBe('test-client')
@@ -666,11 +658,7 @@ describe('WebSocket Manager', () => {
       mockWs.emit('close')
       jest.runOnlyPendingTimers()
 
-      const mockBroadcast = broadcast as jest.Mock
-      const lastCall =
-        mockBroadcast.mock.calls[mockBroadcast.mock.calls.length - 1]
-      // @ts-expect-error: mocking
-      const payload: HrmData[] = lastCall ? lastCall[1].payload : []
+      const payload = getLastBroadcastPayload()
 
       expect(payload.find((c) => c.clientId === clientId)).toBeDefined()
       expect(payload.find((c) => c.clientId === 'test-client')).toBeUndefined()

--- a/tests/unit/webSocketReducer.test.ts
+++ b/tests/unit/webSocketReducer.test.ts
@@ -1,25 +1,18 @@
 /**
  * @jest-environment jsdom
  */
-import {
-  reducer,
-  INITIAL_STATE,
-  WebSocketState,
-  HrmData,
-} from '../../context/webSocketReducer'
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { reducer, INITIAL_STATE, HrmData } from '../../context/webSocketReducer'
 import { ServerMessage } from '../../types/websocket'
 import { HrmStreamData as ServerHrmData } from '../../types/core'
 
-// Define a test-specific type that includes properties commonly used in tests
-// but potentially missing from the strict HrmData/ServerHrmData types.
 interface TestHrmData extends HrmData {
   percentage?: number
   zone?: number
+  restingHr?: number
 }
 
 describe('webSocketReducer', () => {
-  // Helper to create mock users and reduce duplication
-  // Returns TestHrmData to allow for extra test properties
   const createMockUser = (
     overrides: Partial<TestHrmData> = {}
   ): TestHrmData => ({
@@ -37,234 +30,121 @@ describe('webSocketReducer', () => {
     ...overrides,
   })
 
-  const baseUser = createMockUser()
-
-  it('should return the initial state if no action is matched', () => {
-    const action = { type: 'UNKNOWN_ACTION' } as unknown as ServerMessage
-    const state = reducer(INITIAL_STATE, action)
-    expect(state).toEqual(INITIAL_STATE)
+  it('should return initial state for unknown action', () => {
+    const action = { type: 'UNKNOWN' } as unknown as ServerMessage
+    expect(reducer(INITIAL_STATE, action)).toEqual(INITIAL_STATE)
   })
 
-  it('should handle RESET_STATE action', () => {
-    const currentState: WebSocketState = {
-      ...INITIAL_STATE,
-      hrmData: [baseUser],
-    }
-    const state = reducer(currentState, { type: 'RESET_STATE' })
-    expect(state).toEqual(INITIAL_STATE)
+  it('should handle RESET_STATE', () => {
+    const state = { ...INITIAL_STATE, hrmData: [createMockUser()] }
+    expect(reducer(state, { type: 'RESET_STATE' })).toEqual(INITIAL_STATE)
   })
 
-  describe('INITIAL_STATE action', () => {
-    it('should handle INITIAL_STATE action and mark hrmData as connected', () => {
-      const serverState = {
-        hrmData: [
-          createMockUser({
-            value: 120,
-            percentage: 60,
-            calories: 100,
-          }),
-        ] as ServerHrmData[],
-        timerData: {
-          ...INITIAL_STATE.timerData,
-          isRunning: true,
-        },
-        spotifyData: {
+  describe('Simple State Updates', () => {
+    test.each([
+      [
+        'TIMER_UPDATE',
+        'timerData',
+        { timeRemaining: 20, isRunning: true },
+        { ...INITIAL_STATE.timerData, timeRemaining: 20, isRunning: true },
+      ],
+      [
+        'SPOTIFY_UPDATE',
+        'spotifyData',
+        { trackName: 'New Song', isPlaying: true },
+        {
           ...INITIAL_STATE.spotifyData,
-          trackName: 'Test Track',
+          trackName: 'New Song',
+          isPlaying: true,
         },
-      }
-
-      const action: ServerMessage = {
-        type: 'INITIAL_STATE',
-        payload: serverState,
-      }
+      ],
+      [
+        'ACTIVE_ALERTS_UPDATE',
+        'activeAlerts',
+        [{ code: 'HRM_STALE' }],
+        [{ code: 'HRM_STALE' }],
+      ],
+      ['SPOTIFY_SERVICE_INIT_UPDATE', 'spotifyServiceInitialized', true, true],
+    ])('should handle %s', (type, key, payload, expected) => {
+      const action = { type, payload } as unknown as ServerMessage
       const state = reducer(INITIAL_STATE, action)
+      // @ts-expect-error: mocking
+      expect(state[key]).toEqual(expected)
+    })
+  })
+
+  describe('Complex Actions', () => {
+    it('should handle INITIAL_STATE', () => {
+      const payload = {
+        hrmData: [createMockUser({ value: 120 })],
+        timerData: { ...INITIAL_STATE.timerData, isRunning: true },
+        spotifyData: { ...INITIAL_STATE.spotifyData, trackName: 'Test' },
+      }
+      const state = reducer(INITIAL_STATE, {
+        type: 'INITIAL_STATE',
+        payload: payload as any,
+      })
 
       expect(state.hrmData[0].isConnected).toBe(true)
       expect(state.timerData.isRunning).toBe(true)
-      expect(state.spotifyData.trackName).toBe('Test Track')
+      expect(state.spotifyData.trackName).toBe('Test')
     })
-  })
 
-  describe('HRM_UPDATE action', () => {
-    it('should handle HRM_UPDATE by merging new data with existing state', () => {
-      const initialState: WebSocketState = {
+    it('should handle DEVICE_OFFLINE', () => {
+      const state = {
         ...INITIAL_STATE,
-        hrmData: [
-          createMockUser({
-            value: 120,
-            percentage: 60,
-            lastUpdated: 1000,
-          }),
-        ],
+        hrmData: [createMockUser(), createMockUser({ clientId: 'client-2' })],
       }
-
-      const payload: ServerHrmData[] = [
-        createMockUser({
-          value: 125,
-          percentage: 65,
-          zone: 2,
-          updatedAt: 2000,
-          calories: 105,
-        }) as ServerHrmData,
-      ]
-
-      const message: ServerMessage = {
-        type: 'HRM_UPDATE',
-        payload: payload,
-      }
-
-      const newState = reducer(initialState, message)
-
-      expect(newState.hrmData).toHaveLength(1)
-      expect(newState.hrmData[0]).toEqual(
-        expect.objectContaining({
-          clientId: 'client-1',
-          value: 125,
-          percentage: 65,
-          zone: 2,
-          updatedAt: 2000,
-          isConnected: true,
-        })
-      )
-      expect(newState.hrmData[0].lastUpdated).toBeGreaterThan(1000)
-    })
-
-    it('should handle HRM_UPDATE by adding new clients', () => {
-      const initialState: WebSocketState = { ...INITIAL_STATE, hrmData: [] }
-
-      const payload: ServerHrmData[] = [
-        createMockUser({
-          clientId: 'client-2',
-          value: 140,
-          percentage: 75,
-          zone: 3,
-          updatedAt: 3000,
-          calories: 50,
-        }) as ServerHrmData,
-      ]
-
-      const message: ServerMessage = {
-        type: 'HRM_UPDATE',
-        payload: payload,
-      }
-
-      const newState = reducer(initialState, message)
-
-      expect(newState.hrmData).toHaveLength(1)
-      expect(newState.hrmData[0]).toEqual(
-        expect.objectContaining({
-          clientId: 'client-2',
-          value: 140,
-          isConnected: true,
-        })
-      )
-    })
-
-    it('should handle HRM_UPDATE by removing clients not present in the payload', () => {
-      const initialState: WebSocketState = {
-        ...INITIAL_STATE,
-        hrmData: [
-          createMockUser({
-            clientId: 'client-toremove',
-            lastUpdated: 1000,
-          }),
-        ],
-      }
-
-      const payload: ServerHrmData[] = [
-        createMockUser({
-          clientId: 'client-new',
-          value: 140,
-          percentage: 75,
-          zone: 3,
-          updatedAt: 3000,
-          calories: 50,
-        }) as ServerHrmData,
-      ]
-
-      const message: ServerMessage = {
-        type: 'HRM_UPDATE',
-        payload: payload,
-      }
-
-      const newState = reducer(initialState, message)
-
-      expect(newState.hrmData).toHaveLength(1)
-      expect(newState.hrmData[0].clientId).toBe('client-new')
-      expect(
-        newState.hrmData.find((c) => c.clientId === 'client-toremove')
-      ).toBeUndefined()
-    })
-
-    it('should preserve existing client state properties not present in payload if merging', () => {
-      const initialState: WebSocketState = {
-        ...INITIAL_STATE,
-        hrmData: [
-          createMockUser({
-            name: 'Existing Name',
-            lastUpdated: 1000,
-          }),
-        ],
-      }
-
-      const payloadItem = createMockUser({
-        value: 125,
-        percentage: 65,
-        zone: 2,
-        updatedAt: 2000,
-        calories: 105,
-      })
-      // Explicitly remove name to simulate server payload not sending it
-      delete payloadItem.name
-
-      const payload: ServerHrmData[] = [payloadItem as ServerHrmData]
-
-      const message: ServerMessage = {
-        type: 'HRM_UPDATE',
-        payload: payload,
-      }
-
-      const newState = reducer(initialState, message)
-
-      expect(newState.hrmData[0].name).toBe('Existing Name')
-      expect(newState.hrmData[0].value).toBe(125)
-    })
-  })
-
-  describe('DEVICE_OFFLINE action', () => {
-    it('should remove the specified device from the state', () => {
-      const user2 = createMockUser({ clientId: 'client-2', name: 'User B' })
-      const initialState: WebSocketState = {
-        ...INITIAL_STATE,
-        hrmData: [baseUser, user2],
-      }
-      const action: ServerMessage = {
+      const newState = reducer(state, {
         type: 'DEVICE_OFFLINE',
         payload: { deviceId: 'client-1' },
-      }
-      const state = reducer(initialState, action)
-      expect(state.hrmData).toHaveLength(1)
-      expect(
-        state.hrmData.find((d) => d.clientId === 'client-1')
-      ).toBeUndefined()
-      expect(state.hrmData[0].clientId).toBe('client-2')
+      })
+      expect(newState.hrmData).toHaveLength(1)
+      expect(newState.hrmData[0].clientId).toBe('client-2')
     })
   })
 
-  it('should handle TIMER_UPDATE action', () => {
-    const payload = { timeRemaining: 20, isRunning: true }
-    const action: ServerMessage = { type: 'TIMER_UPDATE', payload }
-    const state = reducer(INITIAL_STATE, action)
-    expect(state.timerData.timeRemaining).toBe(20)
-    expect(state.timerData.isRunning).toBe(true)
-  })
+  describe('HRM_UPDATE Logic', () => {
+    it('should merge, add, and remove clients correctly', () => {
+      const initialState = {
+        ...INITIAL_STATE,
+        hrmData: [
+          createMockUser({ clientId: 'c1', value: 100, name: 'Keep Me' }),
+          createMockUser({ clientId: 'c2', value: 100 }), // To be removed
+        ],
+      }
 
-  it('should handle SPOTIFY_UPDATE action', () => {
-    const payload = { trackName: 'New Song', isPlaying: true }
-    const action: ServerMessage = { type: 'SPOTIFY_UPDATE', payload }
-    const state = reducer(INITIAL_STATE, action)
-    expect(state.spotifyData.trackName).toBe('New Song')
-    expect(state.spotifyData.isPlaying).toBe(true)
+      const payload = [
+        createMockUser({ clientId: 'c1', value: 110 }), // Update
+        createMockUser({ clientId: 'c3', value: 120 }), // Add
+      ]
+      // Simulate partial update for c1 (server might not send name)
+      delete (payload[0] as any).name
+
+      const state = reducer(initialState, {
+        type: 'HRM_UPDATE',
+        payload: payload as ServerHrmData[],
+      })
+
+      expect(state.hrmData).toHaveLength(2)
+
+      // Check Update + Merge (name preserved)
+      const c1 = state.hrmData.find((d) => d.clientId === 'c1')
+      expect(c1).toBeDefined()
+      expect(c1!).toMatchObject({
+        value: 110,
+        name: 'Keep Me',
+        isConnected: true,
+      })
+      expect(c1!.lastUpdated).toBeGreaterThan(0)
+
+      // Check Add
+      const c3 = state.hrmData.find((d) => d.clientId === 'c3')
+      expect(c3).toBeDefined()
+      expect(c3!).toMatchObject({ value: 120, isConnected: true })
+
+      // Check Remove
+      expect(state.hrmData.find((d) => d.clientId === 'c2')).toBeUndefined()
+    })
   })
 })

--- a/tests/unit/webSocketReducer.test.ts
+++ b/tests/unit/webSocketReducer.test.ts
@@ -1,9 +1,11 @@
 /**
  * @jest-environment jsdom
  */
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { reducer, INITIAL_STATE, HrmData } from '../../context/webSocketReducer'
-import { ServerMessage } from '../../types/websocket'
+import {
+  InitialStateSnapshotPayload,
+  ServerMessage,
+} from '../../types/websocket'
 import { HrmStreamData as ServerHrmData } from '../../types/core'
 
 interface TestHrmData extends HrmData {
@@ -68,21 +70,21 @@ describe('webSocketReducer', () => {
     ])('should handle %s', (type, key, payload, expected) => {
       const action = { type, payload } as unknown as ServerMessage
       const state = reducer(INITIAL_STATE, action)
-      // @ts-expect-error: mocking
+      // @ts-expect-error: mocking dynamic key access for test brevity
       expect(state[key]).toEqual(expected)
     })
   })
 
   describe('Complex Actions', () => {
     it('should handle INITIAL_STATE', () => {
-      const payload = {
+      const payload: InitialStateSnapshotPayload = {
         hrmData: [createMockUser({ value: 120 })],
         timerData: { ...INITIAL_STATE.timerData, isRunning: true },
         spotifyData: { ...INITIAL_STATE.spotifyData, trackName: 'Test' },
       }
       const state = reducer(INITIAL_STATE, {
         type: 'INITIAL_STATE',
-        payload: payload as any,
+        payload,
       })
 
       expect(state.hrmData[0].isConnected).toBe(true)
@@ -114,16 +116,18 @@ describe('webSocketReducer', () => {
         ],
       }
 
-      const payload = [
-        createMockUser({ clientId: 'c1', value: 110 }), // Update
+      // Simulate partial update for c1 (server might not send name)
+      const c1Payload = createMockUser({ clientId: 'c1', value: 110 })
+      delete c1Payload.name
+
+      const payload: ServerHrmData[] = [
+        c1Payload, // Update
         createMockUser({ clientId: 'c3', value: 120 }), // Add
       ]
-      // Simulate partial update for c1 (server might not send name)
-      delete (payload[0] as any).name
 
       const state = reducer(initialState, {
         type: 'HRM_UPDATE',
-        payload: payload as ServerHrmData[],
+        payload,
       })
 
       expect(state.hrmData).toHaveLength(2)

--- a/tests/unit/websocketUtils.test.ts
+++ b/tests/unit/websocketUtils.test.ts
@@ -1,7 +1,6 @@
 /**
  * @jest-environment node
  */
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import {
   afterEach,
   beforeEach,
@@ -10,7 +9,7 @@ import {
   it,
   jest,
 } from '@jest/globals'
-import { WebSocketServer } from 'ws'
+import { Server as WebSocketServer } from 'ws'
 import { EventEmitter } from 'events'
 import { ConnectionMonitor } from '../../utils/websocketUtils'
 import logger from '@/utils/logger.server'
@@ -30,7 +29,8 @@ jest.mock('@/utils/logger.server', () => ({
 jest.mock('ws', () => ({
   Server: jest.fn().mockImplementation(() => {
     const wss = new EventEmitter() as jest.Mocked<WebSocketServer>
-    wss.clients = new Set<MockWebSocket>() as any
+    // In tests, we use MockWebSocket but force it to be compatible with WebSocket type
+    wss.clients = new Set<MockWebSocket>() as unknown as Set<WebSocket>
     return wss
   }),
   WebSocket: jest.fn(),
@@ -69,7 +69,9 @@ describe('ConnectionMonitor', () => {
   })
 
   afterEach(() => {
-    connectionMonitor.stop()
+    if (connectionMonitor) {
+      connectionMonitor.stop()
+    }
     jest.useRealTimers()
     jest.clearAllMocks()
     ;(mockWss.clients as unknown as Set<MockWebSocket>).clear()
@@ -104,7 +106,7 @@ describe('ConnectionMonitor', () => {
     connectionMonitor = new ConnectionMonitor(mockWss, WATCHDOG_INTERVAL)
     const unresponsiveClient = new MockWebSocket()
     unresponsiveClient.isAlive = false // Simulate a client that missed a pong
-    ;(mockWss.clients as any).add(unresponsiveClient)
+    ;(mockWss.clients as unknown as Set<MockWebSocket>).add(unresponsiveClient)
 
     connectionMonitor.start()
     jest.advanceTimersByTime(WATCHDOG_INTERVAL)
@@ -120,7 +122,7 @@ describe('ConnectionMonitor', () => {
     connectionMonitor = new ConnectionMonitor(mockWss, WATCHDOG_INTERVAL)
     const responsiveClient = new MockWebSocket()
     responsiveClient.isAlive = true
-    ;(mockWss.clients as any).add(responsiveClient)
+    ;(mockWss.clients as unknown as Set<MockWebSocket>).add(responsiveClient)
 
     connectionMonitor.start()
     jest.advanceTimersByTime(WATCHDOG_INTERVAL)
@@ -132,7 +134,7 @@ describe('ConnectionMonitor', () => {
     connectionMonitor = new ConnectionMonitor(mockWss, WATCHDOG_INTERVAL)
     const activeClient = new MockWebSocket()
     activeClient.isAlive = true
-    ;(mockWss.clients as any).add(activeClient)
+    ;(mockWss.clients as unknown as Set<MockWebSocket>).add(activeClient)
 
     connectionMonitor.start()
     jest.advanceTimersByTime(WATCHDOG_INTERVAL)
@@ -148,9 +150,9 @@ describe('ConnectionMonitor', () => {
     const client3 = new MockWebSocket() // Responsive
 
     client2.isAlive = false
-    ;(mockWss.clients as any).add(client1)
-    ;(mockWss.clients as any).add(client2)
-    ;(mockWss.clients as any).add(client3)
+    ;(mockWss.clients as unknown as Set<MockWebSocket>).add(client1)
+    ;(mockWss.clients as unknown as Set<MockWebSocket>).add(client2)
+    ;(mockWss.clients as unknown as Set<MockWebSocket>).add(client3)
 
     connectionMonitor.start()
     jest.advanceTimersByTime(WATCHDOG_INTERVAL)

--- a/tests/unit/websocketUtils.test.ts
+++ b/tests/unit/websocketUtils.test.ts
@@ -1,6 +1,7 @@
 /**
  * @jest-environment node
  */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import {
   afterEach,
   beforeEach,
@@ -9,11 +10,10 @@ import {
   it,
   jest,
 } from '@jest/globals'
-import { Server as WebSocketServer } from 'ws'
+import { WebSocketServer } from 'ws'
 import { EventEmitter } from 'events'
 import { ConnectionMonitor } from '../../utils/websocketUtils'
 import logger from '@/utils/logger.server'
-import { ExtWebSocket } from '@/types/websocket'
 
 // Mock the logger to prevent console output during tests
 jest.mock('@/utils/logger.server', () => ({
@@ -30,13 +30,13 @@ jest.mock('@/utils/logger.server', () => ({
 jest.mock('ws', () => ({
   Server: jest.fn().mockImplementation(() => {
     const wss = new EventEmitter() as jest.Mocked<WebSocketServer>
-    wss.clients = new Set<MockWebSocket>()
+    wss.clients = new Set<MockWebSocket>() as any
     return wss
   }),
   WebSocket: jest.fn(),
 }))
 
-class MockWebSocket extends EventEmitter implements Partial<ExtWebSocket> {
+class MockWebSocket extends EventEmitter {
   isAlive = true
   clientId = `test-client-${Math.random()}`
   terminate = jest.fn()
@@ -44,20 +44,20 @@ class MockWebSocket extends EventEmitter implements Partial<ExtWebSocket> {
   pong = (): void => {}
   send = (): void => {}
   close = (): void => {}
-  readyState = 1
-  CONNECTING = 0
-  OPEN = 1
-  CLOSING = 2
-  CLOSED = 3
-  binaryType = 'nodebuffer'
+  readyState: 0 | 1 | 2 | 3 = 1
+  CONNECTING = 0 as const
+  OPEN = 1 as const
+  CLOSING = 2 as const
+  CLOSED = 3 as const
+  binaryType: 'nodebuffer' | 'arraybuffer' | 'fragments' = 'nodebuffer'
 }
 
 describe('ConnectionMonitor', () => {
   let mockWss: jest.Mocked<WebSocketServer>
   let connectionMonitor: ConnectionMonitor
   const WATCHDOG_INTERVAL = 5000 // Use a shorter interval for testing
-  let setIntervalSpy: jest.SpyInstance
-  let clearIntervalSpy: jest.SpyInstance
+  let setIntervalSpy: ReturnType<typeof jest.spyOn>
+  let clearIntervalSpy: ReturnType<typeof jest.spyOn>
 
   beforeEach(() => {
     jest.useFakeTimers()
@@ -72,7 +72,7 @@ describe('ConnectionMonitor', () => {
     connectionMonitor.stop()
     jest.useRealTimers()
     jest.clearAllMocks()
-    ;(mockWss.clients as Set<MockWebSocket>).clear()
+    ;(mockWss.clients as unknown as Set<MockWebSocket>).clear()
     setIntervalSpy.mockRestore()
     clearIntervalSpy.mockRestore()
   })
@@ -104,7 +104,7 @@ describe('ConnectionMonitor', () => {
     connectionMonitor = new ConnectionMonitor(mockWss, WATCHDOG_INTERVAL)
     const unresponsiveClient = new MockWebSocket()
     unresponsiveClient.isAlive = false // Simulate a client that missed a pong
-    ;(mockWss.clients as Set<MockWebSocket>).add(unresponsiveClient)
+    ;(mockWss.clients as any).add(unresponsiveClient)
 
     connectionMonitor.start()
     jest.advanceTimersByTime(WATCHDOG_INTERVAL)
@@ -120,7 +120,7 @@ describe('ConnectionMonitor', () => {
     connectionMonitor = new ConnectionMonitor(mockWss, WATCHDOG_INTERVAL)
     const responsiveClient = new MockWebSocket()
     responsiveClient.isAlive = true
-    ;(mockWss.clients as Set<MockWebSocket>).add(responsiveClient)
+    ;(mockWss.clients as any).add(responsiveClient)
 
     connectionMonitor.start()
     jest.advanceTimersByTime(WATCHDOG_INTERVAL)
@@ -132,7 +132,7 @@ describe('ConnectionMonitor', () => {
     connectionMonitor = new ConnectionMonitor(mockWss, WATCHDOG_INTERVAL)
     const activeClient = new MockWebSocket()
     activeClient.isAlive = true
-    ;(mockWss.clients as Set<MockWebSocket>).add(activeClient)
+    ;(mockWss.clients as any).add(activeClient)
 
     connectionMonitor.start()
     jest.advanceTimersByTime(WATCHDOG_INTERVAL)
@@ -148,9 +148,9 @@ describe('ConnectionMonitor', () => {
     const client3 = new MockWebSocket() // Responsive
 
     client2.isAlive = false
-    ;(mockWss.clients as Set<MockWebSocket>).add(client1)
-    ;(mockWss.clients as Set<MockWebSocket>).add(client2)
-    ;(mockWss.clients as Set<MockWebSocket>).add(client3)
+    ;(mockWss.clients as any).add(client1)
+    ;(mockWss.clients as any).add(client2)
+    ;(mockWss.clients as any).add(client3)
 
     connectionMonitor.start()
     jest.advanceTimersByTime(WATCHDOG_INTERVAL)

--- a/types/websocket.ts
+++ b/types/websocket.ts
@@ -54,9 +54,7 @@ export const SpotifyCommandSchema = z.union([
   z.literal('GET_DEVICES'),
 ])
 
-export const SpotifyCommandMessageSchema = z.object({
-  type: z.literal('SPOTIFY_COMMAND'),
-  command: SpotifyCommandSchema,
+export const SpotifyCommandParametersSchema = z.object({
   deviceId: z.string().optional(),
   volume: z.number().min(0).max(100).optional(),
   playlistUri: z.string().optional(),
@@ -68,6 +66,12 @@ export const SpotifyCommandMessageSchema = z.object({
     })
     .optional(),
 })
+
+export const SpotifyCommandMessageSchema =
+  SpotifyCommandParametersSchema.extend({
+    type: z.literal('SPOTIFY_COMMAND'),
+    command: SpotifyCommandSchema,
+  })
 
 export const GetStateMessageSchema = z.object({
   type: z.literal('GET_STATE'),
@@ -99,6 +103,112 @@ export const ClientCommandMessageSchema = z.discriminatedUnion('type', [
   PingMessageSchema,
 ])
 
+// --- Server Message Schemas ---
+
+export const HrmStreamDataSchema = z.object({
+  clientId: z.string(),
+  value: z.number(),
+  maxHr: z.number(),
+  name: z.string().optional(),
+  age: z.number().optional(),
+  calories: z.number(),
+  weightKg: z.number().optional(),
+  updatedAt: z.number().optional(),
+})
+
+export const TimerPhaseSchema = z.enum([
+  'IDLE',
+  'PREPARE',
+  'WORK',
+  'REST',
+  'COOLDOWN',
+  'RUNNING',
+])
+export const TimerModeSchema = z.enum(['STOPWATCH', 'TABATA'])
+
+export const TimerDataSchema = z.object({
+  isRunning: z.boolean(),
+  currentPhase: TimerPhaseSchema,
+  timeRemaining: z.number(),
+  timeElapsed: z.number(),
+  caloriesBurned: z.number(),
+  mode: TimerModeSchema,
+  workDuration: z.number(),
+  restDuration: z.number(),
+  soundToPlay: z.enum(['WORK', 'REST', 'COUNTDOWN']).optional(),
+  soundEventId: z.number(),
+})
+
+export const SpotifyDeviceSchema = z.object({
+  id: z.string(),
+  is_active: z.boolean(),
+  is_private_session: z.boolean(),
+  is_restricted: z.boolean(),
+  name: z.string(),
+  type: z.string(),
+  volume_percent: z.number(),
+})
+
+export const SpotifyPlaybackStateSchema = z.object({
+  trackId: z.string().nullable(),
+  trackName: z.string(),
+  artist: z.string(),
+  albumName: z.string(),
+  albumArtUrl: z.string(),
+  isPlaying: z.boolean(),
+  devices: z.array(SpotifyDeviceSchema),
+  volume: z.number(),
+  isMuted: z.boolean(),
+})
+
+export const ActiveAlertSchema = z.object({
+  clientId: z.string(),
+  code: z.enum(['HRM_STALE', 'BAD_PLACEMENT']),
+  message: z.string(),
+  severity: z.enum(['warning', 'error']),
+  timestamp: z.number(),
+})
+
+export const InitialStateSnapshotPayloadSchema = z.object({
+  hrmData: z.array(HrmStreamDataSchema),
+  timerData: TimerDataSchema,
+  spotifyData: SpotifyPlaybackStateSchema,
+  spotifyServiceInitialized: z.boolean().optional(),
+})
+
+export const ServerMessageSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('INITIAL_STATE'),
+    payload: InitialStateSnapshotPayloadSchema,
+  }),
+  z.object({
+    type: z.literal('HRM_UPDATE'),
+    payload: z.array(HrmStreamDataSchema),
+  }),
+  z.object({ type: z.literal('TIMER_UPDATE'), payload: TimerDataSchema }),
+  z.object({
+    type: z.literal('SPOTIFY_UPDATE'),
+    payload: SpotifyPlaybackStateSchema,
+  }),
+  z.object({
+    type: z.literal('ACTIVE_ALERTS_UPDATE'),
+    payload: z.array(ActiveAlertSchema),
+  }),
+  z.object({
+    type: z.literal('SPOTIFY_SERVICE_INIT_UPDATE'),
+    payload: z.boolean(),
+  }),
+  z.object({ type: z.literal('PONG') }),
+  z.object({
+    type: z.literal('DEVICE_OFFLINE'),
+    payload: z.object({ deviceId: z.string() }),
+  }),
+  z.object({
+    type: z.literal('EXECUTE_SPOTIFY'),
+    payload: SpotifyCommandMessageSchema,
+  }),
+])
+
 // --- WebSocket Connection & Augmentation ---
 
 export interface ExtWebSocket extends WebSocket {
@@ -123,6 +233,9 @@ export type TimerModeCommandMessage = z.infer<
 >
 export type TimerConfigMessage = z.infer<typeof TimerConfigMessageSchema>
 export type SpotifyCommand = z.infer<typeof SpotifyCommandSchema>
+export type SpotifyCommandParameters = z.infer<
+  typeof SpotifyCommandParametersSchema
+>
 export type SpotifyCommandMessage = z.infer<typeof SpotifyCommandMessageSchema>
 export type GetStateMessage = z.infer<typeof GetStateMessageSchema>
 export type ClientRegistrationMessage = z.infer<
@@ -137,33 +250,12 @@ export interface SpotifyExecutionMessage {
   payload: SpotifyCommandMessage
 }
 
-export interface InitialStateSnapshotPayload {
-  hrmData: HrmData[]
-  timerData: TimerData
-  spotifyData: SpotifyData
-  spotifyServiceInitialized?: boolean
-}
+export type InitialStateSnapshotPayload = z.infer<
+  typeof InitialStateSnapshotPayloadSchema
+>
 
 export type StateSnapshot = Omit<InitialStateSnapshotPayload, 'hrmData'>
 
-export interface ActiveAlert {
-  clientId: string
-  code: 'HRM_STALE' | 'BAD_PLACEMENT'
-  message: string
-  severity: 'warning' | 'error'
-  timestamp: number
-}
+export type ActiveAlert = z.infer<typeof ActiveAlertSchema>
 
-export type ServerMessage =
-  | {
-      type: 'INITIAL_STATE'
-      payload: InitialStateSnapshotPayload
-    }
-  | { type: 'HRM_UPDATE'; payload: HrmData[] }
-  | { type: 'TIMER_UPDATE'; payload: TimerData }
-  | { type: 'SPOTIFY_UPDATE'; payload: SpotifyData }
-  | { type: 'ACTIVE_ALERTS_UPDATE'; payload: ActiveAlert[] }
-  | { type: 'SPOTIFY_SERVICE_INIT_UPDATE'; payload: boolean }
-  | { type: 'PONG' }
-  | { type: 'DEVICE_OFFLINE'; payload: { deviceId: string } }
-  | SpotifyExecutionMessage
+export type ServerMessage = z.infer<typeof ServerMessageSchema>

--- a/utils/socketManager.ts
+++ b/utils/socketManager.ts
@@ -33,6 +33,7 @@ let getUnifiedStateSnapshot: () => StateSnapshot
 let wsServerInstance: WebSocketServer
 let connectionMonitor: ConnectionMonitor
 let services: AppServices
+let staleCheckInterval: NodeJS.Timeout | undefined
 
 // State Management:
 // - hrmDataStore: Stores the live HRM data for each client (e.g., HR value, calories). This is the primary source of truth for broadcasted state.
@@ -123,7 +124,8 @@ const initSocketManager = (
   connectionMonitor = new ConnectionMonitor(wss)
   connectionMonitor.start()
 
-  setInterval(() => {
+  if (staleCheckInterval) clearInterval(staleCheckInterval)
+  staleCheckInterval = setInterval(() => {
     const now = Date.now()
     for (const [clientId, session] of clientSessionState.entries()) {
       if (now - session.lastUpdate > STALE_THRESHOLD_MS) {
@@ -218,6 +220,10 @@ const initSocketManager = (
 
   wss.on('close', () => {
     connectionMonitor.stop()
+    if (staleCheckInterval) {
+      clearInterval(staleCheckInterval)
+      staleCheckInterval = undefined
+    }
   })
 }
 
@@ -227,6 +233,10 @@ const initSocketManager = (
 export const resetSocketManager = () => {
   hrmDataStore.clear()
   clientSessionState.clear()
+  if (staleCheckInterval) {
+    clearInterval(staleCheckInterval)
+    staleCheckInterval = undefined
+  }
 }
 
 const broadcastState = () => {


### PR DESCRIPTION
## Description

This pull request focuses on refactoring WebSocket-related types and tests to enhance safety, clarity, and maintainability, directly addressing directives from a Principal Engineer audit to repair PR #6653.

**Key Changes include:**
*   **Safe WebSocket Mocking:** `MockWebSocket` has been refactored to extend `EventEmitter` instead of the real `WebSocket` class, eliminating the risk of unintentional network calls during unit tests and resolving potential flaky timeouts. Static constants (`OPEN`, `CONNECTING`, etc.) were added for runtime compatibility.
*   **Test Simplification:** `webSocketReducer.test.ts` was rewritten to consolidate repetitive test cases using `test.each`, reducing verbosity while maintaining full coverage of state transitions.
*   **Zod Schema Integration:** `types/websocket.ts` now fully defines `ServerMessage` and payload structures using Zod for strict runtime validation. This includes fixing `SpotifyCommandMessageSchema` to properly compose parameters and adding schemas for various data types (`HrmStreamData`, `TimerData`, `SpotifyPlaybackState`).
*   **Bug Fixes:** Cleanup logic for `staleCheckInterval` was added in `utils/socketManager.ts` to prevent interval leaks during test execution, and TypeScript errors in test files were resolved related to stricter type checks and mock compatibilities.

Fixes #6653

## Change Type: 🏗️ Refactoring (code change that neither fixes bug nor adds feature)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [x] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [x] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

This PR addresses directives from the Principal Engineer audit to repair PR #6653.

**Key Changes:**
1.  **Safe WebSocket Mocking:**
    *   Refactored `MockWebSocket` in `tests/unit/socketManager.test.ts` and `tests/unit/websocketUtils.test.ts` to extend `EventEmitter` instead of the real `WebSocket` class.
    *   This eliminates the risk of unintentional network calls during unit tests and resolves potential flaky timeouts.
    *   Added static constants (`OPEN`, `CONNECTING`, etc.) to the mock class to satisfy runtime checks.

2.  **Test Simplication:**
    *   Rewrote `tests/unit/webSocketReducer.test.ts` to consolidate repetitive test cases using `test.each`.
    *   Reduced code verbosity while maintaining full coverage of state transitions (Timer, Spotify, HRM updates).

3.  **Zod Schema Integration:**
    *   Refactored `types/websocket.ts` to fully define `ServerMessage` and payload structures using Zod.
    *   Fixed `SpotifyCommandMessageSchema` to properly compose parameters using `SpotifyCommandParametersSchema`.
    *   Added schemas for `HrmStreamData`, `TimerData`, `SpotifyPlaybackState`, etc., to ensure strict runtime validation.

4.  **Bug Fixes:**
    *   Added cleanup logic for `staleCheckInterval` in `utils/socketManager.ts` (specifically in `resetSocketManager`) to prevent interval leaks during test execution.
    *   Fixed TypeScript errors in test files related to stricter type checks and mock compatibilities.

**Verification:**
*   `pnpm run test:unit tests/unit/socketManager.test.ts` - PASSED
*   `pnpm run test:unit tests/unit/webSocketReducer.test.ts` - PASSED
*   `pnpm exec tsc --noEmit` - PASSED (Verified strict type integrity)
*   `pnpm run lint` - PASSED (Fixed linting issues)

---
*PR created automatically by Jules for task [1803140140222831462](https://jules.google.com/task/1803140140222831462) started by @arii*
</details>