### PR TITLE
test(medium): Refactor Spotify command bus and cleanup dead code

### DIFF
--- a/context/webSocketReducer.ts
+++ b/context/webSocketReducer.ts
@@ -114,10 +114,6 @@ export const reducer = (
       return { ...state, activeAlerts: message.payload }
     case 'SPOTIFY_SERVICE_INIT_UPDATE':
       return { ...state, spotifyServiceInitialized: message.payload }
-    case 'EXECUTE_SPOTIFY':
-      // This message type is handled by useDashboardRegistration hook
-      // We don't need to update state here, just pass it through
-      return state
     default:
       return state
   }

--- a/hooks/useDashboardRegistration.ts
+++ b/hooks/useDashboardRegistration.ts
@@ -13,7 +13,6 @@ export const useDashboardRegistration = (player: unknown | null): void => {
   useEffect(() => {
     if (!player) return
 
-    // Register this client as the "Dashboard".
     sendData({ type: 'REGISTER_CLIENT', role: 'dashboard' })
   }, [player, sendData])
 }

--- a/hooks/useSpotifyCommand.ts
+++ b/hooks/useSpotifyCommand.ts
@@ -74,7 +74,7 @@ export const useSpotifyCommand = () => {
       const message: SpotifyCommandMessage = {
         type: 'SPOTIFY_COMMAND',
         command,
-        ...(payload as Partial<SpotifyCommandMessage>),
+        ...(payload || {}),
         deviceId: resolvedDeviceId,
       }
 

--- a/tests/unit/hooks/useSpotifyCommand.test.tsx
+++ b/tests/unit/hooks/useSpotifyCommand.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook, act } from '@testing-library/react'
+import { useSpotifyCommand } from '@/hooks/useSpotifyCommand'
+import { useWebSocket } from '@/context/WebSocketContext'
+import { HRM_WEB_PLAYER_NAME } from '@/constants/spotify'
+
+// Mock useWebSocket
+jest.mock('@/context/WebSocketContext', () => ({
+  useWebSocket: jest.fn(),
+}))
+
+describe('useSpotifyCommand', () => {
+  const mockSendData = jest.fn()
+
+  const defaultSpotifyData = {
+    devices: [],
+    playback: {
+      track: {},
+      is_playing: false,
+      volume_percent: 50,
+    },
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(useWebSocket as jest.Mock).mockReturnValue({
+      spotifyData: defaultSpotifyData,
+      sendData: mockSendData,
+    })
+  })
+
+  it('sends PLAY command with deviceId from payload (highest priority)', () => {
+    const { result } = renderHook(() => useSpotifyCommand())
+
+    act(() => {
+      result.current.execute('PLAY', {
+        deviceId: 'payload-device',
+        uri: 'spotify:track:test'
+      })
+    })
+
+    expect(mockSendData).toHaveBeenCalledWith({
+      type: 'SPOTIFY_COMMAND',
+      command: 'PLAY',
+      deviceId: 'payload-device',
+      uri: 'spotify:track:test',
+    })
+  })
+
+  it('sends PLAY command using active device if no payload deviceId', () => {
+    const activeDeviceData = {
+      ...defaultSpotifyData,
+      devices: [
+        { id: 'active-device', name: 'Speaker', is_active: true },
+        { id: 'other-device', name: 'Phone', is_active: false },
+      ],
+    }
+    ;(useWebSocket as jest.Mock).mockReturnValue({
+      spotifyData: activeDeviceData,
+      sendData: mockSendData,
+    })
+
+    const { result } = renderHook(() => useSpotifyCommand())
+
+    act(() => {
+      result.current.execute('PLAY', { uri: 'spotify:track:test' })
+    })
+
+    expect(mockSendData).toHaveBeenCalledWith({
+      type: 'SPOTIFY_COMMAND',
+      command: 'PLAY',
+      deviceId: 'active-device',
+      uri: 'spotify:track:test',
+    })
+  })
+
+  it('sends PLAY command using HRM Web Player if no active device', () => {
+    const hrmDeviceData = {
+      ...defaultSpotifyData,
+      devices: [
+        { id: 'hrm-device', name: HRM_WEB_PLAYER_NAME, is_active: false },
+        { id: 'other-device', name: 'Phone', is_active: false },
+      ],
+    }
+    ;(useWebSocket as jest.Mock).mockReturnValue({
+      spotifyData: hrmDeviceData,
+      sendData: mockSendData,
+    })
+
+    const { result } = renderHook(() => useSpotifyCommand())
+
+    act(() => {
+      result.current.execute('PLAY', { uri: 'spotify:track:test' })
+    })
+
+    expect(mockSendData).toHaveBeenCalledWith({
+      type: 'SPOTIFY_COMMAND',
+      command: 'PLAY',
+      deviceId: 'hrm-device',
+      uri: 'spotify:track:test',
+    })
+  })
+
+  it('sends PLAY command with undefined deviceId if no devices available', () => {
+    const { result } = renderHook(() => useSpotifyCommand())
+
+    act(() => {
+      result.current.execute('PLAY', { uri: 'spotify:track:test' })
+    })
+
+    expect(mockSendData).toHaveBeenCalledWith({
+      type: 'SPOTIFY_COMMAND',
+      command: 'PLAY',
+      deviceId: undefined,
+      uri: 'spotify:track:test',
+    })
+  })
+
+  it('sends SET_VOLUME command correctly', () => {
+    const { result } = renderHook(() => useSpotifyCommand())
+
+    act(() => {
+      result.current.execute('SET_VOLUME', { volume: 75, deviceId: 'target-device' })
+    })
+
+    expect(mockSendData).toHaveBeenCalledWith({
+      type: 'SPOTIFY_COMMAND',
+      command: 'SET_VOLUME',
+      deviceId: 'target-device',
+      volume: 75,
+    })
+  })
+
+  it('sends TRANSFER_PLAYBACK command correctly', () => {
+    const { result } = renderHook(() => useSpotifyCommand())
+
+    act(() => {
+      result.current.execute('TRANSFER_PLAYBACK', { deviceId: 'new-device' })
+    })
+
+    expect(mockSendData).toHaveBeenCalledWith({
+      type: 'SPOTIFY_COMMAND',
+      command: 'TRANSFER_PLAYBACK',
+      deviceId: 'new-device',
+    })
+  })
+})

