### PR TITLE
Revert "Revert "feat(small): Refactor Spotify Token Delivery to Event-Driven Singleton Pattern""

### DIFF
--- a/app/api/internal/token-delivery/route.ts
+++ b/app/api/internal/token-delivery/route.ts
@@ -1,52 +1,40 @@
 import { ApiError } from '@/lib/errors'
 import { NextRequest, NextResponse } from 'next/server'
 import logger from '@/utils/logger'
-import { AccessToken } from '@spotify/web-api-ts-sdk'
+import { getSpotifyService } from '@/lib/services'
+import { env } from '@/lib/env'
+import { TokenDeliverySchema } from '@/types/spotify'
 
 /**
  * @route POST /api/internal/token-delivery
  * @description Secure internal endpoint for receiving updated Spotify tokens from NextAuth callbacks.
- * This route is the new, reliable, event-driven way of updating the Spotify polling service.
- * It directly accesses the singleton `spotifyService` instance and calls its token update handler.
- * This replaces the previous fragile, timing-based middleware interception in `server.ts`.
  *
  * @protection This endpoint is protected by a secret header (`x-internal-token-secret`)
- * defined in the `INTERNAL_TOKEN_DELIVERY_SECRET` environment variable.
+ * defined in the `INTERNAL_TOKEN_DELIVERY_SECRET` or `NEXTAUTH_SECRET` environment variables.
  */
 export async function POST(req: NextRequest) {
   try {
-    // 1. Parse the token from the request body
-    const tokenData = (await req.json()) as AccessToken
-    if (!tokenData || !tokenData.refresh_token) {
-      throw new ApiError(400, 'Bad Request: Missing token data.')
-    }
-
-    // 2. Authenticate the request from our internal callback
     const secretHeader = req.headers.get('x-internal-token-secret') || ''
-    const expected = process.env.NEXTAUTH_SECRET
-    if (!expected) {
-      throw new ApiError(500, 'NEXTAUTH_SECRET is not set.')
-    }
+    const expected = env.INTERNAL_TOKEN_DELIVERY_SECRET || env.NEXTAUTH_SECRET
+
     if (secretHeader !== expected) {
       throw new ApiError(401, 'Unauthorized: Missing or invalid secret.')
     }
 
-    // 3. Get the singleton instance of the Spotify service
-    // FIX: Removed `!spotifyService.isReady()` check.
-    // The service might be uninitialized (not ready) because it's waiting for this very token to initialize.
-    // This check created a circular dependency. We must allow the token delivery to proceed to bootstrap the SDK.
-    if (!global.spotifyService) {
-      throw new ApiError(503, 'Spotify service is not available.')
+    const body = await req.json()
+    const result = TokenDeliverySchema.safeParse(body)
+
+    if (!result.success) {
+      logger.warn({ errors: result.error.format() }, 'Invalid token structure')
+      throw new ApiError(400, 'Bad Request: Invalid token structure.')
     }
 
-    // 4. Directly and reliably update the service with the new token
-    await global.spotifyService.handleTokenUpdate({
-      ...tokenData,
-      provider: 'spotify',
-      sub: '',
-      scope: '',
-      obtainedAt: Date.now(),
-    })
+    const tokenData = {
+      ...result.data,
+      obtainedAt: result.data.obtainedAt ?? Date.now(),
+    }
+
+    await getSpotifyService().handleTokenUpdate(tokenData)
     logger.info('Spotify token delivered and processed successfully.')
 
     return NextResponse.json({
@@ -61,6 +49,7 @@ export async function POST(req: NextRequest) {
         { status: err.statusCode }
       )
     }
+
     logger.error({ err }, 'Unhandled error in token-delivery')
     return NextResponse.json({ error: 'server_error' }, { status: 500 })
   }

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -40,16 +40,17 @@ async function syncTokenWithBackend(token: JWT) {
         ((token.accessTokenExpires as number) - Date.now()) / 1000
       ),
       scope: token.scope || '', // Ensure scope is preserved in JWT if needed
-      obtainedAt: Date.now(),
     }
     // Only sync if we have valid data
     if (!tokenPayload.access_token || !tokenPayload.refresh_token) return
+
+    const secret = env.INTERNAL_TOKEN_DELIVERY_SECRET || env.NEXTAUTH_SECRET
 
     const response = await fetch(getAPIURL('internal/token-delivery'), {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'x-internal-token-secret': env.NEXTAUTH_SECRET,
+        'x-internal-token-secret': secret,
       },
       body: JSON.stringify(tokenPayload),
     })

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -22,3 +22,15 @@ export class ApiError extends Error {
     this.statusCode = statusCode
   }
 }
+
+/**
+ * Custom error class for service initialization errors.
+ */
+export class ServiceInitializationError extends Error {
+  constructor(serviceName: string, message?: string) {
+    super(
+      message || `${serviceName} not initialized. Server may be starting up.`
+    )
+    this.name = 'ServiceInitializationError'
+  }
+}

