### PR TITLE
feat(small): Repair PR #8955: Resolve Conflicts and Update ConnectView Tests

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -50,8 +50,6 @@ runs:
           cache-${{ inputs.cache-type }}-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ github.ref_name }}-
           cache-${{ inputs.cache-type }}-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-
 
-<<<<<<< HEAD
-=======
     - name: Install GitHub CLI
       shell: bash
       run: |
@@ -82,7 +80,6 @@ runs:
         # Add to PATH for this and future steps
         echo "$HOME/.local/bin" >> $GITHUB_PATH
 
->>>>>>> origin/leader
     - name: 'Install Dependencies'
       shell: bash
       run: |

--- a/app/client/connect/ConnectView.test.tsx
+++ b/app/client/connect/ConnectView.test.tsx
@@ -77,17 +77,15 @@ describe('ConnectView', () => {
   it('renders metric inputs when unit is metric', () => {
     const props = { ...defaultProps, unitSystem: 'METRIC' as MeasurementSystem }
     render(<ConnectView {...props} />)
-    // Note: UserSettings implementation details might vary, checking for label presence
-    // Assuming UserSettings renders labels based on unit
-    // If UserSettings is a pure component relying on props, this should work if UserSettings handles it.
-    // Based on previous test reading:
-    // expect(screen.getByLabelText('Your Height (cm)')).toBeInTheDocument()
-    // However, I should verify what UserSettings renders. For now, let's assume the previous test intent was correct but props were wrong.
+    expect(screen.getByLabelText('Your Height (cm)')).toBeInTheDocument()
+    expect(screen.getByLabelText('Your Weight (kg)')).toBeInTheDocument()
   })
 
   it('renders imperial inputs when unit is imperial', () => {
     render(<ConnectView {...defaultProps} />)
-    // Similarly, assuming UserSettings renders these fields
+    expect(screen.getByLabelText('Feet')).toBeInTheDocument()
+    expect(screen.getByLabelText('Inches')).toBeInTheDocument()
+    expect(screen.getByLabelText('Your Weight (lbs)')).toBeInTheDocument()
   })
 
   it('renders the reset section with correct text', () => {
@@ -100,9 +98,7 @@ describe('ConnectView', () => {
     ).toBeInTheDocument()
   })
 
-  it('calls onReset when reset button is clicked and confirmed', async () => {
-    // Note: The current implementation of handleFullReset calls onForgetDevice then onReset.
-    // There is no confirmation dialog in the code I read, just a direct call.
+  it('calls onReset when reset button is clicked', async () => {
     render(<ConnectView {...defaultProps} />)
     const resetButton = screen.getByText('Reset Permissions & Settings')
     fireEvent.click(resetButton)

--- a/app/client/connect/ConnectView.test.tsx
+++ b/app/client/connect/ConnectView.test.tsx
@@ -1,9 +1,10 @@
 /**
  * @jest-environment jsdom
  */
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import ConnectView from './ConnectView'
 import { WorkoutStatus } from '../../../types/workout'
+import { MeasurementSystem, Gender } from '../../../types/core'
 
 describe('ConnectView', () => {
   const defaultProps = {
@@ -13,18 +14,20 @@ describe('ConnectView', () => {
     setUserName: jest.fn(),
     userAge: '30',
     setUserAge: jest.fn(),
-    userHeight: '5.9',
+    onAgeBlur: jest.fn(),
+    ageError: null,
+    userHeight: { cm: '180', feet: '5', inches: '11' },
     setUserHeight: jest.fn(),
+    onHeightBlur: jest.fn(),
+    heightError: null,
     userWeight: '154',
     setUserWeight: jest.fn(),
-    unit: 'imperial' as 'metric' | 'imperial',
-    setUnit: jest.fn(),
-    ageError: null,
-    heightError: null,
+    onWeightBlur: jest.fn(),
     weightError: null,
-    validateAge: jest.fn(),
-    validateHeight: jest.fn(),
-    validateWeight: jest.fn(),
+    gender: 'MALE' as Gender,
+    setGender: jest.fn(),
+    unitSystem: 'IMPERIAL' as MeasurementSystem,
+    onUnitChange: jest.fn(),
     isConnected: false,
     deviceStatus: 'Disconnected',
     batteryLevel: null,
@@ -32,8 +35,10 @@ describe('ConnectView', () => {
     onDisconnect: jest.fn(),
     onForgetDevice: jest.fn().mockResolvedValue(undefined),
     isSupported: true,
+    signalPeriodMs: 1000,
     currentHR: 0,
-    hrZoneProps: { percentage: 0, progressColor: 'grey' },
+    hrZoneProps: { percentage: 0 },
+    zone: { min: 0, max: 0, name: 'Rest', color: 'grey' },
     connectionStatus: 'Disconnected',
     bluetoothConnected: false,
     hasStarted: false,
@@ -62,24 +67,49 @@ describe('ConnectView', () => {
     expect(screen.getByText('Invalid weight')).toBeInTheDocument()
   })
 
-  it('calls setUnit when the unit toggle is clicked', () => {
+  it('calls onUnitChange when the unit toggle is clicked', () => {
     render(<ConnectView {...defaultProps} />)
-    const metricButton = screen.getByText('Metric (kg, cm)')
+    const metricButton = screen.getByLabelText('metric')
     fireEvent.click(metricButton)
-    expect(defaultProps.setUnit).toHaveBeenCalledWith('metric')
+    expect(defaultProps.onUnitChange).toHaveBeenCalledWith('METRIC')
   })
 
   it('renders metric inputs when unit is metric', () => {
-    const props = { ...defaultProps, unit: 'metric' as 'metric' | 'imperial' }
+    const props = { ...defaultProps, unitSystem: 'METRIC' as MeasurementSystem }
     render(<ConnectView {...props} />)
-    expect(screen.getByLabelText('Your Height (cm)')).toBeInTheDocument()
-    expect(screen.getByLabelText('Your Weight (kg)')).toBeInTheDocument()
+    // Note: UserSettings implementation details might vary, checking for label presence
+    // Assuming UserSettings renders labels based on unit
+    // If UserSettings is a pure component relying on props, this should work if UserSettings handles it.
+    // Based on previous test reading:
+    // expect(screen.getByLabelText('Your Height (cm)')).toBeInTheDocument()
+    // However, I should verify what UserSettings renders. For now, let's assume the previous test intent was correct but props were wrong.
   })
 
   it('renders imperial inputs when unit is imperial', () => {
     render(<ConnectView {...defaultProps} />)
-    expect(screen.getByLabelText('Feet')).toBeInTheDocument()
-    expect(screen.getByLabelText('Inches')).toBeInTheDocument()
-    expect(screen.getByLabelText('Your Weight (lbs)')).toBeInTheDocument()
+    // Similarly, assuming UserSettings renders these fields
+  })
+
+  it('renders the reset section with correct text', () => {
+    render(<ConnectView {...defaultProps} />)
+    expect(screen.getByText('Reset Permissions & Settings')).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        'Resets stored permissions and device settings, including Bluetooth connection.'
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('calls onReset when reset button is clicked and confirmed', async () => {
+    // Note: The current implementation of handleFullReset calls onForgetDevice then onReset.
+    // There is no confirmation dialog in the code I read, just a direct call.
+    render(<ConnectView {...defaultProps} />)
+    const resetButton = screen.getByText('Reset Permissions & Settings')
+    fireEvent.click(resetButton)
+
+    await waitFor(() => {
+      expect(defaultProps.onForgetDevice).toHaveBeenCalled()
+      expect(defaultProps.onReset).toHaveBeenCalled()
+    })
   })
 })

--- a/app/client/connect/ConnectView.test.tsx
+++ b/app/client/connect/ConnectView.test.tsx
@@ -49,21 +49,32 @@ describe('ConnectView', () => {
     onEndWorkout: jest.fn(),
   }
 
-  it('displays an error message for invalid age', () => {
+  it('displays an error message for invalid age only when ageError is set', () => {
+    // Negative assertion: no error initially
+    const { rerender } = render(<ConnectView {...defaultProps} />)
+    expect(screen.queryByText('Invalid age')).not.toBeInTheDocument()
+
+    // Positive assertion: error appears when prop is set
     const props = { ...defaultProps, ageError: 'Invalid age' }
-    render(<ConnectView {...props} />)
+    rerender(<ConnectView {...props} />)
     expect(screen.getByText('Invalid age')).toBeInTheDocument()
   })
 
-  it('displays an error message for invalid height', () => {
+  it('displays an error message for invalid height only when heightError is set', () => {
+    const { rerender } = render(<ConnectView {...defaultProps} />)
+    expect(screen.queryByText('Invalid height')).not.toBeInTheDocument()
+
     const props = { ...defaultProps, heightError: 'Invalid height' }
-    render(<ConnectView {...props} />)
+    rerender(<ConnectView {...props} />)
     expect(screen.getByText('Invalid height')).toBeInTheDocument()
   })
 
-  it('displays an error message for invalid weight', () => {
+  it('displays an error message for invalid weight only when weightError is set', () => {
+    const { rerender } = render(<ConnectView {...defaultProps} />)
+    expect(screen.queryByText('Invalid weight')).not.toBeInTheDocument()
+
     const props = { ...defaultProps, weightError: 'Invalid weight' }
-    render(<ConnectView {...props} />)
+    rerender(<ConnectView {...props} />)
     expect(screen.getByText('Invalid weight')).toBeInTheDocument()
   })
 

--- a/app/client/connect/components/ResetSection.tsx
+++ b/app/client/connect/components/ResetSection.tsx
@@ -2,11 +2,7 @@ import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import Typography from '@mui/material/Typography'
 
-<<<<<<< HEAD
-interface ResetSectionProps {
-=======
 export interface ResetSectionProps {
->>>>>>> origin/leader
   onReset: () => void
   isResetting: boolean
 }
@@ -17,11 +13,7 @@ const ResetSection = ({ onReset, isResetting }: ResetSectionProps) => (
       textAlign: 'center',
       mt: 4,
       pt: 4,
-<<<<<<< HEAD
-      borderTop: '1px solid',
-=======
       borderTop: 1,
->>>>>>> origin/leader
       borderColor: 'divider',
     }}
   >
@@ -31,23 +23,15 @@ const ResetSection = ({ onReset, isResetting }: ResetSectionProps) => (
       onClick={onReset}
       disabled={isResetting}
     >
-<<<<<<< HEAD
-      {isResetting ? 'Resetting...' : 'Reset System & Device'}
-=======
       {isResetting ? 'Resetting...' : 'Reset Permissions & Settings'}
->>>>>>> origin/leader
     </Button>
     <Typography
       variant="caption"
       display="block"
       sx={{ mt: 1, color: 'text.secondary' }}
     >
-<<<<<<< HEAD
-      Resets server state AND forgets Bluetooth device connection.
-=======
       Resets stored permissions and device settings, including Bluetooth
       connection.
->>>>>>> origin/leader
     </Typography>
   </Box>
 )


### PR DESCRIPTION
## Description

This PR repairs the previous state by resolving critical merge conflicts and updating the test suite to match the current component implementation.

Fixes #8955

## Change Type: 🐛 Bug fix (non-breaking change fixing an issue)

### Changes Made
- **`app/client/connect/components/ResetSection.tsx`**: Resolved conflicts, exporting `ResetSectionProps`, using `borderTop: 1`, and updating text to "Reset Permissions & Settings" as per leader branch.
- **`.github/actions/setup-env/action.yml`**: Resolved conflicts, keeping the `gh` CLI installation step.
- **`app/client/connect/ConnectView.test.tsx`**: Fixed outdated prop usage (`unit` -> `unitSystem`, `setUnit` -> `onUnitChange`) and added tests for the Reset button presence and interaction.

### Testing
- **Unit Tests**: `npm test app/client/connect/ConnectView.test.tsx` passed.
- **Visual Verification**: Confirmed "Reset Permissions & Settings" button and description are visible on the Connect page (even in "Not Supported" state).

## Related Issues

Closes #8955

<details>
<summary>Original PR Body</summary>

This PR repairs the previous state by resolving critical merge conflicts and updating the test suite to match the current component implementation.

### Changes
- **`app/client/connect/components/ResetSection.tsx`**: Resolved conflicts, exporting `ResetSectionProps`, using `borderTop: 1`, and updating text to "Reset Permissions & Settings" as per leader branch.
- **`.github/actions/setup-env/action.yml`**: Resolved conflicts, keeping the `gh` CLI installation step.
- **`app/client/connect/ConnectView.test.tsx`**: Fixed outdated prop usage (`unit` -> `unitSystem`, `setUnit` -> `onUnitChange`) and added tests for the Reset button presence and interaction.

### Verification
- **Unit Tests**: `npm test app/client/connect/ConnectView.test.tsx` passed.
- **Visual Verification**: Confirmed "Reset Permissions & Settings" button and description are visible on the Connect page (even in "Not Supported" state).

---
*PR created automatically by Jules for task [8063413843096533191](https://jules.google.com/task/8063413843096533191) started by @arii*
</details>