### PR TITLE
feat(small): refactor: unify SpotifyService interface and remove unused abstractions

### DIFF
--- a/app/client/spotify-selection/page.tsx
+++ b/app/client/spotify-selection/page.tsx
@@ -10,11 +10,8 @@ import Typography from '@mui/material/Typography'
 import dynamic from 'next/dynamic'
 import { useState } from 'react'
 import { useWebSocket } from '@/context/WebSocketContext'
-<<<<<<< HEAD
 import { useSpotifyCommand } from '@/hooks/useSpotifyCommand'
-=======
 import { useTestPageReady } from '@/hooks/useTestPageReady'
->>>>>>> origin/leader
 
 const PlaylistSelector = dynamic(
   () => import('../../../components/Spotify/PlaylistSelector'),

--- a/types/interfaces.ts
+++ b/types/interfaces.ts
@@ -1,96 +1,50 @@
-// File: types/interfaces.ts
-/**
- * Defines common interfaces for services to promote consistency and enable
- * dependency inversion (the "D" in SOLID). By depending on these abstractions
- * rather than concrete implementations, consuming code becomes more modular,
-t* estable, and easier to refactor.
- */
-
 import { SpotifyTokenPayload } from '../services/spotifyTokenManager'
 import { SpotifyData } from './websocket'
-import { SpotifyCommand } from './core'
+import { SpotifyCommand, SpotifyCommandParameters } from './core'
 
 /**
- * Represents a service that provides a snapshot of its current state.
- * @template T The type of the state object.
+ * Defines the unified interface for the Spotify service.
+ * This interface consolidates state access, command handling, and lifecycle management
+ * into a single cohesive definition, avoiding unnecessary abstraction layers.
  */
-interface StateProvider<T> {
+export interface SpotifyService {
   /**
    * Returns the current state.
-   * @returns {T} The state object.
    */
-  getState(): T
-}
+  getState(): SpotifyData
 
-/**
- * Represents a service that can handle specific commands.
- * @template C The type representing the command identifier (e.g., a string union).
- * @template P The type representing the command payload or parameters.
- */
-interface CommandHandler<C, P> {
   /**
    * Handles a command.
-   * @param {C} command - The command to handle.
-   * @param {P} params - The command parameters.
    */
-  handleCommand(command: C, params: P): void | Promise<void>
-}
+  handleCommand(
+    command: SpotifyCommand,
+    params: SpotifyCommandParameters
+  ): void | Promise<void>
 
-/**
- * Defines the basic lifecycle methods for a service, such as starting,
- * stopping, and cleaning up resources.
- */
-interface Lifecycle {
+  /**
+   * Checks if the service is ready and initialized.
+   */
+  isReady(): boolean
+
   /**
    * Starts the service's polling mechanism, if applicable.
    */
   startPolling?(): void
+
   /**
    * Stops the service's polling mechanism, if applicable.
    */
   stopPolling?(): void
-  /**
-   * Checks if the service is ready and initialized.
-   * @returns {boolean} True if the service is ready, false otherwise.
-   */
-  isReady(): boolean
+
   /**
    * Cleans up resources used by the service, like intervals or timeouts.
    */
   cleanup?(): void
-}
 
-/**
- * Interface for services that handle Spotify token updates.
- */
-interface SpotifyTokenHandler {
   /**
    * Handles the reception of new Spotify authentication tokens.
-   * @param {SpotifyTokenPayload} tokens - The new token payload.
-   * @returns {Promise<void>}
    */
   handleTokenUpdate(tokens: SpotifyTokenPayload): Promise<void>
+
+  forcePollAndBroadcast(): void
 }
-
-// --- Domain-Specific Types ---
-
-// --- Composite Service Interfaces ---
-
-/**
- * Combined interface for the Spotify service, adhering to ISP.
- * Consumers can depend on this, or on one of the more granular interfaces.
- */
-export type SpotifyService = StateProvider<SpotifyData> &
-  CommandHandler<
-    SpotifyCommand,
-    {
-      deviceId?: string
-      volume?: number
-      playlistUri?: string
-      contextUri?: string
-    }
-  > &
-  Lifecycle &
-  SpotifyTokenHandler & {
-    forcePollAndBroadcast(): void
-  }


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Refactored `types/interfaces.ts` to replace the fragmented `StateProvider`, `CommandHandler`, `Lifecycle`, and `SpotifyTokenHandler` interfaces with a single cohesive `SpotifyService` interface. This simplifies the codebase and aligns with the directive to avoid over-engineering. Also resolved a merge conflict in `app/client/spotify-selection/page.tsx` by retaining both necessary hooks, and updated file comments based on code review feedback.

Fixes # 

## Change Type: 🏗️ Refactoring (code change that neither fixes bug nor adds feature)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [ ] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [ ] Changes are **backward compatible** (or breaking changes are documented)
- [ ] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

Refactored `types/interfaces.ts` to replace the fragmented `StateProvider`, `CommandHandler`, `Lifecycle`, and `SpotifyTokenHandler` interfaces with a single cohesive `SpotifyService` interface. This simplifies the codebase and aligns with the directive to avoid over-engineering. Also resolved a merge conflict in `app/client/spotify-selection/page.tsx` by retaining both necessary hooks, and updated file comments based on code review feedback.

---
*PR created automatically by Jules for task [14751015065612065967](https://jules.google.com/task/14751015065612065967) started by @arii*
</details>