### PR TITLE
ci: remove polling steps from workflows

### DIFF
--- a/.github/workflows/e2e-ci-tests.yml
+++ b/.github/workflows/e2e-ci-tests.yml
@@ -57,61 +57,12 @@ jobs:
           BRANCH_NAME: ${{ env.BRANCH_NAME }}
         run: |
           set -e
-          # 1. Establish initial SHA
-          REPO="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          INITIAL_SHA=$(git ls-remote "$REPO" "refs/heads/$BRANCH_NAME" | awk '{print $1}')
-          echo "Initial SHA: $INITIAL_SHA"
-
-          # 2. Trigger bot
+          # Trigger bot
           echo "Triggering bot with @pr-squash comment..."
           gh pr comment $PR_NUMBER --body "@pr-squash"
-          echo "Waiting for squash and rebase to complete..."
+          echo "Triggered bot. Proceeding immediately to watch checks."
 
-          # 3. Wait for SHA to change or success comment
-          MAX_RETRIES=60
-          RETRY_COUNT=0
-          while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
-            CURRENT_SHA=$(git ls-remote "$REPO" "refs/heads/$BRANCH_NAME" | awk '{print $1}')
-            if [ -n "$CURRENT_SHA" ] && [ "$CURRENT_SHA" != "$INITIAL_SHA" ]; then
-              echo "✅ Bot has pushed changes (New SHA: $CURRENT_SHA)"
-              break
-            fi
-
-            # Fallback: check for the bot's success comment
-            if gh pr view "$PR_NUMBER" --json comments --jq '.comments[].body' | grep -qi "successfully"; then
-              echo "✅ Bot has commented success. Proceeding to watch checks."
-              CURRENT_SHA=$(git ls-remote "$REPO" "refs/heads/$BRANCH_NAME" | awk '{print $1}')
-              break
-            fi
-
-            echo "Waiting for SHA change or success comment... ($RETRY_COUNT/$MAX_RETRIES)"
-            RETRY_COUNT=$((RETRY_COUNT + 1))
-            sleep 15
-          done
-
-          if [ -z "$CURRENT_SHA" ] || [ "$CURRENT_SHA" == "$INITIAL_SHA" ]; then
-            echo "❌ Bot failed to push changes or comment success within timeout."
-            exit 1
-          fi
-
-          # 4. Wait for checks to appear for the new commit.
-          # We add a mandatory 15s delay to allow GitHub's eventually consistent API to index the new push.
-          echo "Waiting 15s for GitHub API to index the new commit..."
-          sleep 15
-          echo "Waiting for checks to appear for SHA $CURRENT_SHA..."
-          MAX_CHECK_RETRIES=60
-          CHECK_RETRY=0
-          while [ $CHECK_RETRY -lt $MAX_CHECK_RETRIES ]; do
-            # Filter checks by name to avoid being confused by older runs
-            if gh pr checks "$PR_NUMBER" | grep -v "no checks reported" | grep -qiE "pending|pass|fail|progressing|waiting|success|failure"; then
-              echo "✅ Checks have been registered."
-              break
-            fi
-            echo "Still waiting for checks to be indexed... ($CHECK_RETRY/$MAX_CHECK_RETRIES)"
-            CHECK_RETRY=$((CHECK_RETRY + 1))
-            sleep 10
-          done
-
+          # Efficiently wait for checks to complete
           timeout 900 gh pr checks $PR_NUMBER --watch
 
       - name: Verify Squash
@@ -209,59 +160,12 @@ jobs:
           BRANCH_B: ${{ env.BRANCH_B }}
         run: |
           set -e
-          # 1. Establish initial SHA
-          REPO="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          INITIAL_SHA=$(git ls-remote "$REPO" "refs/heads/$BRANCH_B" | awk '{print $1}')
-          echo "Initial SHA: $INITIAL_SHA"
-
-          # 2. Trigger bot
+          # Trigger bot
           echo "Triggering bot with @conflict-resolve comment..."
           gh pr comment $PR_NUMBER --body "@conflict-resolve"
-          echo "Waiting for conflict resolver to complete..."
+          echo "Triggered bot. Proceeding immediately to watch checks."
 
