### PR TITLE
fix(ci): ensure tests and config changes trigger CI pipeline

### DIFF
--- a/.github/workflows/pr-orchestrator.yml
+++ b/.github/workflows/pr-orchestrator.yml
@@ -67,6 +67,14 @@ jobs:
               - '.env*'
               - '.github/**'
               - 'scripts/**'
+              - 'tests/**'
+              - 'stories/**'
+              - '.storybook/**'
+              - 'verification/**'
+              - '*.config.*'
+              - '*.ts'
+              - 'ecosystem.config.cjs'
+              - 'verify_empty_dashboard.py'
 
       - uses: dorny/paths-filter@v3
         if: github.event_name == 'workflow_dispatch'
@@ -93,6 +101,14 @@ jobs:
               - '.env*'
               - '.github/**'
               - 'scripts/**'
+              - 'tests/**'
+              - 'stories/**'
+              - '.storybook/**'
+              - 'verification/**'
+              - '*.config.*'
+              - '*.ts'
+              - 'ecosystem.config.cjs'
+              - 'verify_empty_dashboard.py'
 
       - name: Consolidate Changes
         id: changes


### PR DESCRIPTION
This PR updates the `pr-orchestrator.yml` workflow to ensure that PRs containing only changes to tests, stories, or configuration files correctly trigger the CI pipeline. Previously, such PRs were skipped because these paths were not included in the `paths-filter` configuration.

Changes:
- Added `tests/**`, `stories/**`, `.storybook/**`, `verification/**` to the `src` filter in `paths-filter`.
- Added `*.config.*`, `ecosystem.config.cjs`, `*.ts`, and `verify_empty_dashboard.py` to the `src` filter.
- Applied these changes to both `pull_request` and `workflow_dispatch` triggers.

---
*PR created automatically by Jules for task [3063356350337963958](https://jules.google.com/task/3063356350337963958) started by @arii*