### PR TITLE
test(medium): Fix linting issues and finalize Spotify command bus refactor

### DIFF
--- a/context/webSocketReducer.ts
+++ b/context/webSocketReducer.ts
@@ -114,10 +114,6 @@ export const reducer = (
       return { ...state, activeAlerts: message.payload }
     case 'SPOTIFY_SERVICE_INIT_UPDATE':
       return { ...state, spotifyServiceInitialized: message.payload }
-    case 'EXECUTE_SPOTIFY':
-      // This message type is handled by useDashboardRegistration hook
-      // We don't need to update state here, just pass it through
-      return state
     default:
       return state
   }

--- a/hooks/useDashboardRegistration.ts
+++ b/hooks/useDashboardRegistration.ts
@@ -13,7 +13,6 @@ export const useDashboardRegistration = (player: unknown | null): void => {
   useEffect(() => {
     if (!player) return
 
-    // Register this client as the "Dashboard".
     sendData({ type: 'REGISTER_CLIENT', role: 'dashboard' })
   }, [player, sendData])
 }

--- a/hooks/useSpotifyCommand.ts
+++ b/hooks/useSpotifyCommand.ts
@@ -74,7 +74,7 @@ export const useSpotifyCommand = () => {
       const message: SpotifyCommandMessage = {
         type: 'SPOTIFY_COMMAND',
         command,
-        ...(payload as Partial<SpotifyCommandMessage>),
+        ...(payload || {}),
         deviceId: resolvedDeviceId,
       }
 

--- a/hooks/useSpotifyCommand.ts
+++ b/hooks/useSpotifyCommand.ts
@@ -72,9 +72,9 @@ export const useSpotifyCommand = () => {
         payloadDeviceId || activeDevice?.id || hrmPlayer?.id || undefined
 
       const message: SpotifyCommandMessage = {
+        ...(payload || {}),
         type: 'SPOTIFY_COMMAND',
         command,
-        ...(payload || {}),
         deviceId: resolvedDeviceId,
       }
 

--- a/tests/unit/hooks/useSpotifyCommand.test.ts
+++ b/tests/unit/hooks/useSpotifyCommand.test.ts
@@ -3,243 +3,150 @@
  */
 import { renderHook, act } from '@testing-library/react'
 import { useSpotifyCommand } from '@/hooks/useSpotifyCommand'
-import { useWebSocket, WebSocketContextType } from '@/context/WebSocketContext'
+import { useWebSocket } from '@/context/WebSocketContext'
 import { HRM_WEB_PLAYER_NAME } from '@/constants/spotify'
-import { jest } from '@jest/globals'
 
-// Mock the WebSocket context
-jest.mock('@/context/WebSocketContext')
-
-const mockedUseWebSocket = useWebSocket as jest.MockedFunction<
-  typeof useWebSocket
->
+// Mock useWebSocket
+jest.mock('@/context/WebSocketContext', () => ({
+  useWebSocket: jest.fn(),
+}))
 
 describe('useSpotifyCommand', () => {
-  let sendDataMock: jest.Mock
+  const mockSendData = jest.fn()
+
+  const defaultSpotifyData = {
+    devices: [],
+    playback: {
+      track: {},
+      is_playing: false,
+      volume_percent: 50,
+    },
+  }
 
   beforeEach(() => {
     jest.clearAllMocks()
-    sendDataMock = jest.fn()
-
-    mockedUseWebSocket.mockReturnValue({
-      spotifyData: {
-        devices: [],
-        playback: {
-          track: {
-            id: 't1',
-            name: 'Song',
-            artist: 'Artist',
-            albumName: 'Album',
-            albumArtUrl: 'url',
-          },
-          is_playing: true,
-          volume_percent: 50,
-        },
-      },
-      sendData: sendDataMock,
-      connectionStatus: 'Connected',
-      connect: jest.fn(),
-      disconnect: jest.fn(),
-      hrmData: [],
-      activeAlerts: [],
-      spotifyServiceInitialized: true,
-    } as unknown as WebSocketContextType)
-  })
-
-  describe('Device ID Resolution Logic', () => {
-    it('Priority 1: Payload deviceId overrides everything', () => {
-      mockedUseWebSocket.mockReturnValue({
-        spotifyData: {
-          devices: [
-            {
-              id: 'active-device',
-              name: 'Active Speaker',
-              is_active: true,
-              volume_percent: 50,
-            },
-            {
-              id: 'hrm-device',
-              name: HRM_WEB_PLAYER_NAME,
-              is_active: false,
-              volume_percent: 50,
-            },
-          ],
-        },
-        sendData: sendDataMock,
-      } as unknown as WebSocketContextType)
-
-      const { result } = renderHook(() => useSpotifyCommand())
-
-      act(() => {
-        // Even with an active device and HRM player available, payload ID 'target-device' should be used
-        result.current.execute('PLAY', { deviceId: 'target-device' })
-      })
-
-      expect(sendDataMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          command: 'PLAY',
-          deviceId: 'target-device',
-        })
-      )
-    })
-
-    it('Priority 2: Active Device is used if no payload deviceId', () => {
-      mockedUseWebSocket.mockReturnValue({
-        spotifyData: {
-          devices: [
-            {
-              id: 'active-device',
-              name: 'Active Speaker',
-              is_active: true,
-              volume_percent: 50,
-            },
-            {
-              id: 'hrm-device',
-              name: HRM_WEB_PLAYER_NAME,
-              is_active: false,
-              volume_percent: 50,
-            },
-          ],
-        },
-        sendData: sendDataMock,
-      } as unknown as WebSocketContextType)
-
-      const { result } = renderHook(() => useSpotifyCommand())
-
-      act(() => {
-        // No payload deviceId -> should use 'active-device'
-        result.current.execute('PAUSE')
-      })
-
-      expect(sendDataMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          command: 'PAUSE',
-          deviceId: 'active-device',
-        })
-      )
-    })
-
-    it('Priority 3: HRM Web Player is used if no payload deviceId and no active device', () => {
-      mockedUseWebSocket.mockReturnValue({
-        spotifyData: {
-          devices: [
-            {
-              id: 'inactive-speaker',
-              name: 'Inactive Speaker',
-              is_active: false,
-              volume_percent: 50,
-            },
-            {
-              id: 'hrm-device',
-              name: HRM_WEB_PLAYER_NAME,
-              is_active: false,
-              volume_percent: 50,
-            },
-          ],
-        },
-        sendData: sendDataMock,
-      } as unknown as WebSocketContextType)
-
-      const { result } = renderHook(() => useSpotifyCommand())
-
-      act(() => {
-        // No payload, no active device -> should fallback to 'hrm-device'
-        result.current.execute('NEXT')
-      })
-
-      expect(sendDataMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          command: 'NEXT',
-          deviceId: 'hrm-device',
-        })
-      )
-    })
-
-    it('Priority 4: Returns undefined if no devices available', () => {
-      mockedUseWebSocket.mockReturnValue({
-        spotifyData: {
-          devices: [], // No devices at all
-        },
-        sendData: sendDataMock,
-      } as unknown as WebSocketContextType)
-
-      const { result } = renderHook(() => useSpotifyCommand())
-
-      act(() => {
-        result.current.execute('PREVIOUS')
-      })
-
-      expect(sendDataMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          command: 'PREVIOUS',
-          deviceId: undefined,
-        })
-      )
+    ;(useWebSocket as jest.Mock).mockReturnValue({
+      spotifyData: defaultSpotifyData,
+      sendData: mockSendData,
     })
   })
 