-          # 3. Wait for SHA to change or success comment
-          MAX_RETRIES=60
-          RETRY_COUNT=0
-          while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
-            CURRENT_SHA=$(git ls-remote "$REPO" "refs/heads/$BRANCH_B" | awk '{print $1}')
-            if [ -n "$CURRENT_SHA" ] && [ "$CURRENT_SHA" != "$INITIAL_SHA" ]; then
-              echo "✅ Bot has pushed changes (New SHA: $CURRENT_SHA)"
-              break
-            fi
-
-            # Fallback: check for the bot's success comment
-            if gh pr view "$PR_NUMBER" --json comments --jq '.comments[].body' | grep -qi "Successfully resolved all conflicts"; then
-              echo "✅ Bot has commented success. Proceeding to watch checks."
-              CURRENT_SHA=$(git ls-remote "$REPO" "refs/heads/$BRANCH_B" | awk '{print $1}')
-              break
-            fi
-
-            echo "Waiting for SHA change or success comment... ($RETRY_COUNT/$MAX_RETRIES)"
-            RETRY_COUNT=$((RETRY_COUNT + 1))
-            sleep 15
-          done
-
-          if [ -z "$CURRENT_SHA" ] || [ "$CURRENT_SHA" == "$INITIAL_SHA" ]; then
-            echo "❌ Bot failed to push changes or comment success within timeout."
-            exit 1
-          fi
-
-          # 4. Wait for checks to appear for the new commit
-          echo "Waiting 15s for GitHub API to index the new commit..."
-          sleep 15
-          echo "Waiting for checks to appear for SHA $CURRENT_SHA..."
-          MAX_CHECK_RETRIES=60
-          CHECK_RETRY=0
-          while [ $CHECK_RETRY -lt $MAX_CHECK_RETRIES ]; do
-            if gh pr checks "$PR_NUMBER" | grep -v "no checks reported" | grep -qiE "pending|pass|fail|progressing|waiting|success|failure"; then
-              echo "✅ Checks have been registered."
-              break
-            fi
-            echo "Still waiting for checks to be indexed... ($CHECK_RETRY/$MAX_CHECK_RETRIES)"
-            CHECK_RETRY=$((CHECK_RETRY + 1))
-            sleep 10
-          done
-
+          # Efficiently wait for checks to complete
           timeout 900 gh pr checks $PR_NUMBER --watch
 
       - name: Verify Conflict Resolution
@@ -338,59 +242,12 @@ jobs:
           BRANCH_NAME: ${{ env.BRANCH_NAME }}
         run: |
           set -e
-          # 1. Establish initial SHA
-          REPO="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          INITIAL_SHA=$(git ls-remote "$REPO" "refs/heads/$BRANCH_NAME" | awk '{print $1}')
-          echo "Initial SHA: $INITIAL_SHA"
-
-          # 2. Trigger bot
+          # Trigger bot
           echo "Triggering bot with @pr-squash-rebase comment..."
           gh pr comment $PR_NUMBER --body "@pr-squash-rebase"
-          echo "Waiting for squash and rebase to complete..."
+          echo "Triggered bot. Proceeding immediately to watch checks."
 
-          # 3. Wait for SHA to change or success comment
-          MAX_RETRIES=60
-          RETRY_COUNT=0
-          while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
-            CURRENT_SHA=$(git ls-remote "$REPO" "refs/heads/$BRANCH_NAME" | awk '{print $1}')
-            if [ -n "$CURRENT_SHA" ] && [ "$CURRENT_SHA" != "$INITIAL_SHA" ]; then
-              echo "✅ Bot has pushed changes (New SHA: $CURRENT_SHA)"
-              break
-            fi
-
-            # Fallback: check for the bot's success comment
-            if gh pr view "$PR_NUMBER" --json comments --jq '.comments[].body' | grep -qi "successfully"; then
-              echo "✅ Bot has commented success. Proceeding to watch checks."
-              CURRENT_SHA=$(git ls-remote "$REPO" "refs/heads/$BRANCH_NAME" | awk '{print $1}')
-              break
-            fi
-
-            echo "Waiting for SHA change or success comment... ($RETRY_COUNT/$MAX_RETRIES)"
-            RETRY_COUNT=$((RETRY_COUNT + 1))
-            sleep 15
-          done
-
-          if [ -z "$CURRENT_SHA" ] || [ "$CURRENT_SHA" == "$INITIAL_SHA" ]; then
-            echo "❌ Bot failed to push changes or comment success within timeout."
-            exit 1
-          fi
-
-          # 4. Wait for checks to appear for the new commit
-          echo "Waiting 15s for GitHub API to index the new commit..."
-          sleep 15
-          echo "Waiting for checks to appear for SHA $CURRENT_SHA..."
-          MAX_CHECK_RETRIES=60
-          CHECK_RETRY=0
-          while [ $CHECK_RETRY -lt $MAX_CHECK_RETRIES ]; do
-            if gh pr checks "$PR_NUMBER" | grep -v "no checks reported" | grep -qiE "pending|pass|fail|progressing|waiting|success|failure"; then
-              echo "✅ Checks have been registered."
-              break
-            fi
-            echo "Still waiting for checks to be indexed... ($CHECK_RETRY/$MAX_CHECK_RETRIES)"
-            CHECK_RETRY=$((CHECK_RETRY + 1))
-            sleep 10
-          done
-
+          # Efficiently wait for checks to complete
           timeout 900 gh pr checks $PR_NUMBER --watch
 
       - name: Verify Squash and Rebase

