### PR TITLE
chore(ci): optimize and standardize performance test execution

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "test:oauth:local": "python3 scripts/verify_oauth_local.py",
     "test:oauth:playwright": "playwright test --config=playwright.oauth.config.ts",
     "test:remote": "pnpm run build && playwright test remote-capabilities --project=chromium",
-    "test:perf": "playwright test tests/playwright/perf-*.spec.ts --project=chromium",
+    "test:perf": "playwright test tests/playwright/perf-*.spec.ts --project=chromium --workers=1",
     "test:perf:debug": "cross-env PWDEBUG=1 pnpm run test:perf",
     "verify:spotify": "bash scripts/verify-spotify.sh",
     "kill-all": "./scripts/kill-all.sh",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -180,18 +180,5 @@ export default defineConfig({
 
   // Output configuration
   outputDir: 'test-results/',
-  reporter: [
-    ['list'],
-    ...(process.env.CI ? [['github']] : []),
-    ['blob'],
-    [
-      'junit',
-      {
-        outputFile:
-          process.env.PLAYWRIGHT_JUNIT_OUTPUT_NAME || 'test-results/results.xml',
-      },
-    ],
-    ['html', { outputFolder: 'playwright-report', open: 'never' }],
-    ['json', { outputFile: 'test-results/results.json' }],
-  ],
+  reporter: reporters,
 })

--- a/scripts/ci/run-perf-tests.sh
+++ b/scripts/ci/run-perf-tests.sh
@@ -5,4 +5,4 @@ echo "🧪 Running performance tests..."
 mkdir -p logs test-results
 
 # Run performance tests sequentially to ensure metric reliability (avoid "noisy neighbor" effects)
-PLAYWRIGHT_JUNIT_OUTPUT_NAME=test-results/perf-results.xml pnpm exec playwright test tests/playwright/perf-*.spec.ts --project=chromium --workers=1 2>&1 | tee logs/perf-output.log
+PLAYWRIGHT_JUNIT_OUTPUT_NAME=test-results/perf-results.xml pnpm run test:perf 2>&1 | tee logs/perf-output.log


### PR DESCRIPTION
## Description

This PR repairs PR #9198 by addressing code review feedback. It standardizes the execution of performance tests by encapsulating the command in `package.json` and ensuring sequential execution via `--workers=1`. It also cleans up `playwright.config.ts` by removing verbose inline reporter configuration in favor of a cleaner variable-based approach.

Fixes #9198

## Change Type: 🐛 Bug fix (non-breaking change fixing an issue)

## Related Issues

Closes #9198

## Changes Made
- Standardized the execution of performance tests by encapsulating the command in `package.json` and ensuring sequential execution via `--workers=1`.
- Cleaned up `playwright.config.ts` by removing verbose inline reporter configuration in favor of a cleaner variable-based approach.

## Testing
- The changes were verified by running the performance test suite.

<details>
<summary>Original PR Body</summary>

This PR repairs PR #9198 by addressing code review feedback. It standardizes the execution of performance tests by encapsulating the command in `package.json` and ensuring sequential execution via `--workers=1`. It also cleans up `playwright.config.ts` by removing verbose inline reporter configuration in favor of a cleaner variable-based approach. The changes were verified by running the performance test suite.

---
*PR created automatically by Jules for task [12258477843866041529](https://jules.google.com/task/12258477843866041529) started by @arii*
</details>