### PR TITLE
ci(small): Configure PR Comments: Disable Quality Reports, Retain Gemini Reviews

### DIFF
--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -11,6 +11,11 @@ on:
         description: 'PR number to post comments to (optional)'
         required: false
         type: string
+      enable_pr_comment:
+        description: 'Whether to post a detailed quality report as a PR comment'
+        required: false
+        type: boolean
+        default: false
 
   workflow_call:
     inputs:
@@ -23,6 +28,11 @@ on:
         description: 'PR number to post comments to (optional)'
         required: false
         type: string
+      enable_pr_comment:
+        description: 'Whether to post a detailed quality report as a PR comment'
+        required: false
+        type: boolean
+        default: false
 
     secrets:
       GH_TOKEN:
@@ -1001,6 +1011,7 @@ jobs:
           FINAL_RESULT: ${{ steps.aggregate-results.outputs.final_result }}
           PR_NUMBER: ${{ needs.prepare-env.outputs.pr_number }}
           SHA: ${{ needs.prepare-env.outputs.sha }}
+          ENABLE_PR_COMMENT: ${{ inputs.enable_pr_comment }}
         run: |
           set +e
 
@@ -1092,18 +1103,14 @@ jobs:
           # Write the final comment to a file
           echo -e "$COMMENT_BODY" > test-results/pr-comment.md
 
-          # Only post comment to PR if there are genuine failures
-          if [ "$FINAL_RESULT" == "failure" ]; then
+          # Always add the detailed report to the step summary
+          echo -e "$COMMENT_BODY" >> $GITHUB_STEP_SUMMARY
+
+          # Only post comment to PR if there are genuine failures AND enabled
+          if [ "$FINAL_RESULT" == "failure" ] && [ "$ENABLE_PR_COMMENT" == "true" ]; then
             gh pr comment "$PR_NUMBER" --body-file test-results/pr-comment.md || {
               echo "::warning::Failed to post PR comment."
             }
           else
-            echo "Skipping PR comment because all checks passed or were cancelled."
-          fi
-
-          # Check if all passed
-          if [ "$FINAL_RESULT" = "success" ]; then
-            echo "✅ **All quality checks passed!**" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "⚠️ **Some checks failed.** Review the workflow run logs for details." >> $GITHUB_STEP_SUMMARY
+            echo "Skipping PR comment (Result: $FINAL_RESULT, Enabled: $ENABLE_PR_COMMENT)."
           fi

--- a/scripts/generate-failure-report.sh
+++ b/scripts/generate-failure-report.sh
@@ -122,17 +122,25 @@ echo "::endgroup::"
 
 # --- 3. REPORTING ---
 if [ -n "$FAILED_CHECKS_LIST" ]; then
-  echo "::group::Posting PR Comment"
-  # --- Post PR Comment ---
+  # Always generate Step Summary
   COMMIT_HASH_MSG="> Failed at commit: \`${GITHUB_SHA}\`"
   COMMENT_HEADER="CI checks failed: ${FAILED_CHECKS_LIST}.\n\n${COMMIT_HASH_MSG}\n\n"
   LOG_FOOTER="---\n*Note: Logs are truncated. View the [full workflow run](https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}) for details.*"
   COMMENT_DETAILS="<details><summary><strong>Failed Test Report Log</strong></summary>${LOGS_BODY}\n${LOG_FOOTER}\n</details>"
+
   echo -e "${COMMENT_HEADER}${COMMENT_DETAILS}" > "$COMMENT_FILE"
-  if ! gh pr comment "$PR_NUMBER" --body-file "$COMMENT_FILE"; then
-    echo "::error::Failed to post comment to PR. The GitHub token may have expired or lack permissions."
+  echo -e "${COMMENT_HEADER}${COMMENT_DETAILS}" >> "$GITHUB_STEP_SUMMARY"
+
+  if [ "$ENABLE_PR_COMMENT" == "true" ]; then
+    echo "::group::Posting PR Comment"
+    # --- Post PR Comment ---
+    if ! gh pr comment "$PR_NUMBER" --body-file "$COMMENT_FILE"; then
+      echo "::error::Failed to post comment to PR. The GitHub token may have expired or lack permissions."
+    fi
+    echo "::endgroup::"
+  else
+    echo "PR commenting is disabled for quality reports."
   fi
-  echo "::endgroup::"
 
 
   echo "::group::Generating JSON Artifact"


### PR DESCRIPTION
## Description

The "pr-quality results" comments on Pull Requests have been disabled by default to streamline the review process and reduce automated noise.

Key changes:
1.  **New Configuration**: Added an `enable_pr_comment` input to the `PR Quality Gate` workflow. It defaults to `false`, effectively disabling the comments for all new PRs.
2.  **Redirected Reporting**: The detailed quality report, which includes a status table and truncated logs for failed checks, is now always posted to the **GitHub Actions Step Summary**. This ensures that the information is still easily accessible to developers without cluttering the PR conversation.
3.  **Script Synchronization**: Updated the `scripts/generate-failure-report.sh` script to align with the new reporting logic, using the `ENABLE_PR_COMMENT` environment variable.
4.  **Preservation of Gemini Reviews**: Verified that the Gemini review comments (managed in `reusable-gemini-review.yml`) are not affected by these changes and will continue to be posted as expected.

This fulfills the requirement to disable the quality report PR comments while retaining the valuable Gemini review feedback.

Fixes #9018

## Change Type: ✨ New feature (non-breaking change adding functionality)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [ ] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [ ] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

The "pr-quality results" comments on Pull Requests have been disabled by default to streamline the review process and reduce automated noise. 

Key changes:
1.  **New Configuration**: Added an `enable_pr_comment` input to the `PR Quality Gate` workflow. It defaults to `false`, effectively disabling the comments for all new PRs.
2.  **Redirected Reporting**: The detailed quality report, which includes a status table and truncated logs for failed checks, is now always posted to the **GitHub Actions Step Summary**. This ensures that the information is still easily accessible to developers without cluttering the PR conversation.
3.  **Script Synchronization**: Updated the `scripts/generate-failure-report.sh` script to align with the new reporting logic, using the `ENABLE_PR_COMMENT` environment variable.
4.  **Preservation of Gemini Reviews**: Verified that the Gemini review comments (managed in `reusable-gemini-review.yml`) are not affected by these changes and will continue to be posted as expected.

This fulfills the requirement to disable the quality report PR comments while retaining the valuable Gemini review feedback.

Fixes #9018

---
*PR created automatically by Jules for task [17011012363165141933](https://jules.google.com/task/17011012363165141933) started by @arii*
</details>