### PR TITLE
chore(small): Remove redundant GitHub CLI installation from setup-env action

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -50,36 +50,6 @@ runs:
           cache-${{ inputs.cache-type }}-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ github.ref_name }}-
           cache-${{ inputs.cache-type }}-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}-
 
-    - name: Install GitHub CLI
-      shell: bash
-      run: |
-        if command -v gh &> /dev/null; then
-          echo "GitHub CLI already installed: $(gh --version)"
-          exit 0
-        fi
-
-        mkdir -p $HOME/.local/bin
-        # Detect OS and Architecture
-        OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
-        ARCH="$(uname -m)"
-        if [ "$ARCH" = "x86_64" ]; then
-          ARCH="amd64"
-        elif [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then
-          ARCH="arm64"
-        fi
-
-        GH_VERSION=2.63.0
-        URL="https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_${OS}_${ARCH}.tar.gz"
-
-        echo "Downloading GitHub CLI from $URL"
-        curl -f -L --retry 3 --retry-delay 5 "$URL" -o gh.tar.gz
-        tar xvf gh.tar.gz
-
-        # Move binary to local bin
-        mv "gh_${GH_VERSION}_${OS}_${ARCH}/bin/gh" "$HOME/.local/bin/"
-        # Add to PATH for this and future steps
-        echo "$HOME/.local/bin" >> $GITHUB_PATH
-
     - name: 'Install Dependencies'
       shell: bash
       run: |


### PR DESCRIPTION
## Description

This change removes the manual installation of the GitHub CLI in the `setup-env` composite action. Since GitHub-hosted runners already include the CLI, this step was redundant and added unnecessary overhead to the CI process.

Fixes #9099

## Change Type: 🏗️ Refactoring (code change that neither fixes bug nor adds feature)

## Testing
The change was verified by checking the YAML syntax with Prettier and ensuring that subsequent steps in the action do not rely on a custom installation of `gh`.

## Related Issues

Closes #9099

<details>
<summary>Original PR Body</summary>

This change removes the manual installation of the GitHub CLI in the `setup-env` composite action. Since GitHub-hosted runners already include the CLI, this step was redundant and added unnecessary overhead to the CI process. The change was verified by checking the YAML syntax with Prettier and ensuring that subsequent steps in the action do not rely on a custom installation of `gh`.

Fixes #9099

---
*PR created automatically by Jules for task [8234125998124684031](https://jules.google.com/task/8234125998124684031) started by @arii*
</details>