### PR TITLE
feat(large): Fix: Resolve merge conflicts and standardize aliases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,8 +86,4 @@ verification/screenshots/
 .next_prod/
 release.tar.gz
 knip_report.txt
-<<<<<<< HEAD
-.cache/
-=======
 /.cache/
->>>>>>> origin/leader

--- a/app/client/experimental/components/ExperimentalAnalyticsPage.tsx
+++ b/app/client/experimental/components/ExperimentalAnalyticsPage.tsx
@@ -25,20 +25,12 @@ const defaultTimeInZones: Record<HeartRateZone, number> = {
 }
 
 // Components
-<<<<<<< HEAD
 import WorkoutSummary from '@/app/client/experimental/components/WorkoutSummary'
 import ZoneDistribution from '@/app/client/experimental/components/ZoneDistribution'
 import CalorieTracker from '@/app/client/experimental/components/CalorieTracker'
 import SessionList from '@/app/client/experimental/components/SessionList'
 import SessionDetail from '@/app/client/experimental/components/SessionDetail'
-=======
-import WorkoutSummary from './WorkoutSummary'
-import ZoneDistribution from './ZoneDistribution'
-import CalorieTracker from './CalorieTracker'
-import SessionList from './SessionList'
-import SessionDetail from './SessionDetail'
 import { useTestPageReady } from '@/hooks/useTestPageReady'
