### PR TITLE
test(medium): Refactor usePersistentStorage for safer fallback and correct reactivity

### DIFF
--- a/context/UserSettingsContext.tsx
+++ b/context/UserSettingsContext.tsx
@@ -78,7 +78,9 @@ export const UserSettingsProvider: React.FC<{ children: React.ReactNode }> = ({
 }) => {
   // Use the usePersistentStorage hook directly within the provider
   const [userPreferences, setUserPreferences] =
-    usePersistentStorage<UserPreferences>('user-prefs', DEFAULT_PREFERENCES)
+    usePersistentStorage<UserPreferences>('user-prefs', DEFAULT_PREFERENCES, {
+      enableCookieFallback: true,
+    })
 
   useEffect(() => {
     const migrated = migratePreferences(userPreferences)

--- a/hooks/usePersistentStorage.ts
+++ b/hooks/usePersistentStorage.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import Cookies from 'js-cookie'
 
 let isLocalStorageAvailable: boolean | null = null
@@ -26,52 +26,69 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return proto === null || proto === Object.prototype
 }
 
-function usePersistentStorage<T>(key: string, initialValue: T) {
+interface PersistentStorageOptions {
+  enableCookieFallback?: boolean
+}
+
+function usePersistentStorage<T>(
+  key: string,
+  initialValue: T,
+  options: PersistentStorageOptions = {}
+) {
+  const { enableCookieFallback = false } = options
   const [storedValue, setStoredValue] = useState<T>(initialValue)
-  const lastKeyRef = useRef<string | null>(null)
 
   useEffect(() => {
-    if (lastKeyRef.current === key) return
     if (typeof window === 'undefined') return
 
     try {
-      const useLocal = checkLocalStorage()
-      const item = useLocal
-        ? window.localStorage.getItem(key)
-        : Cookies.get(key)
+      const isLocalAvailable = checkLocalStorage()
+      // Use cookies only if localStorage is unavailable AND fallback is enabled
+      const useCookie = !isLocalAvailable && enableCookieFallback
+
+      let item: string | undefined | null = null
+
+      if (isLocalAvailable) {
+        item = window.localStorage.getItem(key)
+      } else if (useCookie) {
+        item = Cookies.get(key)
+      }
 
       if (item) {
         const parsed = JSON.parse(item)
+        let valueToUse = parsed
 
         if (isPlainObject(parsed) && isPlainObject(initialValue)) {
           const merged = { ...initialValue, ...parsed } as T
+          valueToUse = merged
 
-          if (JSON.stringify(merged) !== JSON.stringify(storedValue)) {
-            // eslint-disable-next-line react-hooks/set-state-in-effect
-            setStoredValue(merged)
-          }
-
-          if (useLocal) {
+          // Sync merged value back to storage if using localStorage
+          if (isLocalAvailable) {
             window.localStorage.setItem(key, JSON.stringify(merged))
           }
-        } else {
-          if (JSON.stringify(parsed) !== JSON.stringify(storedValue)) {
-            setStoredValue(parsed)
+        }
+
+        setStoredValue((current) => {
+          if (JSON.stringify(valueToUse) !== JSON.stringify(current)) {
+            return valueToUse
           }
-        }
+          return current
+        })
       } else {
-        if (JSON.stringify(initialValue) !== JSON.stringify(storedValue)) {
-          setStoredValue(initialValue)
-        }
+        setStoredValue((current) => {
+          if (JSON.stringify(initialValue) !== JSON.stringify(current)) {
+            return initialValue
+          }
+          return current
+        })
       }
-      lastKeyRef.current = key
     } catch (error) {
       console.error(
         `Error reading or parsing persistent storage key “${key}”`,
         error
       )
     }
-  }, [key, initialValue, storedValue])
+  }, [key, initialValue, enableCookieFallback])
 
   const setValue = useCallback(
     (value: T | ((val: T) => T)) => {
@@ -80,13 +97,15 @@ function usePersistentStorage<T>(key: string, initialValue: T) {
           const valueToStore =
             value instanceof Function ? value(currentStoredValue) : value
 
-          if (checkLocalStorage()) {
+          const isLocalAvailable = checkLocalStorage()
+
+          if (isLocalAvailable) {
             try {
               window.localStorage.setItem(key, JSON.stringify(valueToStore))
             } catch (storageError) {
               console.error('LocalStorage write failed:', storageError)
             }
-          } else {
+          } else if (enableCookieFallback) {
             try {
               Cookies.set(key, JSON.stringify(valueToStore), {
                 expires: 365,
@@ -103,7 +122,7 @@ function usePersistentStorage<T>(key: string, initialValue: T) {
         console.error(`Error setting persistent storage key “${key}”:`, error)
       }
     },
-    [key]
+    [key, enableCookieFallback]
   )
 
   useEffect(() => {
@@ -113,9 +132,12 @@ function usePersistentStorage<T>(key: string, initialValue: T) {
       if (e.key === key && e.newValue) {
         try {
           const parsed = JSON.parse(e.newValue)
-          if (JSON.stringify(parsed) !== JSON.stringify(storedValue)) {
-            setStoredValue(parsed)
-          }
+          setStoredValue((current) => {
+            if (JSON.stringify(parsed) !== JSON.stringify(current)) {
+              return parsed
+            }
+            return current
+          })
         } catch (error) {
           console.error(`Error parsing storage change for key “${key}”:`, error)
         }
@@ -125,7 +147,7 @@ function usePersistentStorage<T>(key: string, initialValue: T) {
     return () => {
       window.removeEventListener('storage', handleStorageChange)
     }
-  }, [key, storedValue])
+  }, [key])
 
   return [storedValue, setValue] as const
 }

--- a/hooks/usePersistentStorage.ts
+++ b/hooks/usePersistentStorage.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import Cookies from 'js-cookie'
 
 let isLocalStorageAvailable: boolean | null = null
@@ -36,14 +36,72 @@ function usePersistentStorage<T>(
   options: PersistentStorageOptions = {}
 ) {
   const { enableCookieFallback = false } = options
-  const [storedValue, setStoredValue] = useState<T>(initialValue)
 
-  useEffect(() => {
-    if (typeof window === 'undefined') return
+  // Read value once during initialization
+  const [storedValue, setStoredValue] = useState<T>(() => {
+    if (typeof window === 'undefined') return initialValue
 
     try {
       const isLocalAvailable = checkLocalStorage()
       // Use cookies only if localStorage is unavailable AND fallback is enabled
+      const useCookie = !isLocalAvailable && enableCookieFallback
+
+      let item: string | undefined | null = null
+
+      if (isLocalAvailable) {
+        item = window.localStorage.getItem(key)
+      } else if (useCookie) {
+        item = Cookies.get(key)
+      }
+
+      if (item) {
+        const parsed = JSON.parse(item)
+
+        if (isPlainObject(parsed) && isPlainObject(initialValue)) {
+          const merged = { ...initialValue, ...parsed } as T
+          // Sync merged value back to storage if using localStorage
+          if (isLocalAvailable) {
+            window.localStorage.setItem(key, JSON.stringify(merged))
+          }
+          return merged
+        }
+        return parsed
+      }
+    } catch (error) {
+      console.error(
+        `Error reading or parsing persistent storage key “${key}”`,
+        error
+      )
+    }
+    return initialValue
+  })
+
+  // Use refs to avoid unnecessary re-renders or effect loops
+  const initialValueRef = useRef(initialValue)
+  const keyRef = useRef(key)
+  const isMounted = useRef(false)
+
+  // Handle key changes or external initialValue changes
+  useEffect(() => {
+    if (!isMounted.current) {
+      isMounted.current = true
+      return
+    }
+
+    // Only run if key changed OR initialValue changed significantly
+    const keyChanged = keyRef.current !== key
+    const initialValueChanged =
+      JSON.stringify(initialValueRef.current) !== JSON.stringify(initialValue)
+
+    if (!keyChanged && !initialValueChanged) return
+
+    keyRef.current = key
+    initialValueRef.current = initialValue
+
+    if (typeof window === 'undefined') return
+
+    try {
+      const isLocalAvailable = checkLocalStorage()
       const useCookie = !isLocalAvailable && enableCookieFallback
 
       let item: string | undefined | null = null
@@ -62,12 +120,12 @@ function usePersistentStorage<T>(
           const merged = { ...initialValue, ...parsed } as T
           valueToUse = merged
 
-          // Sync merged value back to storage if using localStorage
           if (isLocalAvailable) {
             window.localStorage.setItem(key, JSON.stringify(merged))
           }
         }
 
+        // eslint-disable-next-line react-hooks/set-state-in-effect
         setStoredValue((current) => {
           if (JSON.stringify(valueToUse) !== JSON.stringify(current)) {
             return valueToUse
@@ -75,6 +133,7 @@ function usePersistentStorage<T>(
           return current
         })
       } else {
+        // If no item in storage, use initialValue
         setStoredValue((current) => {
           if (JSON.stringify(initialValue) !== JSON.stringify(current)) {
             return initialValue

--- a/tests/unit/hooks/usePersistentStorage.test.ts
+++ b/tests/unit/hooks/usePersistentStorage.test.ts
@@ -227,27 +227,27 @@ describe('usePersistentStorage', () => {
   })
 
   it('should update state if initialValue changes dynamically', () => {
-     // This tests the fix for "Problem 2"
-     const { result, rerender } = renderHook(
-       ({ initVal }) => usePersistentStorage(TEST_KEY, initVal),
-       {
-         initialProps: { initVal: INITIAL_VALUE }
-       }
-     )
+    // This tests the fix for "Problem 2"
+    const { result, rerender } = renderHook(
+      ({ initVal }) => usePersistentStorage(TEST_KEY, initVal),
+      {
+        initialProps: { initVal: INITIAL_VALUE },
+      }
+    )
 
-     // First render: uses INITIAL_VALUE ({ foo: 'bar' })
-     expect(result.current[0]).toEqual(INITIAL_VALUE)
+    // First render: uses INITIAL_VALUE ({ foo: 'bar' })
+    expect(result.current[0]).toEqual(INITIAL_VALUE)
 
-     // Update initialValue
-     const NEW_INITIAL_VALUE = { foo: 'changed' }
-     rerender({ initVal: NEW_INITIAL_VALUE })
+    // Update initialValue
+    const NEW_INITIAL_VALUE = { foo: 'changed' }
+    rerender({ initVal: NEW_INITIAL_VALUE })
 
-     // Since storage was empty, it should pick up the new initial value?
-     // Wait, on first render, it sets state to INITIAL_VALUE.
-     // Storage is empty.
-     // In second render, it checks storage (empty).
-     // Else block: checks if initialValue !== current.
-     // Updates to NEW_INITIAL_VALUE.
-     expect(result.current[0]).toEqual(NEW_INITIAL_VALUE)
+    // Since storage was empty, it should pick up the new initial value?
+    // Wait, on first render, it sets state to INITIAL_VALUE.
+    // Storage is empty.
+    // In second render, it checks storage (empty).
+    // Else block: checks if initialValue !== current.
+    // Updates to NEW_INITIAL_VALUE.
+    expect(result.current[0]).toEqual(NEW_INITIAL_VALUE)
   })
 })

--- a/tests/unit/hooks/usePersistentStorage.test.ts
+++ b/tests/unit/hooks/usePersistentStorage.test.ts
@@ -52,7 +52,40 @@ describe('usePersistentStorage', () => {
     expect(Cookies.set).not.toHaveBeenCalled()
   })
 
-  it('should use cookies when localStorage is not available', () => {
+  it('should use cookies when localStorage is not available AND fallback is enabled', () => {
+    // Mock localStorage to be unavailable
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        setItem: () => {
+          throw new Error('Storage full')
+        },
+        getItem: jest.fn(),
+        removeItem: jest.fn(),
+        clear: jest.fn(),
+      },
+      writable: true,
+      configurable: true,
+    })
+
+    const { result } = renderHook(() =>
+      usePersistentStorage(TEST_KEY, INITIAL_VALUE, {
+        enableCookieFallback: true,
+      })
+    )
+
+    act(() => {
+      const [, setValue] = result.current
+      setValue(UPDATED_VALUE)
+    })
+
+    expect(Cookies.set).toHaveBeenCalledWith(
+      TEST_KEY,
+      JSON.stringify(UPDATED_VALUE),
+      expect.any(Object)
+    )
+  })
+
+  it('should NOT use cookies when localStorage is not available and fallback is disabled', () => {
     // Mock localStorage to be unavailable
     Object.defineProperty(window, 'localStorage', {
       value: {
@@ -76,11 +109,9 @@ describe('usePersistentStorage', () => {
       setValue(UPDATED_VALUE)
     })
 
-    expect(Cookies.set).toHaveBeenCalledWith(
-      TEST_KEY,
-      JSON.stringify(UPDATED_VALUE),
-      expect.any(Object)
-    )
+    expect(Cookies.set).not.toHaveBeenCalled()
+    // Should still update state (in-memory)
+    expect(result.current[0]).toEqual(UPDATED_VALUE)
   })
 
   it('should not fallback to cookies when localStorage is available but write fails', () => {
@@ -103,7 +134,9 @@ describe('usePersistentStorage', () => {
     })
 
     const { result } = renderHook(() =>
-      usePersistentStorage(TEST_KEY, INITIAL_VALUE)
+      usePersistentStorage(TEST_KEY, INITIAL_VALUE, {
+        enableCookieFallback: true,
+      })
     )
 
     act(() => {
@@ -128,7 +161,7 @@ describe('usePersistentStorage', () => {
     expect(result.current[0]).toEqual(UPDATED_VALUE)
   })
 
-  it('should load initial value from cookies if localStorage is not available and cookies have value', () => {
+  it('should load initial value from cookies if localStorage is not available and cookies have value and fallback enabled', () => {
     // Mock localStorage to be unavailable
     Object.defineProperty(window, 'localStorage', {
       value: {
@@ -145,7 +178,9 @@ describe('usePersistentStorage', () => {
     ;(Cookies.get as jest.Mock).mockReturnValue(JSON.stringify(UPDATED_VALUE))
 
     const { result } = renderHook(() =>
-      usePersistentStorage(TEST_KEY, INITIAL_VALUE)
+      usePersistentStorage(TEST_KEY, INITIAL_VALUE, {
+        enableCookieFallback: true,
+      })
     )
 
     expect(result.current[0]).toEqual(UPDATED_VALUE)
@@ -169,5 +204,50 @@ describe('usePersistentStorage', () => {
     rerender({ key: OTHER_KEY })
 
     expect(result.current[0]).toEqual({ ...INITIAL_VALUE, ...OTHER_VALUE })
+  })
+
+  it('should merge new fields from initialValue into stored value', () => {
+    const OLD_STORED_VALUE = { foo: 'bar' }
+    const NEW_INITIAL_VALUE = { foo: 'default', newField: 'newValue' }
+    // Expected: foo comes from storage (preserved), newField comes from initialValue
+    const EXPECTED_VALUE = { foo: 'bar', newField: 'newValue' }
+
+    window.localStorage.setItem(TEST_KEY, JSON.stringify(OLD_STORED_VALUE))
+
+    const { result } = renderHook(() =>
+      usePersistentStorage(TEST_KEY, NEW_INITIAL_VALUE)
+    )
+
+    expect(result.current[0]).toEqual(EXPECTED_VALUE)
+
+    // Verify it updated storage with the merged value
+    expect(JSON.parse(window.localStorage.getItem(TEST_KEY)!)).toEqual(
+      EXPECTED_VALUE
+    )
+  })
+
+  it('should update state if initialValue changes dynamically', () => {
+     // This tests the fix for "Problem 2"
+     const { result, rerender } = renderHook(
+       ({ initVal }) => usePersistentStorage(TEST_KEY, initVal),
+       {
+         initialProps: { initVal: INITIAL_VALUE }
+       }
+     )
+
+     // First render: uses INITIAL_VALUE ({ foo: 'bar' })
+     expect(result.current[0]).toEqual(INITIAL_VALUE)
+
+     // Update initialValue
+     const NEW_INITIAL_VALUE = { foo: 'changed' }
+     rerender({ initVal: NEW_INITIAL_VALUE })
+
+     // Since storage was empty, it should pick up the new initial value?
+     // Wait, on first render, it sets state to INITIAL_VALUE.
+     // Storage is empty.
+     // In second render, it checks storage (empty).
+     // Else block: checks if initialValue !== current.
+     // Updates to NEW_INITIAL_VALUE.
+     expect(result.current[0]).toEqual(NEW_INITIAL_VALUE)
   })
 })


### PR DESCRIPTION
## Description

This PR addresses architectural risks in the `usePersistentStorage` hook identified in a previous audit. It disables the implicit cookie fallback mechanism by default to prevent potential header bloat, making it an opt-in feature via an `options` object. The `UserSettingsContext` has been updated to opt-in to this behavior. Additionally, the hook's `useEffect` dependencies and logic have been refactored to correctly handle changes in `initialValue` (e.g., new default preferences) without causing infinite loops or stale closures. This ensures that new application settings are correctly merged and persisted.

## Change Type: 🏗️ Refactoring (code change that neither fixes bug nor adds feature)

## Related Issues

Jules Task: [6068292813065146149](https://jules.google.com/task/6068292813065146149)

## Changes Made
- Disabled the implicit cookie fallback mechanism in `usePersistentStorage` by default; it is now opt-in via an `options` object.
- Updated `UserSettingsContext` to explicitly opt-in to the cookie fallback behavior.
- Refactored `useEffect` dependencies and logic within `usePersistentStorage` to correctly handle `initialValue` changes.
- Ensured proper merging and persistence of new application settings.

## Testing
Unit tests have been expanded to verify the updated behaviors.

<details>
<summary>Original PR Body</summary>

This PR addresses architectural risks in the `usePersistentStorage` hook identified in a previous audit. It disables the implicit cookie fallback mechanism by default to prevent potential header bloat, making it an opt-in feature via an `options` object. The `UserSettingsContext` has been updated to opt-in to this behavior. Additionally, the hook's `useEffect` dependencies and logic have been refactored to correctly handle changes in `initialValue` (e.g., new default preferences) without causing infinite loops or stale closures. This ensures that new application settings are correctly merged and persisted. Unit tests have been expanded to verify these behaviors.

---
*PR created automatically by Jules for task [6068292813065146149](https://jules.google.com/task/6068292813065146149) started by @arii*
</details>