-  describe('Payload Handling', () => {
-    it('Merges payload properties with command', () => {
-      const { result } = renderHook(() => useSpotifyCommand())
+  it('sends PLAY command with deviceId from payload (highest priority)', () => {
+    const { result } = renderHook(() => useSpotifyCommand())
 
-      act(() => {
-        result.current.execute('PLAY', {
-          contextUri: 'spotify:album:123',
-          offset: { position: 5 },
-        })
+    act(() => {
+      result.current.execute('PLAY', {
+        deviceId: 'payload-device',
+        uri: 'spotify:track:test',
       })
-
-      expect(sendDataMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          command: 'PLAY',
-          contextUri: 'spotify:album:123',
-          offset: { position: 5 },
-        })
-      )
     })
 
-    it('Ensures deviceId property exists in message even if resolved to undefined', () => {
-      mockedUseWebSocket.mockReturnValue({
-        spotifyData: { devices: [] },
-        sendData: sendDataMock,
-      } as unknown as WebSocketContextType)
-
-      const { result } = renderHook(() => useSpotifyCommand())
-
-      act(() => {
-        result.current.execute('PLAY')
-      })
-
-      // The resolvedDeviceId will be undefined, but the property should be present
-      expect(sendDataMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          command: 'PLAY',
-          deviceId: undefined,
-        })
-      )
+    expect(mockSendData).toHaveBeenCalledWith({
+      type: 'SPOTIFY_COMMAND',
+      command: 'PLAY',
+      deviceId: 'payload-device',
+      uri: 'spotify:track:test',
     })
   })
 
-  // Keep existing tests for backward compatibility / broader coverage check
-  it('should return correct status flags', () => {
-    mockedUseWebSocket.mockReturnValue({
-      spotifyData: {
-        devices: [
-          {
-            id: 'd1',
-            name: HRM_WEB_PLAYER_NAME,
-            is_active: true,
-            volume_percent: 50,
-          },
-        ],
-        playback: { is_playing: true },
-      },
-      sendData: sendDataMock,
-    } as unknown as WebSocketContextType)
+  it('sends PLAY command using active device if no payload deviceId', () => {
+    const activeDeviceData = {
+      ...defaultSpotifyData,
+      devices: [
+        { id: 'active-device', name: 'Speaker', is_active: true },
+        { id: 'other-device', name: 'Phone', is_active: false },
+      ],
+    }
+    ;(useWebSocket as jest.Mock).mockReturnValue({
+      spotifyData: activeDeviceData,
+      sendData: mockSendData,
+    })
 
     const { result } = renderHook(() => useSpotifyCommand())
 
-    expect(result.current.isHrmPlayerActive).toBe(true)
-    expect(result.current.activeDevice?.id).toBe('d1')
+    act(() => {
+      result.current.execute('PLAY', { uri: 'spotify:track:test' })
+    })
+
+    expect(mockSendData).toHaveBeenCalledWith({
+      type: 'SPOTIFY_COMMAND',
+      command: 'PLAY',
+      deviceId: 'active-device',
+      uri: 'spotify:track:test',
+    })
+  })
+
+  it('sends PLAY command using HRM Web Player if no active device', () => {
+    const hrmDeviceData = {
+      ...defaultSpotifyData,
+      devices: [
+        { id: 'hrm-device', name: HRM_WEB_PLAYER_NAME, is_active: false },
+        { id: 'other-device', name: 'Phone', is_active: false },
+      ],
+    }
+    ;(useWebSocket as jest.Mock).mockReturnValue({
+      spotifyData: hrmDeviceData,
+      sendData: mockSendData,
+    })
+
+    const { result } = renderHook(() => useSpotifyCommand())
+
+    act(() => {
+      result.current.execute('PLAY', { uri: 'spotify:track:test' })
+    })
+
+    expect(mockSendData).toHaveBeenCalledWith({
+      type: 'SPOTIFY_COMMAND',
+      command: 'PLAY',
+      deviceId: 'hrm-device',
+      uri: 'spotify:track:test',
+    })
+  })
+
+  it('sends PLAY command with undefined deviceId if no devices available', () => {
+    const { result } = renderHook(() => useSpotifyCommand())
+
+    act(() => {
+      result.current.execute('PLAY', { uri: 'spotify:track:test' })
+    })
+
+    expect(mockSendData).toHaveBeenCalledWith({
+      type: 'SPOTIFY_COMMAND',
+      command: 'PLAY',
+      deviceId: undefined,
+      uri: 'spotify:track:test',
+    })
+  })
+
+  it('sends SET_VOLUME command correctly', () => {
+    const { result } = renderHook(() => useSpotifyCommand())
+
+    act(() => {
+      result.current.execute('SET_VOLUME', {
+        volume: 75,
+        deviceId: 'target-device',
+      })
+    })
+
+    expect(mockSendData).toHaveBeenCalledWith({
+      type: 'SPOTIFY_COMMAND',
+      command: 'SET_VOLUME',
+      deviceId: 'target-device',
+      volume: 75,
+    })
+  })
+
+  it('sends TRANSFER_PLAYBACK command correctly', () => {
+    const { result } = renderHook(() => useSpotifyCommand())
+
+    act(() => {
+      result.current.execute('TRANSFER_PLAYBACK', { deviceId: 'new-device' })
+    })
+
+    expect(mockSendData).toHaveBeenCalledWith({
+      type: 'SPOTIFY_COMMAND',
+      command: 'TRANSFER_PLAYBACK',
+      deviceId: 'new-device',
+    })
   })
 })

--- a/tests/unit/hooks/useSpotifyCommand.test.ts
+++ b/tests/unit/hooks/useSpotifyCommand.test.ts
@@ -23,12 +23,17 @@ describe('useSpotifyCommand', () => {
     },
   }
 
-  beforeEach(() => {
-    jest.clearAllMocks()
+  // Helper to setup mock state
+  const mockSpotifyState = (devices: unknown[] = []) => {
     ;(useWebSocket as jest.Mock).mockReturnValue({
-      spotifyData: defaultSpotifyData,
+      spotifyData: { ...defaultSpotifyData, devices },
       sendData: mockSendData,
     })
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockSpotifyState()
   })
 
   it('sends PLAY command with deviceId from payload (highest priority)', () => {
@@ -50,17 +55,10 @@ describe('useSpotifyCommand', () => {
   })
 
   it('sends PLAY command using active device if no payload deviceId', () => {
-    const activeDeviceData = {
-      ...defaultSpotifyData,
-      devices: [
-        { id: 'active-device', name: 'Speaker', is_active: true },
-        { id: 'other-device', name: 'Phone', is_active: false },
-      ],
-    }
-    ;(useWebSocket as jest.Mock).mockReturnValue({
-      spotifyData: activeDeviceData,
-      sendData: mockSendData,
-    })
+    mockSpotifyState([
+      { id: 'active-device', name: 'Speaker', is_active: true },
+      { id: 'other-device', name: 'Phone', is_active: false },
+    ])
 
     const { result } = renderHook(() => useSpotifyCommand())
 
@@ -77,17 +75,10 @@ describe('useSpotifyCommand', () => {
   })
 
   it('sends PLAY command using HRM Web Player if no active device', () => {
-    const hrmDeviceData = {
-      ...defaultSpotifyData,
-      devices: [
-        { id: 'hrm-device', name: HRM_WEB_PLAYER_NAME, is_active: false },
-        { id: 'other-device', name: 'Phone', is_active: false },
-      ],
-    }
-    ;(useWebSocket as jest.Mock).mockReturnValue({
-      spotifyData: hrmDeviceData,
-      sendData: mockSendData,
-    })
+    mockSpotifyState([
+      { id: 'hrm-device', name: HRM_WEB_PLAYER_NAME, is_active: false },
+      { id: 'other-device', name: 'Phone', is_active: false },
+    ])
 
     const { result } = renderHook(() => useSpotifyCommand())
 

--- a/tests/unit/socketManager.test.ts
+++ b/tests/unit/socketManager.test.ts
@@ -560,13 +560,6 @@ describe('WebSocket Manager', () => {
       })
       mockWs.emit('message', message.toString())
 
-      // Should NOT have sent EXECUTE_SPOTIFY to dashboard
-      expect(sendWebSocketMessage).not.toHaveBeenCalledWith(
-        dashboardWs,
-        expect.objectContaining({ type: 'EXECUTE_SPOTIFY' }),
-        expect.any(String)
-      )
-
       // Should still call the server-side service
       expect(mockServices.spotifyService.handleCommand).toHaveBeenCalledWith(
         'PLAY',

--- a/types/websocket.ts
+++ b/types/websocket.ts
@@ -90,7 +90,6 @@ export type ServerMessage =
   | { type: 'SPOTIFY_SERVICE_INIT_UPDATE'; payload: boolean }
   | { type: 'PONG' } // Add PONG message type for server-to-client heartbeat
   | { type: 'DEVICE_OFFLINE'; payload: { deviceId: string } }
-  | SpotifyExecutionMessage
 
 /**
  * BroadcastData: a small, optional-shaped payload that services may send to
@@ -173,11 +172,6 @@ export interface GetStateMessage {
 export interface ClientRegistrationMessage {
   type: 'REGISTER_CLIENT'
   role: 'dashboard' | 'controller'
-}
-
-export interface SpotifyExecutionMessage {
-  type: 'EXECUTE_SPOTIFY'
-  payload: SpotifyCommandMessage
 }
 
 export interface PingMessage {


### PR DESCRIPTION
## Description

This submission fixes the linting failure in the CI/CD pipeline by renaming the test file to match the project's TypeScript configuration. It also includes the previously implemented refactor of the Spotify command bus, improved type safety, and cleanup of dead code.

**Motivation and Context:**
*   **Refactor:** `hooks/useSpotifyCommand.ts` now uses safe type spreading.
*   **Test:** Added `tests/unit/hooks/useSpotifyCommand.test.ts` (renamed from `.tsx`).
*   **Cleanup:** Removed `EXECUTE_SPOTIFY` and related dead code.
*   **Fix:** Resolved linting errors.

Dependencies: None.

Fixes # (issue)

## Change Type: 🏗️ Refactoring (code change that neither fixes bug nor adds feature)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [x] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [x] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

This submission fixes the linting failure in the CI/CD pipeline by renaming the test file to match the project's TypeScript configuration. It also includes the previously implemented refactor of the Spotify command bus, improved type safety, and cleanup of dead code.

Changes:
1.  **Refactor:** `hooks/useSpotifyCommand.ts` now uses safe type spreading.
2.  **Test:** Added `tests/unit/hooks/useSpotifyCommand.test.ts` (renamed from `.tsx`).
3.  **Cleanup:** Removed `EXECUTE_SPOTIFY` and related dead code.
4.  **Fix:** Resolved linting errors.

---
*PR created automatically by Jules for task [1540960530068960329](https://jules.google.com/task/1540960530068960329) started by @arii*
</details>