### PR TITLE
Fix CI missing build logs by excluding logs directory from cleanup

### DIFF
--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -44,7 +44,7 @@ rm -rf "$APP_DIR/dist"
 rm -rf "$APP_DIR/coverage"
 rm -rf "$APP_DIR/test-results"
 rm -rf "$APP_DIR/playwright-report"
-find "$APP_DIR" -name "*.log" -type f -delete
+find "$APP_DIR" -type f -name "*.log" -not -path "*/logs/*" -delete
 find "$APP_DIR" -name "*.backup" -type f -delete
 rm -f "$APP_DIR/nohup.out"
 rm -f "$APP_DIR/diff.txt"


### PR DESCRIPTION
- Modified `scripts/cleanup.sh` to exclude `logs/` directory from the `find` command that deletes `.log` files.
- Verified that other `.log` files outside `logs/` are still deleted.
- This fixes the issue where CI build logs were missing in `pr-quality.yml`.

---
*PR created automatically by Jules for task [1785670891179903851](https://jules.google.com/task/1785670891179903851) started by @arii*