--- a/tests/unit/socketManager.test.ts
+++ b/tests/unit/socketManager.test.ts
@@ -560,13 +560,6 @@ describe('WebSocket Manager', () => {
       })
       mockWs.emit('message', message.toString())
 
-      // Should NOT have sent EXECUTE_SPOTIFY to dashboard
-      expect(sendWebSocketMessage).not.toHaveBeenCalledWith(
-        dashboardWs,
-        expect.objectContaining({ type: 'EXECUTE_SPOTIFY' }),
-        expect.any(String)
-      )
-
       // Should still call the server-side service
       expect(mockServices.spotifyService.handleCommand).toHaveBeenCalledWith(
         'PLAY',

--- a/types/websocket.ts
+++ b/types/websocket.ts
@@ -90,7 +90,6 @@ export type ServerMessage =
   | { type: 'SPOTIFY_SERVICE_INIT_UPDATE'; payload: boolean }
   | { type: 'PONG' } // Add PONG message type for server-to-client heartbeat
   | { type: 'DEVICE_OFFLINE'; payload: { deviceId: string } }
-  | SpotifyExecutionMessage
 
 /**
  * BroadcastData: a small, optional-shaped payload that services may send to
@@ -173,11 +172,6 @@ export interface GetStateMessage {
 export interface ClientRegistrationMessage {
   type: 'REGISTER_CLIENT'
   role: 'dashboard' | 'controller'
-}
-
-export interface SpotifyExecutionMessage {
-  type: 'EXECUTE_SPOTIFY'
-  payload: SpotifyCommandMessage
 }
 
 export interface PingMessage {


### PR DESCRIPTION
## Description
This pull request refactors the Spotify command bus and cleans up dead code. It addresses feedback from a previous audit by:
1. Improving type safety in `hooks/useSpotifyCommand.ts`.
2. Adding comprehensive unit tests for `useSpotifyCommand`.
3. Cleaning up dead code related to the legacy `EXECUTE_SPOTIFY` message type, which was replaced by the unified service bus approach.
4. Removing redundant comments.

Note: `hooks/useSpotifyRemoteExecution.ts` was already missing from the codebase, confirming its deletion.

Fixes # (issue)

## Change Type: 🏗️ Refactoring (code change that neither fixes bug nor adds feature)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [x] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [x] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

This PR addresses the feedback from the previous audit by:
1. Improving type safety in `hooks/useSpotifyCommand.ts`.
2. Adding comprehensive unit tests for `useSpotifyCommand`.
3. Cleaning up dead code related to the legacy `EXECUTE_SPOTIFY` message type, which was replaced by the unified service bus approach.
4. Removing redundant comments.

Note: `hooks/useSpotifyRemoteExecution.ts` was already missing from the codebase, confirming its deletion.

---
*PR created automatically by Jules for task [1540960530068960329](https://jules.google.com/task/1540960530068960329) started by @arii*
</details>