--- a/.github/workflows/pr-enrichment.yml
+++ b/.github/workflows/pr-enrichment.yml
@@ -79,7 +79,7 @@ jobs:
 
           echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
 
-          # Fetch PR details with polling to handle API indexing delays.
+          # Fetch PR details immediately (polling removed).
           # Validation ensures both title and head SHA are available.
           # REDUCED REDUNDANCY: Metrics (additions, deletions, files) are handled in the Analyze step.
           FIELDS="title,body,baseRefName,headRefName,baseRefOid,headRefOid,author"
@@ -120,7 +120,7 @@ jobs:
           PR_NUMBER=${{ env.PR_NUMBER }}
 
           # Retrieval for PR metrics using GitHub API only.
-          # poll_pr_metrics encapsulates the logic for cross-referencing metadata and diffs.
+          # poll_pr_metrics encapsulates the logic for cross-referencing metadata and diffs (polling removed).
           METRICS_JSON=$(poll_pr_metrics "$PR_NUMBER" 18 10)
 
           if [ -z "$METRICS_JSON" ]; then

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -1106,43 +1106,24 @@ jobs:
             )
           fi
 
-          # --- Polling for parent commit checks ---
-          echo "⏳ Waiting for checks on parent commit ($PARENT_SHA) to complete..."
-          TIMEOUT=600 # 10 minutes
-          INTERVAL=30 # 30 seconds
-          ELAPSED=0
-          CHECKS_JSON=""
+          # --- Check parent commit checks (No Polling) ---
+          echo "🔎 Checking status of checks on parent commit ($PARENT_SHA)..."
 
-          while [ $ELAPSED -lt $TIMEOUT ]; do
-            # Fetch check runs for the parent commit
-            PARENT_CHECKS_JSON=$(gh api "repos/${{ github.repository }}/commits/${PARENT_SHA}/check-runs" --jq '.check_runs')
+          # Fetch check runs for the parent commit
+          PARENT_CHECKS_JSON=$(gh api "repos/${{ github.repository }}/commits/${PARENT_SHA}/check-runs" --jq '.check_runs')
 
-            # Filter for the specific jobs we care about
-            RELEVANT_CHECKS_JSON=$(echo "$PARENT_CHECKS_JSON" | jq -c --argjson jobs_to_copy "$(printf '%s\n' "${JOBS_TO_COPY[@]}" | jq -R . | jq -s .)" '[.[] | select(.name as $name | $jobs_to_copy | index($name))]')
+          # Filter for the specific jobs we care about
+          RELEVANT_CHECKS_JSON=$(echo "$PARENT_CHECKS_JSON" | jq -c --argjson jobs_to_copy "$(printf '%s\n' "${JOBS_TO_COPY[@]}" | jq -R . | jq -s .)" '[.[] | select(.name as $name | $jobs_to_copy | index($name))]')
 
-            # Count how many of the relevant checks are NOT completed
-            IN_PROGRESS_COUNT=$(echo "$RELEVANT_CHECKS_JSON" | jq '[.[] | select(.status != "completed")] | length')
+          CHECKS_JSON="$RELEVANT_CHECKS_JSON"
 