->>>>>>> origin/leader
 
 const HeartRateTimeSeries = dynamic(
   () => import('@/app/client/experimental/components/HeartRateTimeSeries'),

--- a/app/client/mock/page.tsx
+++ b/app/client/mock/page.tsx
@@ -1,3 +1,4 @@
+// app/client/mock/page.tsx
 'use client'
 
 import HeartBroken from '@mui/icons-material/HeartBroken'
@@ -12,22 +13,13 @@ import Typography from '@mui/material/Typography'
 import { useCallback, useEffect, useState } from 'react'
 import BottomNavBar from '@/components/BottomNavBar'
 import { useWebSocket } from '@/context/WebSocketContext'
-<<<<<<< HEAD
+import { useTestPageReady } from '@/hooks/useTestPageReady'
 import { HrmInputMessage, HrmMetadataUpdateMessage } from '@/types/websocket'
 import {
   calculateZoneFromMaxHr,
   calculateMaxHr,
   toHeartRateZone,
 } from '@/lib/shared/hr-zones'
-=======
-import { useTestPageReady } from '@/hooks/useTestPageReady'
-import {
-  HrmInputMessage,
-  HrmMetadataUpdateMessage,
-} from '../../../types/websocket'
-import { calculateZoneFromMaxHr, toHeartRateZone } from '@/lib/shared/hr-zones'
-import { calculateMaxHr } from '@/utils/hrCalculations'
->>>>>>> origin/leader
 
 export default function MockPage() {
   const { sendData, connectionStatus } = useWebSocket()

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -115,6 +115,7 @@ export const WebSocketProvider = ({
           window.location.search.includes('testing=true'))
       ) {
         window.__TEST_CONTROLS__ = {
+          ...(window.__TEST_CONTROLS__ || {}),
           dispatch: (msg: unknown) => dispatch(msg as ServerMessage),
           disconnect: () => {},
           connect: () => {},

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -24,13 +24,6 @@ import { ConnectedHrmData as HrmData } from '@/types/websocket'
 
 export type { HrmData }
 
-// Define a type for the test controls
-interface TestControls {
-  dispatch: (message: unknown) => void
-  disconnect: () => void
-  connect: () => void
-}
-
 export interface WebSocketContextType extends WebSocketState {
   connectionStatus: string
   sendData: (data: ClientCommandMessage) => void
@@ -121,11 +114,7 @@ export const WebSocketProvider = ({
         (typeof window !== 'undefined' &&
           window.location.search.includes('testing=true'))
       ) {
-        // Use type assertion to extend Window interface locally without using 'any'
-        const win = window as unknown as Window & {
-          __TEST_CONTROLS__: TestControls
-        }
-        win.__TEST_CONTROLS__ = {
+        window.__TEST_CONTROLS__ = {
           dispatch: (msg: unknown) => dispatch(msg as ServerMessage),
           disconnect: () => {},
           connect: () => {},
@@ -340,13 +329,9 @@ export const WebSocketProvider = ({
         process.env.NEXT_PUBLIC_TESTING === 'true' ||
         window.location.search.includes('testing=true'))
     ) {
-      // Use type assertion to extend Window interface locally without using 'any'
-      const win = window as unknown as Window & {
-        __TEST_CONTROLS__?: TestControls
-      }
-      if (win.__TEST_CONTROLS__) {
-        win.__TEST_CONTROLS__.disconnect = disconnect
-        win.__TEST_CONTROLS__.connect = connect
+      if (window.__TEST_CONTROLS__) {
+        window.__TEST_CONTROLS__.disconnect = disconnect
+        window.__TEST_CONTROLS__.connect = connect
       }
     }
 

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -15,12 +15,6 @@ import {
 import { ClientCommandMessage, ServerMessage } from '@/types/websocket'
 import { getWebSocketURL } from '@/utils/urls'
 
-// Define a type for the test controls to avoid using 'any'
-interface TestControls {
-  dispatch: (message: ServerMessage) => void
-  disconnect: () => void
-  connect: () => void
-}
 import {
   INITIAL_STATE,
   WebSocketState,
@@ -120,9 +114,7 @@ export const WebSocketProvider = ({
         (typeof window !== 'undefined' &&
           window.location.search.includes('testing=true'))
       ) {
-        ;(
-          window as Window & { __TEST_CONTROLS__?: TestControls }
-        ).__TEST_CONTROLS__ = {
+        ;(window as any).__TEST_CONTROLS__ = {
           dispatch,
           disconnect: () => {},
           connect: () => {},
@@ -337,9 +329,7 @@ export const WebSocketProvider = ({
         process.env.NEXT_PUBLIC_TESTING === 'true' ||
         window.location.search.includes('testing=true'))
     ) {
-      const testControls = (
-        window as Window & { __TEST_CONTROLS__?: TestControls }
-      ).__TEST_CONTROLS__
+      const testControls = (window as any).__TEST_CONTROLS__
       if (testControls) {
         testControls.disconnect = disconnect
         testControls.connect = connect

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -24,6 +24,13 @@ import { ConnectedHrmData as HrmData } from '@/types/websocket'
 
 export type { HrmData }
 
+// Define a type for the test controls
+interface TestControls {
+  dispatch: (message: unknown) => void
+  disconnect: () => void
+  connect: () => void
+}
+
 export interface WebSocketContextType extends WebSocketState {
   connectionStatus: string
   sendData: (data: ClientCommandMessage) => void
@@ -114,8 +121,12 @@ export const WebSocketProvider = ({
         (typeof window !== 'undefined' &&
           window.location.search.includes('testing=true'))
       ) {
-        ;(window as any).__TEST_CONTROLS__ = {
-          dispatch,
+        // Use type assertion to extend Window interface locally without using 'any'
+        const win = window as unknown as Window & {
+          __TEST_CONTROLS__: TestControls
+        }
+        win.__TEST_CONTROLS__ = {
+          dispatch: (msg: unknown) => dispatch(msg as ServerMessage),
           disconnect: () => {},
           connect: () => {},
         }
@@ -329,10 +340,13 @@ export const WebSocketProvider = ({
         process.env.NEXT_PUBLIC_TESTING === 'true' ||
         window.location.search.includes('testing=true'))
     ) {
-      const testControls = (window as any).__TEST_CONTROLS__
-      if (testControls) {
-        testControls.disconnect = disconnect
-        testControls.connect = connect
+      // Use type assertion to extend Window interface locally without using 'any'
+      const win = window as unknown as Window & {
+        __TEST_CONTROLS__?: TestControls
+      }
+      if (win.__TEST_CONTROLS__) {
+        win.__TEST_CONTROLS__.disconnect = disconnect
+        win.__TEST_CONTROLS__.connect = connect
       }
     }
 

--- a/hooks/useBluetoothHRM.ts
+++ b/hooks/useBluetoothHRM.ts
@@ -344,8 +344,8 @@ const useBluetoothHRM = (props: UseBluetoothHRMProps = {}) => {
       typeof window !== 'undefined' &&
       process.env.NEXT_PUBLIC_TESTING === 'true'
     ) {
-      window.TEST_CONTROLS = {
-        ...window.TEST_CONTROLS,
+      window.__TEST_CONTROLS__ = {
+        ...window.__TEST_CONTROLS__,
         setHrmStatus: setStatus,
         setCustomHrmStatusMessage: setCustomStatusMessage,
       }
@@ -368,9 +368,10 @@ const useBluetoothHRM = (props: UseBluetoothHRMProps = {}) => {
         typeof window !== 'undefined' &&
         process.env.NEXT_PUBLIC_TESTING === 'true'
       ) {
-        if (window.TEST_CONTROLS) {
-          delete window.TEST_CONTROLS.setHrmStatus
-          delete window.TEST_CONTROLS.setCustomHrmStatusMessage
+        // Safe to delete as the interface marks these as optional
+        if (window.__TEST_CONTROLS__) {
+          delete window.__TEST_CONTROLS__.setHrmStatus
+          delete window.__TEST_CONTROLS__.setCustomHrmStatusMessage
         }
       }
     }

--- a/hooks/useBluetoothHRM.ts
+++ b/hooks/useBluetoothHRM.ts
@@ -345,7 +345,7 @@ const useBluetoothHRM = (props: UseBluetoothHRMProps = {}) => {
       process.env.NEXT_PUBLIC_TESTING === 'true'
     ) {
       window.__TEST_CONTROLS__ = {
-        ...window.__TEST_CONTROLS__,
+        ...(window.__TEST_CONTROLS__ || {}),
         setHrmStatus: setStatus,
         setCustomHrmStatusMessage: setCustomStatusMessage,
       }

--- a/hooks/useWorkoutSessionManager.ts
+++ b/hooks/useWorkoutSessionManager.ts
@@ -12,17 +12,11 @@ import {
   HR_ZONE_ORDER,
   calculateZoneFromMaxHr,
   toHeartRateZone,
+  calculateMaxHr,
 } from '@/lib/shared/hr-zones'
 import { v4 as uuidv4 } from 'uuid'
-<<<<<<< HEAD
-import { calculateMaxHr } from '@/lib/shared/hr-zones'
 import { useAppSnackbar } from '@/hooks/useAppSnackbar'
 import { isSessionStale } from '@/lib/workout-session'
-=======
-import { calculateMaxHr } from '@/utils/hrCalculations'
-import { useAppSnackbar } from './useAppSnackbar'
-import { isSessionStale } from '../lib/workout-session'
->>>>>>> origin/leader
 
 // --- State, Actions, and Reducer ---
 

--- a/server.ts
+++ b/server.ts
@@ -3,11 +3,11 @@ import '@/lib/env' // Triggers validation immediately
 import express, { type RequestHandler } from 'express'
 import { createServer } from 'http'
 import next from 'next'
-import { env } from '@/lib/env' // New import
+import { env } from '@/lib/env'
 import { httpLogger } from '@/utils/logger.server'
 import logger from '@/utils/logger.server'
-import { AppServices, createServices } from '@/lib/services' // New import
-import { WebSocketManager } from '@/lib/websocket' // New import
+import { AppServices, createServices } from '@/lib/services'
+import { WebSocketManager } from '@/lib/websocket'
 import { initSocketManager } from '@/utils/socketManager'
 import { StateSnapshot } from '@/types/websocket'
 import { Socket } from 'net'

--- a/tests/playwright/lib/index.ts
+++ b/tests/playwright/lib/index.ts
@@ -138,12 +138,8 @@ export {
   takeScreenshot,
   takeDashboardScreenshot,
   prepareForVisualRegression,
-<<<<<<< HEAD
-} from '@/tests/playwright/lib/visual'
-=======
   assertFixedDimensions,
-} from './visual'
->>>>>>> origin/leader
+} from '@/tests/playwright/lib/visual'
 
 // ============================================================================
 // Re-export Playwright test utilities for convenience

--- a/tests/playwright/lib/mocks.ts
+++ b/tests/playwright/lib/mocks.ts
@@ -65,7 +65,6 @@ export async function mockMultipleHrDevices(
   devices: HrmData[]
 ): Promise<void> {
   await page.evaluate((payload) => {
-    // @ts-expect-error - __TEST_CONTROLS__ is added at runtime
     window.__TEST_CONTROLS__?.dispatch({
       type: 'HRM_UPDATE',
       payload,
@@ -97,7 +96,6 @@ export async function mockSpotifyPlaybackState(
 
   await page.evaluate(
     (payload) => {
-      // @ts-expect-error - __TEST_CONTROLS__ is added at runtime
       window.__TEST_CONTROLS__?.dispatch({
         type: 'SPOTIFY_UPDATE',
         payload,

--- a/tests/playwright/lib/mocks.ts
+++ b/tests/playwright/lib/mocks.ts
@@ -65,7 +65,7 @@ export async function mockMultipleHrDevices(
   devices: HrmData[]
 ): Promise<void> {
   await page.evaluate((payload) => {
-    window.__TEST_CONTROLS__?.dispatch({
+    window.__TEST_CONTROLS__?.dispatch?.({
       type: 'HRM_UPDATE',
       payload,
     })
@@ -96,7 +96,7 @@ export async function mockSpotifyPlaybackState(
 
   await page.evaluate(
     (payload) => {
-      window.__TEST_CONTROLS__?.dispatch({
+      window.__TEST_CONTROLS__?.dispatch?.({
         type: 'SPOTIFY_UPDATE',
         payload,
       })

--- a/tests/playwright/lib/setup.ts
+++ b/tests/playwright/lib/setup.ts
@@ -9,22 +9,13 @@
  */
 import type { Browser, BrowserContext, Page } from '@playwright/test'
 import { expect } from '@playwright/test'
-<<<<<<< HEAD
 import { getBaseURL } from '@/utils/urls'
 import { mockGoogleDocIframe } from '@/tests/playwright/lib/mocks'
 import {
   waitForFontsLoaded,
   waitForPageReady,
-} from '@/tests/playwright/lib/waits'
-=======
-import { getBaseURL } from '../../../utils/urls'
-import { mockGoogleDocIframe } from './mocks'
-import {
-  waitForFontsLoaded,
-  waitForPageReady,
   waitForWebSocketConnection,
-} from './waits'
->>>>>>> origin/leader
+} from '@/tests/playwright/lib/waits'
 
 /**
  * Common routes used in HRM testing

--- a/tests/playwright/lib/waits.ts
+++ b/tests/playwright/lib/waits.ts
@@ -208,7 +208,6 @@ export async function waitForApiResponse(
  * @param conditions - Array of wait functions to execute in parallel
  */
 export async function waitForAllConditions(
-  page: Page,
   conditions: Array<() => Promise<void>>
 ): Promise<void> {
   await Promise.all(conditions.map((condition) => condition()))

--- a/tests/playwright/playwright-global.d.ts
+++ b/tests/playwright/playwright-global.d.ts
@@ -46,17 +46,11 @@ interface MockBluetoothDevice {
 
 declare global {
   interface Window {
-    // This is defined in types/global.d.ts but we need to ensure Playwright sees it compatible
-    // or we can remove it if we can share the types. For now, let's keep it compatible
-    // by allowing additional properties (index signature or just optional props)
-    // Actually, let's remove the conflicting strict definition and rely on the app's types if possible,
-    // but Playwright runs in a separate context.
-    // The safest fix for the conflict is to match the TestControls interface structure or use 'any'.
     __TEST_CONTROLS__?: {
       dispatch?: (message: unknown) => void
       disconnect?: () => void
       connect?: () => void
-      [key: string]: unknown // Allow other properties like setHrmStatus
+      [key: string]: unknown
     }
     bluetoothTestHelpers?: {
       simulateHeartRate: (bpm: number) => Promise<void>

--- a/tests/playwright/playwright-global.d.ts
+++ b/tests/playwright/playwright-global.d.ts
@@ -46,10 +46,17 @@ interface MockBluetoothDevice {
 
 declare global {
   interface Window {
+    // This is defined in types/global.d.ts but we need to ensure Playwright sees it compatible
+    // or we can remove it if we can share the types. For now, let's keep it compatible
+    // by allowing additional properties (index signature or just optional props)
+    // Actually, let's remove the conflicting strict definition and rely on the app's types if possible,
+    // but Playwright runs in a separate context.
+    // The safest fix for the conflict is to match the TestControls interface structure or use 'any'.
     __TEST_CONTROLS__?: {
-      dispatch: (message: unknown) => void
-      disconnect: () => void
-      connect: () => void
+      dispatch?: (message: unknown) => void
+      disconnect?: () => void
+      connect?: () => void
+      [key: string]: unknown // Allow other properties like setHrmStatus
     }
     bluetoothTestHelpers?: {
       simulateHeartRate: (bpm: number) => Promise<void>

--- a/tests/playwright/test-helpers.ts
+++ b/tests/playwright/test-helpers.ts
@@ -33,16 +33,12 @@ export {
   setupMinimalVisualRegressionTest,
   setupComprehensiveTest,
   setupCoreTest,
-<<<<<<< HEAD
-} from '@/tests/playwright/lib'
-=======
   // Mock utilities
   mockGoogleDocIframe,
   mockMultipleHrDevices,
   mockSpotifyPlaybackState,
   mockLoggedInSession,
-} from './lib'
->>>>>>> origin/leader
+} from '@/tests/playwright/lib'
 
 // Export BASE_URL for backward compatibility
 export const BASE_URL = getBaseURL()

--- a/tests/playwright/vrt-connect-page.spec.ts
+++ b/tests/playwright/vrt-connect-page.spec.ts
@@ -13,7 +13,7 @@ test.describe('Visual Regression Tests for /client/connect Page', () => {
     await connectPage.getByLabel('Your Age').fill('30')
 
     await connectPage.waitForFunction(
-      () => window.TEST_CONTROLS?.setHrmStatus,
+      () => window.__TEST_CONTROLS__?.setHrmStatus,
       {
         timeout: 20000,
       }
@@ -27,8 +27,8 @@ test.describe('Visual Regression Tests for /client/connect Page', () => {
 
   test('scanning state', async ({ connectPage }) => {
     await connectPage.evaluate((status) => {
-      window.TEST_CONTROLS.setHrmStatus(status)
-      window.TEST_CONTROLS.setCustomHrmStatusMessage(
+      window.__TEST_CONTROLS__!.setHrmStatus!(status)
+      window.__TEST_CONTROLS__!.setCustomHrmStatusMessage!(
         'Checking saved devices...'
       )
     }, BluetoothConnectionStatus.CONNECTING)
@@ -65,8 +65,8 @@ test.describe('Visual Regression Tests for /client/connect Page', () => {
 
   test('connection error state', async ({ connectPage }) => {
     await connectPage.evaluate((status) => {
-      window.TEST_CONTROLS.setHrmStatus(status)
-      window.TEST_CONTROLS.setCustomHrmStatusMessage(
+      window.__TEST_CONTROLS__!.setHrmStatus!(status)
+      window.__TEST_CONTROLS__!.setCustomHrmStatusMessage!(
         'Connection Failed: GATT server not found. Please try again.'
       )
     }, BluetoothConnectionStatus.ERROR)
@@ -84,7 +84,7 @@ test.describe('Visual Regression Tests for /client/connect Page', () => {
 
   test('no devices found state', async ({ connectPage }) => {
     await connectPage.evaluate(
-      (status) => window.TEST_CONTROLS.setHrmStatus(status),
+      (status) => window.__TEST_CONTROLS__!.setHrmStatus!(status),
       BluetoothConnectionStatus.DISCONNECTED
     )
     // The button should be visible and ready for another attempt.
@@ -100,8 +100,8 @@ test.describe('Visual Regression Tests for /client/connect Page', () => {
 
   test('auto-connect failed state', async ({ connectPage }) => {
     await connectPage.evaluate((status) => {
-      window.TEST_CONTROLS.setHrmStatus(status)
-      window.TEST_CONTROLS.setCustomHrmStatusMessage(
+      window.__TEST_CONTROLS__!.setHrmStatus!(status)
+      window.__TEST_CONTROLS__!.setCustomHrmStatusMessage!(
         'Auto-connect failed. Use Connect button to select device.'
       )
     }, BluetoothConnectionStatus.DISCONNECTED)

--- a/tests/playwright/vrt-dashboard.spec.ts
+++ b/tests/playwright/vrt-dashboard.spec.ts
@@ -1,23 +1,15 @@
-<<<<<<< HEAD
-import { type BrowserContext, type Page } from '@playwright/test'
+import { type BrowserContext, type Page, expect } from '@playwright/test'
 import { test } from '@/tests/playwright/fixtures'
 import {
   getDynamicContentMasks,
   setupVisualRegressionTest,
 } from '@/tests/playwright/test-helpers'
-import { takeScreenshot } from '@/tests/playwright/lib/visual'
-import { waitForPageReady } from '@/tests/playwright/lib/waits'
-=======
-import { type BrowserContext, type Page, expect } from '@playwright/test'
-import { test } from './fixtures'
 import {
-  getDynamicContentMasks,
-  setupVisualRegressionTest,
-} from './test-helpers'
-import { takeScreenshot, assertFixedDimensions } from './lib/visual'
-import { waitForPageReady } from './lib/waits'
-import { stopTimer } from './lib/setup'
->>>>>>> origin/leader
+  takeScreenshot,
+  assertFixedDimensions,
+} from '@/tests/playwright/lib/visual'
+import { waitForPageReady } from '@/tests/playwright/lib/waits'
+import { stopTimer } from '@/tests/playwright/lib/setup'
 
 // Test suite configuration
 test.describe.configure({ mode: 'serial' })

--- a/tests/playwright/vrt-hr-components.spec.ts
+++ b/tests/playwright/vrt-hr-components.spec.ts
@@ -4,16 +4,13 @@ import {
   getDynamicContentMasks,
   getHrMasks,
   setupVisualRegressionTest,
-<<<<<<< HEAD
-} from '@/tests/playwright/test-helpers'
-import { takeScreenshot } from '@/tests/playwright/lib/visual'
-import { waitForPageReady } from '@/tests/playwright/lib/waits'
-=======
   mockMultipleHrDevices,
-} from './test-helpers'
-import { takeScreenshot, assertFixedDimensions } from './lib/visual'
-import { waitForPageReady } from './lib/waits'
->>>>>>> origin/leader
+} from '@/tests/playwright/test-helpers'
+import {
+  takeScreenshot,
+  assertFixedDimensions,
+} from '@/tests/playwright/lib/visual'
+import { waitForPageReady } from '@/tests/playwright/lib/waits'
 
 // Test suite configuration
 test.describe.configure({ mode: 'serial' })

--- a/tests/playwright/vrt-workout-summary.spec.ts
+++ b/tests/playwright/vrt-workout-summary.spec.ts
@@ -1,14 +1,8 @@
 import { type BrowserContext, type Page } from '@playwright/test'
-<<<<<<< HEAD
 import { test } from '@/tests/playwright/fixtures'
 import { setupVisualRegressionTest } from '@/tests/playwright/test-helpers'
 import { takeScreenshot } from '@/tests/playwright/lib/visual'
-=======
-import { test } from './fixtures'
-import { setupVisualRegressionTest } from './test-helpers'
-import { takeScreenshot } from './lib/visual'
-import { HRM_ROUTES } from './lib/setup'
->>>>>>> origin/leader
+import { HRM_ROUTES } from '@/tests/playwright/lib/setup'
 
 // Test suite configuration
 test.describe.configure({ mode: 'serial' })

--- a/tests/unit/lib/shared/hr-zones.boundary.test.ts
+++ b/tests/unit/lib/shared/hr-zones.boundary.test.ts
@@ -1,12 +1,8 @@
 import {
   calculateZoneFromMaxHr,
   toHeartRateZone,
-<<<<<<< HEAD
+  calculateMaxHr,
 } from '@/lib/shared/hr-zones'
-=======
-} from '../../../../lib/shared/hr-zones'
-import { calculateMaxHr } from '@/utils/hrCalculations'
->>>>>>> origin/leader
 
 describe('lib/shared/hr-zones boundary conditions', () => {
   const age = 20

--- a/tests/unit/lib/shared/hr-zones.test.ts
+++ b/tests/unit/lib/shared/hr-zones.test.ts
@@ -1,12 +1,9 @@
 import {
   calculateZoneFromMaxHr,
   toHeartRateZone,
-<<<<<<< HEAD
+  calculateMaxHr,
+  MAX_HR_DEFAULT,
 } from '@/lib/shared/hr-zones'
-=======
-} from '../../../../lib/shared/hr-zones'
-import { calculateMaxHr, MAX_HR_DEFAULT } from '@/utils/hrCalculations'
->>>>>>> origin/leader
 
 describe('lib/shared/hr-zones', () => {
   describe('calculateMaxHr', () => {

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,7 +1,6 @@
 import { Dispatch, SetStateAction } from 'react'
 import { SpotifyService } from '@/types/interfaces'
 import { BluetoothConnectionStatus } from '@/types/bluetooth'
-import { ServerMessage } from '@/types/websocket'
 
 // Define a comprehensive interface for the global test controls
 // This allows various parts of the application to attach test-specific
@@ -12,8 +11,9 @@ export interface TestControls {
   setCustomHrmStatusMessage?: Dispatch<SetStateAction<string | null>>
 
   // From WebSocketProvider context
-  dispatch?: (message: ServerMessage) => void
+  dispatch?: (message: unknown) => void
   disconnect?: () => void
+  connect?: () => void
 }
 
 declare global {
@@ -22,7 +22,7 @@ declare global {
   interface Window {
     __TEST_READY__?: boolean
     __TEST_WEBSOCKET_READY__?: boolean
-    TEST_CONTROLS?: TestControls
+    __TEST_CONTROLS__?: TestControls
   }
 }
 


### PR DESCRIPTION
## Description

This PR addresses and resolves merge conflicts found in `.gitignore`, `ExperimentalAnalyticsPage`, mocks, and the session manager. A key change is the standardization of all imports across the entire codebase, including tests and the server entry point, to consistently use the `@/` alias. Furthermore, verbose and unnecessary comments have been removed to improve code readability, and a TypeScript type error within `WebSocketContext` related to `__TEST_CONTROLS__` has been fixed.

The primary motivation for standardizing aliases is to enhance code consistency and readability, making the codebase easier to navigate and maintain for developers. Resolving the merge conflicts ensures a stable and coherent development branch for future work.

No new dependencies are introduced or required for this change.

Fixes # 

## Change Type: 🐛 Bug fix (non-breaking change fixing an issue)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [x] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [x] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

Resolved merge conflicts in .gitignore, ExperimentalAnalyticsPage, mocks, and session manager. Standardized imports to use `@/` alias across the codebase including tests and server entry point. Removed verbose comments. Fixed TypeScript type error in WebSocketContext related to __TEST_CONTROLS__.

---
*PR created automatically by Jules for task [1448126593530386122](https://jules.google.com/task/1448126593530386122) started by @arii*
</details>