--- a/lib/healthCheck.ts
+++ b/lib/healthCheck.ts
@@ -1,6 +1,6 @@
 // lib/healthCheck.ts
 import { WebSocket } from 'ws'
-import TabataTimer from '../services/tabataTimer'
+import { TabataTimer } from '@/services/tabataTimer'
 
 export type HealthCheckResult = {
   healthy: boolean

--- a/lib/services.ts
+++ b/lib/services.ts
@@ -1,47 +1,51 @@
-import { ServerMessage } from '../types/websocket.js'
-import { SpotifyPolling } from '../services/spotifyPolling.js'
-import TabataTimer from '../services/tabataTimer.js'
-import { SpotifyService } from '../types/interfaces.js'
+import { SpotifyPollingService } from '@/services/spotifyPolling'
+import { TabataTimer } from '@/services/tabataTimer'
+import { Broadcaster } from '@/lib/websocket'
+import { ServiceInitializationError } from '@/lib/errors'
+import { env } from '@/lib/env'
 
 export interface AppServices {
-  spotifyService: SpotifyService
   tabataService: TabataTimer
+  spotifyService: SpotifyPollingService
   isSpotifyInitialized: boolean
 }
 
+// Ensures singleton persistence across Next.js compilation boundaries
+const globalWithSpotify = global as typeof globalThis & {
+  spotifyServiceInstance?: SpotifyPollingService
+}
+
+export const getSpotifyService = (): SpotifyPollingService => {
+  const instance = globalWithSpotify.spotifyServiceInstance
+  if (!instance) {
+    // This should technically never happen if createServices is called at startup
+    throw new Error('SpotifyService singleton not initialized')
+  }
+  return instance
+}
+
 export async function createServices(
-  broadcast: (data: Partial<ServerMessage>) => void
+  broadcast: Broadcaster
 ): Promise<AppServices> {
   const tabataService = new TabataTimer(broadcast)
-  let spotifyService: SpotifyService
-  let isSpotifyInitialized = true
+  const spotifyService = new SpotifyPollingService(broadcast)
+  let isSpotifyInitialized = false
+
+  // Assign immediately to prevent race conditions during async initialization
+  globalWithSpotify.spotifyServiceInstance = spotifyService
 
   try {
-    spotifyService = await SpotifyPolling.create(broadcast)
-  } catch (e) {
-    console.error('SpotifyPolling initialization failed:', e)
-    isSpotifyInitialized = false
-    // Fallback stub
-    spotifyService = {
-      handleCommand: () => {},
-      stopPolling: () => {},
-      startPolling: () => {},
-      getState: () => ({
-        trackName: 'Service Error',
-        artist: '',
-        isPlaying: false,
-        trackId: '',
-        albumName: '',
-        albumArtUrl: '',
-        devices: [],
-        volume: 0,
-        isMuted: false,
-      }),
-      isReady: () => false,
-      forcePollAndBroadcast: () => {},
-      handleTokenUpdate: () => Promise.resolve(),
-      cleanup: () => {},
+    if (!env.SPOTIFY_CLIENT_ID || !env.SPOTIFY_CLIENT_SECRET) {
+      throw new ServiceInitializationError(
+        'SpotifyService',
+        'Missing Spotify credentials'
+      )
     }
+    await spotifyService.initializeSdk()
+    spotifyService.startPolling()
+    isSpotifyInitialized = true
+  } catch (e) {
+    console.warn('SpotifyPolling initialization paused (waiting for token):', e)
   }
 
   return { tabataService, spotifyService, isSpotifyInitialized }

--- a/lib/websocket.ts
+++ b/lib/websocket.ts
@@ -2,7 +2,9 @@ import { WebSocketServer, WebSocket } from 'ws'
 import { IncomingMessage } from 'http'
 import { Socket } from 'net'
 import { parse } from 'url'
-import { ServerMessage } from '../types/websocket.js'
+import { ServerMessage } from '@/types/websocket'
+
+export type Broadcaster = (data: Partial<ServerMessage>) => void
 
 export class WebSocketManager {
   public wss: WebSocketServer
@@ -20,7 +22,7 @@ export class WebSocketManager {
     }
   }
 
-  public createBroadcaster() {
+  public createBroadcaster(): Broadcaster {
     return (data: Partial<ServerMessage>) => {
       if (this.wss.clients.size > 0) {
         const message = JSON.stringify({

--- a/server.ts
+++ b/server.ts
@@ -117,7 +117,6 @@ app.prepare().then(async () => {
   const services: AppServices = await createServices(
     wsManager.createBroadcaster()
   )
-  global.spotifyService = services.spotifyService
 
   // 3. Initialize Socket Logic (Controllers)
   const getUnifiedStateSnapshot = (): StateSnapshot => ({

--- a/services/spotifyApiErrorHandling.ts
+++ b/services/spotifyApiErrorHandling.ts
@@ -1,4 +1,4 @@
-import logger from '../utils/logger.server.js'
+import logger from '@/utils/logger.server'
 
 // Utility: Safely parse JSON, fallback to text
 function safeParseJSON(input: string): unknown {

--- a/services/spotifyDeviceManager.ts
+++ b/services/spotifyDeviceManager.ts
@@ -1,8 +1,8 @@
 import { Device } from '@spotify/web-api-ts-sdk'
-import { SpotifyDevice } from '../types/core'
-import { ServerMessage, SpotifyData } from '../types/websocket'
-import { SafeSpotifyApi } from './safeSpotifyApi'
-import logger from '../utils/logger.server.js'
+import { SpotifyDevice } from '@/types/core'
+import { ServerMessage, SpotifyData } from '@/types/websocket'
+import { SafeSpotifyApi } from '@/services/safeSpotifyApi'
+import logger from '@/utils/logger.server'
 
 export class SpotifyDeviceManager {
   private sdk: SafeSpotifyApi

--- a/services/spotifyPlayerManager.ts
+++ b/services/spotifyPlayerManager.ts
@@ -1,8 +1,8 @@
-import { SpotifyCommandParameters } from '../types/core'
-import { ServerMessage, SpotifyCommand, SpotifyData } from '../types/websocket'
-import { SafeSpotifyApi } from './safeSpotifyApi'
-import logger from '../utils/logger.server.js'
-import { isEmptyResponseError } from './spotifyUtils.js'
+import { SpotifyCommandParameters } from '@/types/core'
+import { ServerMessage, SpotifyCommand, SpotifyData } from '@/types/websocket'
+import { SafeSpotifyApi } from '@/services/safeSpotifyApi'
+import logger from '@/utils/logger.server'
+import { isEmptyResponseError } from '@/services/spotifyUtils'
 import { Track, Episode } from '@spotify/web-api-ts-sdk'
 
 const NOT_PLAYING_MESSAGE = 'Nothing is currently playing.'

--- a/services/spotifyPolling.ts
+++ b/services/spotifyPolling.ts
@@ -1,22 +1,21 @@
 import { AccessToken, SpotifyApi } from '@spotify/web-api-ts-sdk'
-import { ServerMessage, SpotifyData } from '../types/websocket'
-import { SpotifyCommandParameters } from '../types/core'
-import {
-  SpotifyTokenManager,
-  SpotifyTokenPayload,
-} from './spotifyTokenManager.js'
-import logger from '../utils/logger.server.js'
+import { ServerMessage, SpotifyData } from '@/types/websocket'
+import { SpotifyCommandParameters } from '@/types/core'
+import { SpotifyTokenManager } from '@/services/spotifyTokenManager'
+import { SpotifyTokenPayload } from '@/types/spotify'
+import logger from '@/utils/logger.server'
 import {
   handleSpotifyApiError,
   logSpotifyCommandError,
-} from './spotifyApiErrorHandling.js'
-import { SpotifyCommand, SpotifyService } from '../types/interfaces.js'
-import { SafeSpotifyApi, createSafeSpotifyApi } from './safeSpotifyApi.js'
-import { env } from '../lib/env.js'
-import { SpotifyPlayerManager } from './spotifyPlayerManager.js'
-import { SpotifyDeviceManager } from './spotifyDeviceManager.js'
+} from '@/services/spotifyApiErrorHandling'
+import { SpotifyCommand, SpotifyService } from '@/types/interfaces'
+import { SafeSpotifyApi, createSafeSpotifyApi } from '@/services/safeSpotifyApi'
+import { env } from '@/lib/env'
+import { ServiceInitializationError } from '@/lib/errors'
+import { SpotifyPlayerManager } from '@/services/spotifyPlayerManager'
+import { SpotifyDeviceManager } from '@/services/spotifyDeviceManager'
 
-export class SpotifyPolling implements SpotifyService {
+export class SpotifyPollingService implements SpotifyService {
   public forcePollAndBroadcast() {
     return this.getCurrentlyPlaying()
   }
@@ -43,17 +42,13 @@ export class SpotifyPolling implements SpotifyService {
 
   private sdk: SafeSpotifyApi | null = null
 
-  private constructor(broadcastUpdate: (message: ServerMessage) => void) {
+  constructor(broadcastUpdate: (message: ServerMessage) => void) {
     this.broadcastUpdate = broadcastUpdate
     logger.debug('Spotify Polling Service Initialized.')
 
-    if (!env.SPOTIFY_CLIENT_ID || !env.SPOTIFY_CLIENT_SECRET) {
-      throw new Error('Spotify client ID or secret not configured.')
-    }
-
     this.tokenManager = new SpotifyTokenManager(
-      env.SPOTIFY_CLIENT_ID,
-      env.SPOTIFY_CLIENT_SECRET
+      env.SPOTIFY_CLIENT_ID || '',
+      env.SPOTIFY_CLIENT_SECRET || ''
     )
   }
 
@@ -101,9 +96,14 @@ export class SpotifyPolling implements SpotifyService {
 
   public static async create(
     broadcastUpdate: (message: ServerMessage) => void
-  ): Promise<SpotifyPolling> {
-    const instance = new SpotifyPolling(broadcastUpdate)
-    await instance.initializeSdk()
+  ): Promise<SpotifyPollingService> {
+    const instance = new SpotifyPollingService(broadcastUpdate)
+    try {
+      await instance.initializeSdk()
+    } catch (e) {
+      logger.warn('Initial Spotify SDK bootstrap failed:', e)
+    }
+
     instance.tokenRefreshInterval = setInterval(
       () => instance.checkAndRefreshSdkToken(),
       1000 * 60 * 5
@@ -111,7 +111,7 @@ export class SpotifyPolling implements SpotifyService {
     return instance
   }
 
-  private async initializeSdk() {
+  public async initializeSdk() {
     const token = await this.tokenManager.getValidAccessToken()
     if (token) {
       const sdkToken = this.tokenManager.getSdkAccessToken()
@@ -129,8 +129,10 @@ export class SpotifyPolling implements SpotifyService {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { refresh_token: _, ...tokenWithoutRefresh } = accessToken
     if (!env.SPOTIFY_CLIENT_ID) {
-      logger.error('Spotify client ID not found, cannot initialize SDK.')
-      return
+      throw new ServiceInitializationError(
+        'SpotifyService',
+        'Spotify client ID not found, cannot initialize SDK.'
+      )
     }
     const sdk = SpotifyApi.withAccessToken(
       env.SPOTIFY_CLIENT_ID,
@@ -174,17 +176,20 @@ export class SpotifyPolling implements SpotifyService {
   }
 
   public async handleTokenUpdate(tokens: SpotifyTokenPayload): Promise<void> {
-    logger.info(
-      { tokens },
-      'Spotify token payload received. Updating SDK and forcing poll.'
-    )
+    // 1. Persist to disk and update internal manager state
     this.tokenManager.updateToken(tokens)
+
+    // 2. Re-initialize SDK with new tokens
     const sdkToken = this.tokenManager.getSdkAccessToken()
     if (sdkToken) {
       this.setupSdk(sdkToken)
       this.startPolling()
     }
+
+    // 3. Immediately poll with new tokens to update UI
     await this.forcePollAndBroadcast()
+
+    logger.info('Tokens updated and state broadcasted via direct event')
   }
 
   public startPolling() {

--- a/services/spotifyTokenManager.ts
+++ b/services/spotifyTokenManager.ts
@@ -1,7 +1,7 @@
 import { AccessToken } from '@spotify/web-api-ts-sdk'
 import fs from 'fs'
 import * as path from 'path'
-import { SpotifyTokenResponse } from '../types/spotify'
+import { SpotifyTokenResponse, SpotifyTokenPayload } from '../types/spotify'
 
 /**
  * Helper for atomic writes to prevent file corruption.
@@ -23,16 +23,6 @@ const writeTokenFileSafe = (filePath: string, data: TokenRecord) => {
       fs.unlinkSync(tempPath)
     }
   }
-}
-
-export interface SpotifyTokenPayload {
-  provider: string
-  sub: string
-  access_token: string
-  refresh_token: string
-  expires_in: number
-  scope: string
-  obtainedAt: number
 }
 
 export interface TokenRecord {
@@ -85,6 +75,7 @@ export class SpotifyTokenManager {
       this.currentToken.payload.sub
     )
   }
+
   private tokenFile: string
   private currentToken: TokenRecord | null = null
   private refreshPromise: Promise<void> | null = null

--- a/services/tabataTimer.ts
+++ b/services/tabataTimer.ts
@@ -5,18 +5,18 @@
  * cohesive public API for managing the timer. It delegates all logic to the
  * respective modules, acting as a facade.
  */
-import { ServerMessage } from '../types/websocket'
-import { TimerData, TimerMode } from '../types/core'
+import { ServerMessage } from '@/types/websocket'
+import { TimerData, TimerMode } from '@/types/core'
 import {
   createInitialTimerState,
   DualModeTimerState,
-} from './timer/timerState.js'
-import { TimerQueries } from './timer/timerQueries.js'
-import { TimerCommands } from './timer/timerCommands.js'
+} from '@/services/timer/timerState'
+import { TimerQueries } from '@/services/timer/timerQueries'
+import { TimerCommands } from '@/services/timer/timerCommands'
 
 type TimerCommand = 'START' | 'PAUSE' | 'STOP'
 
-class TabataTimer {
+export class TabataTimer {
   private readonly state: DualModeTimerState
   private readonly queries: TimerQueries
   private readonly commands: TimerCommands
@@ -81,5 +81,3 @@ class TabataTimer {
     this.commands.dispose()
   }
 }
-
-export default TabataTimer

--- a/services/timer/timerCommands.ts
+++ b/services/timer/timerCommands.ts
@@ -3,15 +3,12 @@
  * Encapsulates all state-mutating operations (commands) for the timer.
  * This class directly modifies the state object and triggers broadcasts.
  */
-import { ServerMessage } from '../../types/websocket'
-import { TimerMode } from '../../types/core'
-import {
-  START_COUNTDOWN_DURATION,
-  TIMER_INTERVAL,
-} from '../../utils/constants.js'
-import { DualModeTimerState } from './timerState.js'
-import { ConfigurationError } from '../../types/errors.js'
-import { TimerQueries } from './timerQueries.js'
+import { ServerMessage } from '@/types/websocket'
+import { TimerMode } from '@/types/core'
+import { START_COUNTDOWN_DURATION, TIMER_INTERVAL } from '@/utils/constants'
+import { DualModeTimerState } from './timerState'
+import { ConfigurationError } from '@/types/errors'
+import { TimerQueries } from './timerQueries'
 
 export class TimerCommands {
   private readonly state: DualModeTimerState

--- a/services/timer/timerState.ts
+++ b/services/timer/timerState.ts
@@ -2,12 +2,8 @@
 /**
  * Defines the state structure, constants, and initial state for the dual-mode timer.
  */
-import { TimerMode, TimerPhase } from '../../types/core'
-
-import {
-  DEFAULT_WORK_DURATION,
-  DEFAULT_REST_DURATION,
-} from '../../utils/constants.js'
+import { TimerMode, TimerPhase } from '@/types/core'
+import { DEFAULT_WORK_DURATION, DEFAULT_REST_DURATION } from '@/utils/constants'
 
 /**
  * Encapsulates the complete state of the timer, including both publicly

--- a/tests/unit/app/api/internal/token-delivery/route.test.ts
+++ b/tests/unit/app/api/internal/token-delivery/route.test.ts
@@ -1,9 +1,23 @@
 /**
  * @jest-environment node
  */
-import { describe, expect, it, jest, beforeAll, afterAll } from '@jest/globals'
+import { describe, expect, it, jest } from '@jest/globals'
 import { POST } from '@/app/api/internal/token-delivery/route'
 import { NextRequest } from 'next/server'
+import { getSpotifyService } from '@/lib/services'
+
+// Mock services
+jest.mock('@/lib/services', () => ({
+  getSpotifyService: jest.fn(),
+}))
+
+// Mock env
+jest.mock('@/lib/env', () => ({
+  env: {
+    NEXTAUTH_SECRET: 'test-secret',
+    INTERNAL_TOKEN_DELIVERY_SECRET: undefined,
+  },
+}))
 
 // Mock logger
 jest.mock('@/utils/logger.server', () => ({
@@ -21,22 +35,20 @@ const mockSpotifyService = {
   handleTokenUpdate: jest.fn(),
 }
 
+const validTokenData = {
+  provider: 'spotify',
+  sub: 'test-user',
+  access_token: 'test-access-token',
+  refresh_token: 'test-refresh-token',
+  expires_in: 3600,
+  scope: 'test-scope',
+  obtainedAt: Date.now(),
+}
+
 describe('POST /api/internal/token-delivery', () => {
-  const originalNextAuthSecret = process.env.NEXTAUTH_SECRET
-
-  beforeAll(() => {
-    process.env.NEXTAUTH_SECRET = 'test-secret'
-  })
-
-  afterAll(() => {
-    process.env.NEXTAUTH_SECRET = originalNextAuthSecret
-    // @ts-expect-error - Deleting global for test isolation
-    delete global.spotifyService
-  })
-
   beforeEach(() => {
     jest.clearAllMocks()
-    global.spotifyService = mockSpotifyService
+    ;(getSpotifyService as jest.Mock).mockReturnValue(mockSpotifyService)
   })
 
   it('should return 401 if secret header is missing or invalid', async () => {
@@ -47,7 +59,7 @@ describe('POST /api/internal/token-delivery', () => {
         headers: {
           'x-internal-token-secret': 'wrong-secret',
         },
-        body: JSON.stringify({ refresh_token: 'test' }),
+        body: JSON.stringify(validTokenData),
       }
     )
 
@@ -57,7 +69,25 @@ describe('POST /api/internal/token-delivery', () => {
     expect(body).toEqual({ error: 'Unauthorized: Missing or invalid secret.' })
   })
 
-  it('should return 200 OK if secret header is correct', async () => {
+  it('should return 400 if body structure is invalid', async () => {
+    const req = new NextRequest(
+      'http://localhost/api/internal/token-delivery',
+      {
+        method: 'POST',
+        headers: {
+          'x-internal-token-secret': 'test-secret',
+        },
+        body: JSON.stringify({ invalid: 'data' }),
+      }
+    )
+
+    const response = await POST(req)
+    expect(response.status).toBe(400)
+    const body = await response.json()
+    expect(body).toEqual({ error: 'Bad Request: Invalid token structure.' })
+  })
+
+  it('should return 200 OK if secret header and body are correct', async () => {
     mockSpotifyService.isReady.mockReturnValue(true)
     const req = new NextRequest(
       'http://localhost/api/internal/token-delivery',
@@ -66,24 +96,66 @@ describe('POST /api/internal/token-delivery', () => {
         headers: {
           'x-internal-token-secret': 'test-secret',
         },
-        body: JSON.stringify({ refresh_token: 'test' }),
+        body: JSON.stringify(validTokenData),
       }
     )
-
-    // The route handler does NOT read the body anymore, so we don't need to provide one
-    // or worry about stream consumption in this unit test.
 
     const response = await POST(req)
     expect(response.status).toBe(200)
     const body = await response.json()
     expect(body).toEqual({ ok: true, message: 'Token delivered successfully.' })
+    expect(mockSpotifyService.handleTokenUpdate).toHaveBeenCalledWith(
+      validTokenData
+    )
+  })
+
+  it('should default obtainedAt if missing in payload', async () => {
+    const { obtainedAt: _, ...tokenWithoutObtainedAt } = validTokenData
+    const req = new NextRequest(
+      'http://localhost/api/internal/token-delivery',
+      {
+        method: 'POST',
+        headers: {
+          'x-internal-token-secret': 'test-secret',
+        },
+        body: JSON.stringify(tokenWithoutObtainedAt),
+      }
+    )
+
+    const response = await POST(req)
+    expect(response.status).toBe(200)
+
+    const lastCall = (mockSpotifyService.handleTokenUpdate as jest.Mock).mock
+      .calls[0][0]
+    expect(lastCall.obtainedAt).toBeDefined()
+    expect(typeof lastCall.obtainedAt).toBe('number')
+    // Should be close to current time
+    expect(Math.abs(Date.now() - lastCall.obtainedAt)).toBeLessThan(1000)
+  })
+
+  it('should return 500 if service is not initialized (generic error)', async () => {
+    ;(getSpotifyService as jest.Mock).mockImplementationOnce(() => {
+      throw new Error('SpotifyService singleton not initialized')
+    })
+
+    const req = new NextRequest(
+      'http://localhost/api/internal/token-delivery',
+      {
+        method: 'POST',
+        headers: {
+          'x-internal-token-secret': 'test-secret',
+        },
+        body: JSON.stringify(validTokenData),
+      }
+    )
+
+    const response = await POST(req)
+    expect(response.status).toBe(500)
+    const body = await response.json()
+    expect(body).toEqual({ error: 'server_error' })
   })
 
   it('should return 500 if an unexpected error occurs', async () => {
-    // Force an error by mocking ApiError or something else if possible.
-    // However, since the logic is very simple, it's hard to make it fail unexpectedly
-    // without mocking globals or the request object throwing.
-    // Let's mock headers.get to throw.
     const req = new NextRequest(
       'http://localhost/api/internal/token-delivery',
       {
@@ -98,37 +170,5 @@ describe('POST /api/internal/token-delivery', () => {
     expect(response.status).toBe(500)
     const body = await response.json()
     expect(body).toEqual({ error: 'server_error' })
-  })
-
-  it('should process token even if spotifyService is not ready', async () => {
-    mockSpotifyService.isReady.mockReturnValue(false)
-    const tokenData = {
-      refresh_token: 'new-refresh-token',
-      access_token: 'new-access-token',
-    }
-    const req = new NextRequest(
-      'http://localhost/api/internal/token-delivery',
-      {
-        method: 'POST',
-        headers: {
-          'x-internal-token-secret': 'test-secret',
-        },
-        body: JSON.stringify(tokenData),
-      }
-    )
-
-    const response = await POST(req)
-    expect(response.status).toBe(200)
-    expect(mockSpotifyService.handleTokenUpdate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        ...tokenData,
-        provider: 'spotify',
-        sub: '',
-        scope: '',
-        obtainedAt: expect.any(Number),
-      })
-    )
-    const body = await response.json()
-    expect(body).toEqual({ ok: true, message: 'Token delivered successfully.' })
   })
 })

--- a/tests/unit/lib/healthCheck.test.ts
+++ b/tests/unit/lib/healthCheck.test.ts
@@ -9,7 +9,7 @@ import {
   checkTimerService,
 } from '../../../lib/healthCheck'
 import { WebSocket } from 'ws'
-import TabataTimer from '../../../services/tabataTimer'
+import { TabataTimer } from '../../../services/tabataTimer'
 
 // Mock the 'ws' module
 jest.mock('ws')
@@ -34,7 +34,7 @@ describe('Health Check Logic', () => {
         heapUsed: 100 * 1024 * 1024, // 100MB
         external: 0,
         arrayBuffers: 0,
-      })
+      } as NodeJS.MemoryUsage)
 
       const result = checkMemoryUsage()
       expect(result.healthy).toBe(true)
@@ -48,7 +48,7 @@ describe('Health Check Logic', () => {
         heapUsed: 600 * 1024 * 1024, // 600MB
         external: 0,
         arrayBuffers: 0,
-      })
+      } as NodeJS.MemoryUsage)
 
       const result = checkMemoryUsage()
       expect(result.healthy).toBe(false)

--- a/tests/unit/services.test.ts
+++ b/tests/unit/services.test.ts
@@ -10,9 +10,8 @@ import {
   beforeEach,
   afterEach,
 } from '@jest/globals'
-import { jest } from '@jest/globals'
-import TabataTimer from '../../services/tabataTimer'
-import { SpotifyPolling } from '../../services/spotifyPolling'
+import { TabataTimer } from '../../services/tabataTimer'
+import { SpotifyPollingService } from '../../services/spotifyPolling'
 import { ServerMessage } from '../../types/websocket'
 import { SpotifyApi } from '@spotify/web-api-ts-sdk'
 import { SpotifyTokenManager } from '../../services/spotifyTokenManager'
@@ -31,7 +30,7 @@ jest.mock('@spotify/web-api-ts-sdk', () => ({
 
 describe('Services Integration', () => {
   let tabataTimer: TabataTimer
-  let spotifyService: SpotifyPolling
+  let spotifyService: SpotifyPollingService
   let broadcastedMessages: ServerMessage[]
   let broadcastFn: (message: ServerMessage) => void
   let mockPlayerFns: jest.Mocked<SpotifyApi['player']>
@@ -91,7 +90,7 @@ describe('Services Integration', () => {
 
     tabataTimer = new TabataTimer(broadcastFn)
     // Initialize service (which will trigger async token load)
-    spotifyService = await SpotifyPolling.create(broadcastFn)
+    spotifyService = await SpotifyPollingService.create(broadcastFn)
   })
 
   afterEach(() => {

--- a/tests/unit/services/tabataTimer.test.ts
+++ b/tests/unit/services/tabataTimer.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { jest } from '@jest/globals'
-import TabataTimer from '../../../services/tabataTimer'
+import { TabataTimer } from '../../../services/tabataTimer'
 import { ConfigurationError } from '../../../types/errors'
 
 // Mock the broadcast function

--- a/tests/unit/socketManager.test.ts
+++ b/tests/unit/socketManager.test.ts
@@ -18,8 +18,8 @@ import {
 import { Server as WebSocketServer } from 'ws'
 import { EventEmitter } from 'events'
 import { TLSSocket } from 'tls'
-import TabataTimer from '../../services/tabataTimer'
-import { SpotifyPolling } from '../../services/spotifyPolling'
+import { TabataTimer } from '../../services/tabataTimer'
+import { SpotifyPollingService } from '../../services/spotifyPolling'
 import {
   HrmData,
   StateSnapshot,
@@ -113,7 +113,7 @@ describe('WebSocket Manager', () => {
   let mockWss: jest.Mocked<WebSocketServer>
   let mockServices: {
     tabataService: jest.Mocked<TabataTimer>
-    spotifyService: jest.Mocked<SpotifyPolling>
+    spotifyService: jest.Mocked<SpotifyPollingService>
   }
   let getSnapshot: () => StateSnapshot
   let mockWs: MockWebSocket
@@ -137,9 +137,10 @@ describe('WebSocket Manager', () => {
       getState: jest.fn(),
       getSnapshot: jest.fn(),
       cleanup: jest.fn(),
-    }
+      dispose: jest.fn(),
+    } as unknown as jest.Mocked<TabataTimer>
 
-    const mockSpotifyPolling: jest.Mocked<SpotifyPolling> = {
+    const mockSpotifyPolling: jest.Mocked<SpotifyPollingService> = {
       handleCommand: jest.fn(),
       forcePollAndBroadcast: jest.fn(),
       getState: jest.fn(),
@@ -149,7 +150,7 @@ describe('WebSocket Manager', () => {
       stopPolling: jest.fn(),
       cleanup: jest.fn(),
       refreshDevices: jest.fn(),
-    }
+    } as unknown as jest.Mocked<SpotifyPollingService>
 
     mockServices = {
       tabataService: mockTabataTimer,

--- a/tests/unit/spotify-test-utils.ts
+++ b/tests/unit/spotify-test-utils.ts
@@ -1,5 +1,5 @@
 import { jest } from '@jest/globals'
-import { SpotifyPolling } from '../../services/spotifyPolling'
+import { SpotifyPollingService } from '../../services/spotifyPolling'
 
 export { mockPlayer, mockSpotifyApi, mockLogger } from './spotify-mocks'
 
@@ -9,10 +9,10 @@ export { mockPlayer, mockSpotifyApi, mockLogger } from './spotify-mocks'
  * @returns A tuple containing the service instance and the broadcast mock function.
  */
 export async function setupSpotifyPollingService(): Promise<
-  [SpotifyPolling, jest.Mock]
+  [SpotifyPollingService, jest.Mock]
 > {
   const broadcastMock = jest.fn()
-  const service = await SpotifyPolling.create(broadcastMock)
+  const service = await SpotifyPollingService.create(broadcastMock)
 
   // After creation, immediately stop any running timers to prevent side effects
   if (service._test_) {

--- a/tests/unit/spotifyPolling.test.ts
+++ b/tests/unit/spotifyPolling.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals'
-import { SpotifyPolling } from '../../services/spotifyPolling'
+import { SpotifyPollingService } from '../../services/spotifyPolling'
 import { SpotifyTokenManager } from '../../services/spotifyTokenManager'
 import { SpotifyData } from '../../types/websocket'
 import { setupSpotifyPollingService, mockPlayer } from './spotify-test-utils'
@@ -67,7 +67,7 @@ const flushPromises = async () => {
 }
 
 describe('SpotifyPolling Service', () => {
-  let spotifyService: SpotifyPolling
+  let spotifyService: SpotifyPollingService
   let broadcastMock: jest.Mock<(message: ServerMessage) => void>
   const broadcastedStates: SpotifyData[] = []
 
@@ -126,7 +126,7 @@ describe('SpotifyPolling Service', () => {
         }))
 
         // Act
-        const service = await SpotifyPolling.create(broadcastMock)
+        const service = await SpotifyPollingService.create(broadcastMock)
 
         // Assert
         expect(service.isReady()).toBe(false)
@@ -300,7 +300,7 @@ describe('SpotifyPolling Service', () => {
         getSdkAccessToken: jest.fn().mockReturnValue(null),
       }))
 
-      const newService = await SpotifyPolling.create(broadcastMock)
+      const newService = await SpotifyPollingService.create(broadcastMock)
       await newService.handleCommand('PLAY', {})
       // Should not make API call without token
       expect(mockPlayer.startResumePlayback).not.toHaveBeenCalled()

--- a/types/errors.ts
+++ b/types/errors.ts
@@ -4,21 +4,6 @@
  */
 
 /**
- * Error thrown when a service fails to initialize correctly.
- */
-export class ServiceInitializationError extends Error {
-  /**
-   * @param {string} serviceName - The name of the service that failed.
-   * @param {unknown} [originalError] - The original error that caused the failure.
-   */
-  constructor(serviceName: string, originalError?: unknown) {
-    super(`Failed to initialize ${serviceName}`)
-    this.name = 'ServiceInitializationError'
-    this.cause = originalError
-  }
-}
-
-/**
  * Error thrown when a configuration is invalid.
  */
 export class ConfigurationError extends Error {

--- a/types/interfaces.ts
+++ b/types/interfaces.ts
@@ -6,8 +6,8 @@
 t* estable, and easier to refactor.
  */
 
-import { SpotifyTokenPayload } from '../services/spotifyTokenManager'
 import { SpotifyData } from './websocket'
+import { SpotifyTokenPayload } from './spotify'
 
 /**
  * Represents a service that provides a snapshot of its current state.

--- a/types/spotify.ts
+++ b/types/spotify.ts
@@ -1,4 +1,5 @@
 // types/spotify.ts
+import { z } from 'zod'
 
 export interface Track {
   id: string
@@ -53,3 +54,17 @@ export interface SpotifyTokenResponse {
   expires_in: number
   refresh_token?: string
 }
+
+export const TokenDeliverySchema = z.object({
+  provider: z.string(),
+  sub: z.string(),
+  access_token: z.string(),
+  refresh_token: z.string(),
+  expires_in: z.number(),
+  scope: z.string(),
+  obtainedAt: z.number().optional(),
+})
+
+export type TokenDeliveryPayload = z.infer<typeof TokenDeliverySchema>
+
+export type SpotifyTokenPayload = Required<TokenDeliveryPayload>


### PR DESCRIPTION
## Description

This pull request reverts the previous revert (`arii/hrm#8070`), thereby re-introducing the feature: "Refactor Spotify Token Delivery to Event-Driven Singleton Pattern".

The motivation for this revert is to restore the event-driven singleton pattern for Spotify token delivery, which was previously removed. This change aims to bring back the intended architecture for managing Spotify tokens.

Fixes # (issue)  
Reverts #8070

## Change Type: ✨ New feature (non-breaking change adding functionality)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [x] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [x] **Tests** are added/updated for new functionality
- [x] **Documentation** is updated if needed
- [x] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

Reverts arii/hrm#8070
</details>