### PR TITLE
feat(small): Refactor ExperimentalAnalyticsPage ingestion and verify session logic

### DIFF
--- a/app/client/experimental/components/ExperimentalAnalyticsPage.tsx
+++ b/app/client/experimental/components/ExperimentalAnalyticsPage.tsx
@@ -1,6 +1,6 @@
 // app/client/experimental/components/ExperimentalAnalyticsPage.tsx
 'use client'
-import { useState, useEffect, useMemo, useRef, useCallback } from 'react'
+import { useState, useEffect, useMemo, useCallback } from 'react'
 import { Container, Box, Button, Skeleton } from '@mui/material'
 import dynamic from 'next/dynamic'
 import { useWebSocket } from '@/context/WebSocketContext'
@@ -111,34 +111,21 @@ const ExperimentalAnalyticsPage = () => {
     }
   }, [connectionStatus, userSettings, sendData])
 
-  /**
-   * FIX: Use ref to avoid interval reset on HR updates (addresses audit issue #1)
-   * This prevents the interval from being recreated on every hrmData change
-   */
-  const latestHrRef = useRef(0)
-
-  useEffect(() => {
-    latestHrRef.current = hrmData[0]?.value ?? 0
-  }, [hrmData])
-
-  // Recording interval - only depends on status, not hrmData
+  // Ingest data from WebSocket updates (Event-driven)
   useEffect(() => {
     if (status !== 'running') return
 
-    const intervalId = setInterval(() => {
-      const currentHr = latestHrRef.current
+    const currentData = hrmData[0]
+    if (!currentData) return
 
-      // Add HR data point with zone calculation (calories processed internally by hook)
-      const dataPoint = {
-        time: Date.now(),
-        hr: currentHr,
-      }
+    // Add HR data point with zone calculation (calories processed internally by hook)
+    const dataPoint = {
+      time: Date.now(),
+      hr: currentData.value,
+    }
 
-      addHrData(dataPoint)
-    }, 1000)
-
-    return () => clearInterval(intervalId)
-  }, [status, addHrData])
+    addHrData(dataPoint)
+  }, [hrmData, status, addHrData])
 
   // Handlers
   const handleStartWorkout = useCallback(() => {

--- a/tests/unit/hooks/useWorkoutSessionManager.test.ts
+++ b/tests/unit/hooks/useWorkoutSessionManager.test.ts
@@ -179,6 +179,39 @@ describe('useWorkoutSessionManager', () => {
       expect(result.current.session?.maxHr).toBe(0)
       expect(result.current.session?.averageHr).toBe(0)
     })
+
+    it('should skip calorie calculation if time delta is too large (signal loss)', async () => {
+      const { result } = renderHook(() => useWorkoutSessionManager())
+      await waitFor(() => expect(result.current.isInitialized).toBe(true))
+
+      act(() => {
+        result.current.startWorkout(30, 80)
+      })
+
+      // Add first data point
+      act(() => {
+        result.current.addHrData({ time: 1001000, hr: 140 })
+      })
+      const initialCalories = result.current.session?.totalCaloriesBurned || 0
+
+      // Add second data point with a 15 second gap (simulated signal loss)
+      act(() => {
+        result.current.addHrData({ time: 1016000, hr: 140 })
+      })
+
+      // Assert calories did NOT increase for this large gap
+      expect(result.current.session?.totalCaloriesBurned).toBe(initialCalories)
+
+      // Add third data point with normal gap (1 sec)
+      act(() => {
+        result.current.addHrData({ time: 1017000, hr: 140 })
+      })
+
+      // Assert calories resumed
+      expect(result.current.session?.totalCaloriesBurned).toBeGreaterThan(
+        initialCalories
+      )
+    })
   })
 
   describe('Stale Session Handling', () => {


### PR DESCRIPTION
## Description

This PR addresses the Principal Engineer's directives to refine the Experimental Workout Analytics UI.

Summary of changes:
1.  **Refactor `ExperimentalAnalyticsPage.tsx`**: The polling mechanism (`setInterval` checking a ref) has been replaced with an event-driven approach. The component now listens for changes in `hrmData` from `useWebSocket` and updates the workout session via `addHrData`. This aligns the page with the `ConnectPage` pattern and avoids potential timing mismatches.
2.  **Add Signal Loss Test**: A new test case was added to `tests/unit/hooks/useWorkoutSessionManager.test.ts` to ensure that large gaps in data (simulated signal loss > 10s) do not result in incorrect calorie accumulation.
3.  **Verify Grid Props**: Investigated and verified the correct usage of `Grid` props in `WorkoutSummary.tsx`. The installed `@mui/material` version (v7.3.7) exports `Grid` as Grid2, which supports the `size` prop. The original code was found to be correct, and no changes were required.
4.  **Verify Legacy Hook Removal**: Confirmed the successful deletion of `useCalorieCalculator.ts`, `useCalorieTracker.ts`, and `useWorkoutSession.ts`.

**Motivation and Context:** The primary motivation is to improve the robustness and maintainability of the Experimental Workout Analytics UI by adopting a more reliable event-driven data ingestion pattern and verifying existing logic and component usage.

**Dependencies:** No new external dependencies are required for this change.

Fixes # N/A (Addresses Principal Engineer's directives)

## Change Type: 🏗️ Refactoring (code change that neither fixes bug nor adds feature)

## PR Scope Checklist

_This checklist is mandatory for all PRs._

- [x] **PR has a clear, single purpose:** The title and description of the PR clearly state the purpose of the change.
- [x] **All changes relate to the stated objective:** The code changes should be directly related to the purpose of the PR.
- [x] **No unrelated cleanup or refactoring:** The PR should not contain any changes that are not directly related to the stated objective.
- [x] **Title and description match the actual changes:** The title and description should accurately reflect the changes in the PR.
- [x] **Tests cover the specific change scope:** The tests should be focused on the changes in the PR and should not include unrelated tests.

## Impact Assessment

- [x] Changes are **backward compatible** (or breaking changes are documented)
- [x] **Tests** are added/updated for new functionality
- [ ] **Documentation** is updated if needed
- [ ] **ADR** is created/updated for significant architectural changes

<details>
<summary>Original PR Body</summary>

This PR addresses the Principal Engineer's directives to refine the Experimental Workout Analytics UI.

Changes:
1.  **Refactor `ExperimentalAnalyticsPage.tsx`**: Replaced the polling mechanism (`setInterval` checking a ref) with an event-driven approach. The component now listens for changes in `hrmData` from `useWebSocket` and updates the workout session via `addHrData`. This aligns with the `ConnectPage` pattern and avoids timing mismatches.
2.  **Add Signal Loss Test**: Added a new test case to `tests/unit/hooks/useWorkoutSessionManager.test.ts` to ensure that large gaps in data (simulated signal loss > 10s) do not result in incorrect calorie accumulation.
3.  **Verify Grid Props**: Investigated the flagged issue in `WorkoutSummary.tsx`. The audit claimed usage of invalid props for MUI v5. However, the build process confirmed that the installed `@mui/material` version (v7.3.7) exports `Grid` as Grid2, which supports the `size` prop. The original code was correct, and attempting to "fix" it broke the build. The file was verified and left as is.
4.  **Verify Legacy Hook Removal**: Confirmed that `useCalorieCalculator.ts`, `useCalorieTracker.ts`, and `useWorkoutSession.ts` have been deleted.

Testing:
-   `pnpm run test:unit tests/unit/hooks/useWorkoutSessionManager.test.ts`: Passed (including new test case).
-   `pnpm run build`: Passed (confirming correct MUI usage).
-   Frontend Verification: Verified `ExperimentalAnalyticsPage` renders correctly via Playwright script and screenshot (attached in internal logs). No visual regressions or layout issues observed.

---
*PR created automatically by Jules for task [13103859231588830584](https://jules.google.com/task/13103859231588830584) started by @arii*
</details>