-            # Count how many jobs we expect and how many we found
-            EXPECTED_COUNT=${#JOBS_TO_COPY[@]}
-            FOUND_COUNT=$(echo "$RELEVANT_CHECKS_JSON" | jq 'length')
+          # Count how many of the relevant checks are NOT completed
+          IN_PROGRESS_COUNT=$(echo "$RELEVANT_CHECKS_JSON" | jq '[.[] | select(.status != "completed")] | length')
 
-            if [ "$FOUND_COUNT" -gt 0 ] && [ "$IN_PROGRESS_COUNT" -eq 0 ]; then
-              echo "✅ All relevant checks on parent commit have completed."
-              CHECKS_JSON="$RELEVANT_CHECKS_JSON"
-              break
-            fi
-
-            echo "Still waiting... ($IN_PROGRESS_COUNT checks in progress, found $FOUND_COUNT of ~${EXPECTED_COUNT}). Elapsed: ${ELAPSED}s"
-            ELAPSED=$((ELAPSED + INTERVAL))
-            sleep $INTERVAL
-          done
-
-          if [ -z "$CHECKS_JSON" ]; then
-            echo "::error::Timed out waiting for parent commit checks to complete after ${TIMEOUT} seconds."
-            echo "Last fetched checks:"
-            echo "$PARENT_CHECKS_JSON"
-            exit 1
+          if [ "$IN_PROGRESS_COUNT" -gt 0 ]; then
+            echo "::warning::Some parent checks are still in progress ($IN_PROGRESS_COUNT). Copying current status anyway."
+          else
+            echo "✅ All relevant parent checks are completed (or none found)."
           fi
 
           # --- Create new checks for the current commit ---

--- a/scripts/ci/github-utils.sh
+++ b/scripts/ci/github-utils.sh
@@ -29,132 +29,122 @@ retry_command() {
   return 1
 }
 
-# Polls for PR metadata until a validation condition is met.
+# Attempts to fetch PR metadata once.
 # Usage: poll_pr_view <pr_number> <max_attempts> <sleep_seconds> <fields> <jq_filter> <validation_jq_check>
+# Note: max_attempts and sleep_seconds are ignored/deprecated but kept for signature compatibility.
 poll_pr_view() {
   local pr_number=$1
-  local max_attempts=$2
-  local sleep_seconds=$3
   local fields=$4
   local jq_filter=$5
   local validation_jq_check=$6
 
-  for i in $(seq 1 "$max_attempts"); do
-    echo "📊 Polling PR $pr_number metadata (Attempt $i/$max_attempts)..." >&2
+  echo "📊 Fetching PR $pr_number metadata..." >&2
 
-    local data
-    data=$(retry_command 3 2 gh pr view "$pr_number" --json "$fields" --jq "$jq_filter")
+  local data
+  # Keep retry_command for API stability, not logic polling
+  data=$(retry_command 3 2 gh pr view "$pr_number" --json "$fields" --jq "$jq_filter")
 
-    if [ -n "$data" ]; then
-      if [ -n "$validation_jq_check" ]; then
-        if echo "$data" | jq -e "$validation_jq_check" >/dev/null 2>&1; then
-          echo "$data"
-          return 0
-        fi
+  if [ -n "$data" ]; then
+    if [ -n "$validation_jq_check" ]; then
+      if echo "$data" | jq -e "$validation_jq_check" >/dev/null 2>&1; then
+        echo "$data"
+        return 0
       else
+        echo "⚠️ Metadata validation failed (validation_jq_check returned false), but returning data anyway due to no-polling policy." >&2
         echo "$data"
         return 0
       fi
+    else
+      echo "$data"
+      return 0
     fi
+  fi
 
-    if [ "$i" -lt "$max_attempts" ]; then
-      echo "⏳ Metadata incomplete or validation failed. Retrying in ${sleep_seconds}s..." >&2
-      sleep "$sleep_seconds"
-    fi
-  done
-
+  echo "❌ Failed to fetch valid PR metadata." >&2
   return 1
 }
 
-# Polls for PR metrics (files, additions, deletions) until diff is available or timeout.
-# Optimized to use 'gh pr diff --numstat' as primary source of truth.
+# Attempts to fetch PR metrics (files, additions, deletions) once.
 # Usage: poll_pr_metrics <pr_number> <max_attempts> <sleep_seconds>
+# Note: max_attempts and sleep_seconds are ignored/deprecated but kept for signature compatibility.
 poll_pr_metrics() {
   local pr_number=$1
-  local max_attempts=$2
-  local sleep_seconds=$3
 
   local metadata=""
 
-  for i in $(seq 1 "$max_attempts"); do
-    echo "📊 Gathering PR metrics for $pr_number (Attempt $i/$max_attempts)..." >&2
+  echo "📊 Gathering PR metrics for $pr_number..." >&2
 
-    # 1. Fetch metadata baseline (including files for fallback)
-    metadata=$(retry_command 2 1 gh pr view "$pr_number" --json additions,deletions,changedFiles,files)
+  # 1. Fetch metadata baseline (including files for fallback)
+  metadata=$(retry_command 2 1 gh pr view "$pr_number" --json additions,deletions,changedFiles,files)
 
-    if [ -n "$metadata" ]; then
-      local meta_count=$(echo "$metadata" | jq -r '.changedFiles // 0')
-      local meta_add=$(echo "$metadata" | jq -r '.additions // 0')
-      local meta_del=$(echo "$metadata" | jq -r '.deletions // 0')
-
-      echo "   Current Metadata: Files=$meta_count, Additions=$meta_add, Deletions=$meta_del" >&2
-
-      # 2. Fetch live metrics from diff numstat
-      # This provides paths and counts in a single efficient call.
-      # We check for --numstat support to avoid errors on older gh versions.
-      local numstat
-      local use_numstat=false
-      local diff_cmd=("gh" "pr" "diff" "$pr_number" "--name-only")
-
-      if gh pr diff --help 2>&1 | grep -q -- --numstat; then
-         use_numstat=true
-         diff_cmd=("gh" "pr" "diff" "$pr_number" "--numstat")
-      fi
-
-      numstat=$(retry_command 2 1 "${diff_cmd[@]}")
-
-      if [ -n "$numstat" ]; then
-         local add=0
-         local del=0
-         local files=""
-
-         if [ "$use_numstat" = true ]; then
-             # Numstat output is typically tab-separated: additions\tdeletions\tpath
-             add=$(echo "$numstat" | awk '{sum+=$1} END {print sum+0}')
-             del=$(echo "$numstat" | awk '{sum+=$2} END {print sum+0}')
-             files=$(echo "$numstat" | cut -f3-)
-
-             # Fallback: if cut didn't work (e.g. space-separated), try awk-based extraction for path
-             if [ -z "$files" ] || [ "$(echo "$files" | grep -c .)" -eq 0 ]; then
-                files=$(echo "$numstat" | awk '{ $1=""; $2=""; print $0 }' | sed 's/^[[:space:]]*//')
-             fi
-         else
-             # name-only mode: output is just filenames
-             files="$numstat"
-             # Use metadata for counts as fallback since name-only doesn't provide them.
-             # Note: Metadata (gh pr view) comes from the GitHub API and may slightly lag behind
-             # the raw git diff, but it is the best available fallback when --numstat is unsupported.
-             add="$meta_add"
-             del="$meta_del"
-         fi
-
-         local count=$(echo "$files" | grep -c . || echo "0")
-
-         echo "   Current Diff: Files=$count, Additions=$add, Deletions=$del" >&2
-
-         if [ "$count" -gt 0 ]; then
-            # Return as JSON for easy consumption
-            jq -n --arg count "$count" --arg add "$add" --arg del "$del" --arg files "$files" \
-              '{file_count: ($count|tonumber), additions: ($add|tonumber), deletions: ($del|tonumber), files: $files, source: "diff"}'
-            return 0
-         fi
-      fi
-
-      if [ "$meta_count" -gt 0 ]; then
-        echo "⏳ Metadata indicates changes, but diff is empty. Waiting for indexing..." >&2
-      else
-        echo "❓ Both metadata and diff report 0 changes." >&2
-      fi
-    fi
-
-    if [ "$i" -lt "$max_attempts" ]; then
-      sleep "$sleep_seconds"
-    fi
-  done
-
-  # Final Fallback to metadata if diff polling failed
   if [ -n "$metadata" ]; then
-     echo "⚠️ Metrics polling timed out. Falling back to API metadata." >&2
+    local meta_count=$(echo "$metadata" | jq -r '.changedFiles // 0')
+    local meta_add=$(echo "$metadata" | jq -r '.additions // 0')
+    local meta_del=$(echo "$metadata" | jq -r '.deletions // 0')
+
+    echo "   Current Metadata: Files=$meta_count, Additions=$meta_add, Deletions=$meta_del" >&2
+
+    # 2. Fetch live metrics from diff numstat
+    # This provides paths and counts in a single efficient call.
+    # We check for --numstat support to avoid errors on older gh versions.
+    local numstat
+    local use_numstat=false
+    local diff_cmd=("gh" "pr" "diff" "$pr_number" "--name-only")
+
+    if gh pr diff --help 2>&1 | grep -q -- --numstat; then
+       use_numstat=true
+       diff_cmd=("gh" "pr" "diff" "$pr_number" "--numstat")
+    fi
+
+    numstat=$(retry_command 2 1 "${diff_cmd[@]}")
+
+    if [ -n "$numstat" ]; then
+       local add=0
+       local del=0
+       local files=""
+
+       if [ "$use_numstat" = true ]; then
+           # Numstat output is typically tab-separated: additions\tdeletions\tpath
+           add=$(echo "$numstat" | awk '{sum+=$1} END {print sum+0}')
+           del=$(echo "$numstat" | awk '{sum+=$2} END {print sum+0}')
+           files=$(echo "$numstat" | cut -f3-)
+
+           # Fallback: if cut didn't work (e.g. space-separated), try awk-based extraction for path
+           if [ -z "$files" ] || [ "$(echo "$files" | grep -c .)" -eq 0 ]; then
+              files=$(echo "$numstat" | awk '{ $1=""; $2=""; print $0 }' | sed 's/^[[:space:]]*//')
+           fi
+       else
+           # name-only mode: output is just filenames
+           files="$numstat"
+           # Use metadata for counts as fallback since name-only doesn't provide them.
+           # Note: Metadata (gh pr view) comes from the GitHub API and may slightly lag behind
+           # the raw git diff, but it is the best available fallback when --numstat is unsupported.
+           add="$meta_add"
+           del="$meta_del"
+       fi
+
+       local count=$(echo "$files" | grep -c . || echo "0")
+
+       echo "   Current Diff: Files=$count, Additions=$add, Deletions=$del" >&2
+
+       if [ "$count" -gt 0 ]; then
+          # Return as JSON for easy consumption
+          jq -n --arg count "$count" --arg add "$add" --arg del "$del" --arg files "$files" \
+            '{file_count: ($count|tonumber), additions: ($add|tonumber), deletions: ($del|tonumber), files: $files, source: "diff"}'
+          return 0
+       fi
+    fi
+
+    if [ "$meta_count" -gt 0 ]; then
+      echo "⚠️ Metadata indicates changes, but diff is empty. Falling back to API metadata immediately." >&2
+    else
+      echo "❓ Both metadata and diff report 0 changes." >&2
+    fi
+  fi
+
+  # Fallback to metadata
+  if [ -n "$metadata" ]; then
+     echo "⚠️ Metrics diff empty. Falling back to API metadata." >&2
      local meta_count=$(echo "$metadata" | jq -r '.changedFiles // 0')
      local meta_add=$(echo "$metadata" | jq -r '.additions // 0')
      local meta_del=$(echo "$metadata" | jq -r '.deletions // 0')

--- a/tests/unit/github-utils.bats
+++ b/tests/unit/github-utils.bats
@@ -113,7 +113,7 @@ export -f gh
   # It should return 0 because it falls back to metadata eventually
   [ "$status" -eq 0 ]
   [[ "$output" == *"Both metadata and diff report 0 changes"* ]]
-  [[ "$output" == *"Metrics polling timed out. Falling back to API metadata."* ]]
+  [[ "$output" == *"Metrics diff empty. Falling back to API metadata."* ]]
   [[ "$output" == *"\"source\": \"metadata\""* ]]
   [[ "$output" == *"\"file_count\": 0"* ]]
 }


### PR DESCRIPTION
This PR removes all explicit polling steps from CI workflows to improve efficiency and avoid waiting for results or checks, as per user request.

Key changes:
1.  **`scripts/ci/github-utils.sh`**:
    *   `poll_pr_view`: Removed the loop that waited for JSON validation. Now fetches metadata once and returns it (logging a warning if validation fails).
    *   `poll_pr_metrics`: Removed the loop that waited for diff/numstat availability. Now attempts to fetch metrics once; if the diff is empty, it falls back to metadata immediately instead of retrying.

2.  **`tests/unit/github-utils.bats`**:
    *   Updated the test case `poll_pr_metrics: handles empty diff gracefully by falling back to metadata` to expect the new "Metrics diff empty" log message instead of "Metrics polling timed out".

3.  **`.github/workflows/e2e-ci-tests.yml`**:
    *   Removed `while` loops that polled for the bot's commit SHA to change.
    *   Removed `while` loops that polled for checks to be registered.
    *   Removed fixed `sleep` delays.
    *   Retained `gh pr checks --watch` as an efficient, event-driven wait mechanism.

4.  **`.github/workflows/pr-quality.yml`**:
    *   Removed the `while` loop in the `copy-checks` job that waited for parent commit checks to complete. It now checks status once and proceeds.

5.  **`.github/workflows/pr-enrichment.yml`**:
    *   Updated comments to accurately reflect that the underlying utility functions no longer poll.

---
*PR created automatically by Jules for task [16811729931401712090](https://jules.google.com/task/16811729931401712090) started by @arii*