### PR TITLE
feat(medium): Extract HRM Stats Calculation Logic from HrmSessionManager

### DIFF
--- a/lib/hrm/HrmSessionManager.ts
+++ b/lib/hrm/HrmSessionManager.ts
@@ -4,8 +4,10 @@ import {
   HrmStreamData,
   RawHrmStreamData,
   HeartRateDataPoint,
+  HrmInternalStats,
 } from '../../types/core.js'
 import { env } from '../env.js'
+import { HrmStatsCalculator } from '../../services/HrmStatsCalculator.js'
 
 type HrmDataPoint = Pick<HeartRateDataPoint, 'heartRate' | 'timestamp'>
 
@@ -17,12 +19,7 @@ type HrmDataPoint = Pick<HeartRateDataPoint, 'heartRate' | 'timestamp'>
 interface ClientSession {
   latestData: RawHrmStreamData
   liveWindow: RingBuffer<HrmDataPoint>
-  stats: {
-    count: number
-    sumHr: number
-    peakHr: number
-    minHr: number
-  }
+  stats: HrmInternalStats
   /**
    * Caches the augmented HrmStreamData (latest data + session stats).
    * This prevents repeated object allocations during high-frequency reads.
@@ -39,6 +36,7 @@ const LIVE_WINDOW_SIZE = env.HRM_LIVE_WINDOW_SIZE // 10 minutes at 1Hz (default)
  */
 export class HrmSessionManager {
   private sessions = new Map<string, ClientSession>()
+  private statsCalculator = new HrmStatsCalculator()
 
   /**
    * Finds a client's data by their ID, including aggregated session stats.
@@ -73,7 +71,7 @@ export class HrmSessionManager {
       session = {
         latestData: data,
         liveWindow: new RingBuffer<HrmDataPoint>(LIVE_WINDOW_SIZE),
-        stats: this.createInitialStats(),
+        stats: this.statsCalculator.createInitialStats(),
       }
       this.sessions.set(data.clientId, session)
     }
@@ -88,7 +86,7 @@ export class HrmSessionManager {
         timestamp: data.updatedAt || Date.now(),
       }
       session.liveWindow.push(point)
-      this.updateStats(session, point.heartRate)
+      this.statsCalculator.updateStats(session.stats, point.heartRate)
     }
   }
 
@@ -116,7 +114,7 @@ export class HrmSessionManager {
     const session = this.sessions.get(clientId)
     if (!session) return null
 
-    const derived = this.getDerivedStats(session.stats)
+    const derived = this.statsCalculator.getDerivedStats(session.stats)
     return {
       recentHistory: session.liveWindow.toArray(),
       summary: {
@@ -134,7 +132,7 @@ export class HrmSessionManager {
     const session = this.sessions.get(clientId)
     if (session) {
       session.liveWindow = new RingBuffer<HrmDataPoint>(LIVE_WINDOW_SIZE)
-      session.stats = this.createInitialStats()
+      session.stats = this.statsCalculator.createInitialStats()
       // Reset the current HR value to 0 to prevent UI "ghosting"
       session.latestData = {
         ...session.latestData,
@@ -145,42 +143,15 @@ export class HrmSessionManager {
     }
   }
 
-  private createInitialStats() {
-    return {
-      count: 0,
-      sumHr: 0,
-      peakHr: 0,
-      minHr: Infinity,
-    }
-  }
-
-  private updateStats(session: ClientSession, heartRate: number): void {
-    const { stats } = session
-    stats.count++
-    stats.sumHr += heartRate
-    stats.peakHr = Math.max(stats.peakHr, heartRate)
-    stats.minHr = Math.min(stats.minHr, heartRate)
-  }
-
-  private getDerivedStats(stats: ClientSession['stats']) {
-    const hasData = stats.count > 0
-    return {
-      avgHr: hasData ? Math.round(stats.sumHr / stats.count) : 0,
-      peakHr: stats.peakHr,
-      minHr: hasData ? stats.minHr : 0,
-    }
-  }
-
   private mergeStats(session: ClientSession): HrmStreamData {
     if (session.cachedAugmentedData) {
       return session.cachedAugmentedData
     }
 
-    const { latestData, stats } = session
-    const augmented: HrmStreamData = {
-      ...latestData,
-      sessionStats: this.getDerivedStats(stats),
-    }
+    const augmented = this.statsCalculator.mergeStats(
+      session.latestData,
+      session.stats
+    )
 
     session.cachedAugmentedData = augmented
     return augmented

--- a/services/HrmStatsCalculator.ts
+++ b/services/HrmStatsCalculator.ts
@@ -1,0 +1,69 @@
+import {
+  HrmInternalStats,
+  HrmSessionStats,
+  RawHrmStreamData,
+  HrmStreamData,
+} from '../types/core.js'
+
+/**
+ * Service for calculating heart rate statistics incrementally.
+ * Encapsulates the logic for updating counters and deriving human-readable stats.
+ */
+export class HrmStatsCalculator {
+  /**
+   * Creates a new initial stats object with default values.
+   * @returns A fresh HrmInternalStats object.
+   */
+  createInitialStats(): HrmInternalStats {
+    return {
+      count: 0,
+      sumHr: 0,
+      peakHr: 0,
+      minHr: Infinity,
+    }
+  }
+
+  /**
+   * Updates the internal stats with a new heart rate value.
+   * Performs O(1) incremental updates to avoid re-calculating from history.
+   * @param stats The current internal stats (modified in-place).
+   * @param heartRate The new heart rate value to incorporate.
+   */
+  updateStats(stats: HrmInternalStats, heartRate: number): void {
+    stats.count++
+    stats.sumHr += heartRate
+    stats.peakHr = Math.max(stats.peakHr, heartRate)
+    stats.minHr = Math.min(stats.minHr, heartRate)
+  }
+
+  /**
+   * Calculates derived statistics from the internal counters.
+   * @param stats The internal stats.
+   * @returns Human-readable session statistics.
+   */
+  getDerivedStats(stats: HrmInternalStats): HrmSessionStats {
+    const hasData = stats.count > 0
+    return {
+      avgHr: hasData ? Math.round(stats.sumHr / stats.count) : 0,
+      peakHr: stats.peakHr,
+      minHr: hasData ? stats.minHr : 0,
+    }
+  }
+
+  /**
+   * Merges raw stream data with session statistics.
+   * Helper method to augment real-time data with calculated session metrics.
+   * @param latestData The latest raw heart rate data.
+   * @param stats The internal stats.
+   * @returns The augmented HrmStreamData object.
+   */
+  mergeStats(
+    latestData: RawHrmStreamData,
+    stats: HrmInternalStats
+  ): HrmStreamData {
+    return {
+      ...latestData,
+      sessionStats: this.getDerivedStats(stats),
+    }
+  }
+}

--- a/tests/unit/services/HrmStatsCalculator.test.ts
+++ b/tests/unit/services/HrmStatsCalculator.test.ts
@@ -1,0 +1,90 @@
+import { HrmStatsCalculator } from '../../../services/HrmStatsCalculator'
+import { HrmInternalStats } from '../../../types/core'
+
+describe('HrmStatsCalculator', () => {
+  let calculator: HrmStatsCalculator
+
+  beforeEach(() => {
+    calculator = new HrmStatsCalculator()
+  })
+
+  it('should create initial stats', () => {
+    const stats = calculator.createInitialStats()
+    expect(stats).toEqual({
+      count: 0,
+      sumHr: 0,
+      peakHr: 0,
+      minHr: Infinity,
+    })
+  })
+
+  it('should update stats correctly', () => {
+    const stats = calculator.createInitialStats()
+    calculator.updateStats(stats, 100)
+    expect(stats.count).toBe(1)
+    expect(stats.sumHr).toBe(100)
+    expect(stats.peakHr).toBe(100)
+    expect(stats.minHr).toBe(100)
+
+    calculator.updateStats(stats, 150)
+    expect(stats.count).toBe(2)
+    expect(stats.sumHr).toBe(250)
+    expect(stats.peakHr).toBe(150)
+    expect(stats.minHr).toBe(100)
+
+    calculator.updateStats(stats, 80)
+    expect(stats.count).toBe(3)
+    expect(stats.sumHr).toBe(330)
+    expect(stats.peakHr).toBe(150)
+    expect(stats.minHr).toBe(80)
+  })
+
+  it('should calculate derived stats correctly', () => {
+    const stats: HrmInternalStats = {
+      count: 3,
+      sumHr: 300,
+      peakHr: 150,
+      minHr: 50,
+    }
+    const derived = calculator.getDerivedStats(stats)
+    expect(derived).toEqual({
+      avgHr: 100,
+      peakHr: 150,
+      minHr: 50,
+    })
+  })
+
+  it('should return 0 for derived stats when no data', () => {
+    const stats = calculator.createInitialStats()
+    const derived = calculator.getDerivedStats(stats)
+    expect(derived).toEqual({
+      avgHr: 0,
+      peakHr: 0,
+      minHr: 0,
+    })
+  })
+
+  it('should merge stats correctly', () => {
+    const latestData = {
+      clientId: 'test',
+      value: 100,
+      maxHr: 200,
+      calories: 50,
+    }
+    const stats: HrmInternalStats = {
+      count: 2,
+      sumHr: 180,
+      peakHr: 100,
+      minHr: 80,
+    }
+    const merged = calculator.mergeStats(latestData, stats)
+    expect(merged).toMatchObject({
+      ...latestData,
+      sessionStats: {
+        avgHr: 90,
+        peakHr: 100,
+        minHr: 80,
+      },
+    })
+  })
+})

--- a/types/core.ts
+++ b/types/core.ts
@@ -94,6 +94,16 @@ export interface HrmSessionStats {
 }
 
 /**
+ * Internal counters used for incremental statistics calculation.
+ */
+export interface HrmInternalStats {
+  count: number
+  sumHr: number
+  peakHr: number
+  minHr: number
+}
+
+/**
  * Represents raw heart rate data streamed from a client.
  */
 export interface RawHrmStreamData {


### PR DESCRIPTION
## Description

This refactor extracts the heart rate statistics calculation logic from `HrmSessionManager` into a dedicated `HrmStatsCalculator` service. This improves modularity and separates the concerns of data storage from data analysis, making the codebase easier to maintain and extend as more complex statistics are added in the future.

Fixes #7858

## Change Type: 🏗️ Refactoring (code change that neither fixes bug nor adds feature)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [x] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [x] **Tests** are added/updated for new functionality
- [x] **Documentation** is updated if needed
- [x] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

This refactor extracts the heart rate statistics calculation logic from `HrmSessionManager` into a dedicated `HrmStatsCalculator` service. This improves modularity and separates the concerns of data storage from data analysis, making the codebase easier to maintain and extend as more complex statistics are added in the future.

Fixes #7858

---
*PR created automatically by Jules for task [8675924218333175450](https://jules.google.com/task/8675924218333175450) started by @arii*
</details>