### PR TITLE
feat(small): Revert HrmConnectionPanel Loading State to use Skeleton

### DIFF
--- a/components/HrmConnectionPanel.tsx
+++ b/components/HrmConnectionPanel.tsx
@@ -2,6 +2,7 @@
 import { useMemo } from 'react'
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
+import Skeleton from '@mui/material/Skeleton'
 import { useWebSocket } from '@/context/WebSocketContext'
 import { useNow } from '@/hooks/useNow'
 import HrTile from '@/components/HrTile'
@@ -31,42 +32,58 @@ const HrmConnectionPanel = () => {
         height: '100%',
       }}
     >
-      {isLoading || tileData.length === 0 ? (
+      {isLoading ? (
         <>
           <Box
+            data-testid="hr-tile-grid-item"
             sx={{
-              display: 'flex',
-              flexDirection: 'column',
-              justifyContent: 'center',
-              alignItems: 'center',
               width: { xs: '100%', sm: 'calc(50% - 8px)' },
-              height: '100%', // Ensure the container fills the grid cell
-              gap: 2,
-              p: 2,
-              border: 1,
-              borderColor: 'divider',
-              borderRadius: 2,
             }}
           >
-            <Typography variant="h6" gutterBottom>
-              No Heart Rate Data
-            </Typography>
-            <Typography variant="body1" color="text.secondary" align="center">
-              Heart rate data will be displayed here once a monitor is connected
-              and streaming.
-            </Typography>
+            <Skeleton
+              variant="rectangular"
+              height={220}
+              sx={{ borderRadius: 3 }}
+            />
           </Box>
           <Box
             data-testid="hr-tile-grid-item"
             sx={{
               display: { xs: 'none', md: 'block' },
-              width: { sm: 'calc(50% - 12px)' },
-              height: 220,
-              backgroundColor: 'action.hover',
-              borderRadius: 3,
+              width: { sm: 'calc(50% - 8px)' },
             }}
-          />
+          >
+            <Skeleton
+              variant="rectangular"
+              height={220}
+              sx={{ borderRadius: 3 }}
+            />
+          </Box>
         </>
+      ) : tileData.length === 0 ? (
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'center',
+            alignItems: 'center',
+            width: '100%',
+            height: '100%', // Ensure the container fills the grid cell
+            gap: 2,
+            p: 2,
+            border: 1,
+            borderColor: 'divider',
+            borderRadius: 2,
+          }}
+        >
+          <Typography variant="h6" gutterBottom>
+            No Heart Rate Data
+          </Typography>
+          <Typography variant="body1" color="text.secondary" align="center">
+            Heart rate data will be displayed here once a monitor is connected
+            and streaming.
+          </Typography>
+        </Box>
       ) : (
         tileData.map((user) => {
           // Destructure to remove volatile timestamps causing re-renders

--- a/tests/unit/components/HrmConnectionPanel.test.tsx
+++ b/tests/unit/components/HrmConnectionPanel.test.tsx
@@ -64,12 +64,14 @@ describe('HrmConnectionPanel', () => {
       connectionStatus: 'Connecting...',
       activeAlerts: [],
     })
-    render(
+    const { container } = render(
       <UserSettingsProvider>
         <HrmConnectionPanel />
       </UserSettingsProvider>
     )
-    // Expect the placeholder grid item to be present
-    expect(screen.getByTestId('hr-tile-grid-item')).toBeInTheDocument()
+    // Expect two skeletons to be present for the loading state
+    expect(container.querySelectorAll('.MuiSkeleton-root').length).toBe(2)
+    // Expect "No Heart Rate Data" message NOT to be present when loading
+    expect(screen.queryByText('No Heart Rate Data')).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Description

This change reverts the HrmConnectionPanel loading state to use Skeleton components instead of a plain Box with text. It also improves the logic by separating the 'Loading' state from the 'No Data' state, ensuring that the 'No Heart Rate Data' message only appears after the connection is established and confirmed to have no active data. Unit tests have been updated to reflect these changes.

Fixes #9024

## Change Type: 🐛 Bug fix (non-breaking change fixing an issue)

## Related Issues

Closes #9024

<details>
<summary>Original PR Body</summary>

This change reverts the HrmConnectionPanel loading state to use Skeleton components instead of a plain Box with text. It also improves the logic by separating the 'Loading' state from the 'No Data' state, ensuring that the 'No Heart Rate Data' message only appears after the connection is established and confirmed to have no active data. Unit tests have been updated to reflect these changes.

Fixes #9024

---
*PR created automatically by Jules for task [16184805289156709542](https://jules.google.com/task/16184805289156709542) started by @arii*
</details>