### PR TITLE
feat(medium): Refactor Bluetooth test controls and update WebSocket schema

### DIFF
--- a/app/client/mock/page.tsx
+++ b/app/client/mock/page.tsx
@@ -9,9 +9,10 @@ import Container from '@mui/material/Container'
 import Grid from '@mui/material/Grid'
 import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import BottomNavBar from '../../../components/BottomNavBar'
 import { useWebSocket } from '@/context/WebSocketContext'
+import { useInterval } from '@/hooks/useInterval'
 import {
   HrmInputMessage,
   HrmMetadataUpdateMessage,
@@ -21,28 +22,6 @@ import { calculateMaxHr } from '@/utils/hrCalculations'
 import { estimateCaloriesBurned } from '@/lib/calorie-estimation'
 import { Gender } from '@/types/core'
 import MenuItem from '@mui/material/MenuItem'
-
-/**
- * Custom hook to handle intervals declaratively.
- * @param callback The function to call on every interval.
- * @param delay The delay in milliseconds, or null to stop the interval.
- */
-function useInterval(callback: () => void, delay: number | null) {
-  const savedCallback = useRef(callback)
-
-  // Remember the latest callback.
-  useEffect(() => {
-    savedCallback.current = callback
-  }, [callback])
-
-  // Set up the interval.
-  useEffect(() => {
-    if (delay === null) return
-
-    const id = setInterval(() => savedCallback.current(), delay)
-    return () => clearInterval(id)
-  }, [delay])
-}
 
 export default function MockPage() {
   const { sendData, connectionStatus } = useWebSocket()

--- a/components/Providers.tsx
+++ b/components/Providers.tsx
@@ -3,12 +3,15 @@
 import { AudioProvider } from '@/context/AudioContext'
 import { WebSocketProvider } from '@/context/WebSocketContext'
 import { SessionProvider } from 'next-auth/react'
+import { BluetoothTestProvider } from '@/context/BluetoothTestContext'
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   return (
     <SessionProvider refetchInterval={0} refetchOnWindowFocus={true}>
       <AudioProvider>
-        <WebSocketProvider>{children}</WebSocketProvider>
+        <WebSocketProvider>
+          <BluetoothTestProvider>{children}</BluetoothTestProvider>
+        </WebSocketProvider>
       </AudioProvider>
     </SessionProvider>
   )

--- a/context/BluetoothTestContext.tsx
+++ b/context/BluetoothTestContext.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import { createContext, useCallback, Dispatch, SetStateAction } from 'react'
+import { BluetoothConnectionStatus } from '@/types/bluetooth'
+
+export interface TestControls {
+  setStatus: Dispatch<SetStateAction<BluetoothConnectionStatus>>
+  setCustomStatusMessage: Dispatch<SetStateAction<string | null>>
+}
+
+export interface BluetoothTestContextType {
+  registerControls: (controls: TestControls) => () => void
+}
+
+export const BluetoothTestContext = createContext<BluetoothTestContextType | null>(
+  null
+)
+
+export function BluetoothTestProvider({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const registerControls = useCallback((controls: TestControls) => {
+    // Only expose to window in test environment
+    if (
+      typeof window !== 'undefined' &&
+      (process.env.NEXT_PUBLIC_TESTING === 'true' ||
+        (window as unknown as { __TEST_MODE__?: boolean }).__TEST_MODE__)
+    ) {
+      window.TEST_CONTROLS = {
+        ...window.TEST_CONTROLS,
+        setHrmStatus: controls.setStatus,
+        setCustomHrmStatusMessage: controls.setCustomStatusMessage,
+      }
+    }
+
+    return () => {
+      if (
+        typeof window !== 'undefined' &&
+        (process.env.NEXT_PUBLIC_TESTING === 'true' ||
+          (window as unknown as { __TEST_MODE__?: boolean }).__TEST_MODE__)
+      ) {
+        // Only delete if they are still the same functions we set
+        if (window.TEST_CONTROLS?.setHrmStatus === controls.setStatus) {
+          delete window.TEST_CONTROLS.setHrmStatus
+        }
+        if (
+          window.TEST_CONTROLS?.setCustomHrmStatusMessage ===
+          controls.setCustomStatusMessage
+        ) {
+          delete window.TEST_CONTROLS.setCustomHrmStatusMessage
+        }
+      }
+    }
+  }, [])
+
+  return (
+    <BluetoothTestContext.Provider value={{ registerControls }}>
+      {children}
+    </BluetoothTestContext.Provider>
+  )
+}

--- a/hooks/useBluetoothHRM.ts
+++ b/hooks/useBluetoothHRM.ts
@@ -4,6 +4,7 @@ import {
   useRef,
   useEffect,
   useLayoutEffect,
+  useContext,
 } from 'react'
 import {
   HrmMetadataUpdateMessage,
@@ -14,6 +15,7 @@ import isEqual from 'lodash.isequal'
 import { calculateMaxHr } from '@/utils/hrCalculations'
 import logger from '@/utils/logger'
 import { useWebSocket } from '@/context/WebSocketContext'
+import { BluetoothTestContext } from '@/context/BluetoothTestContext'
 import { cancellablePromise } from '@/utils/promise'
 import { getCookie, setCookie } from '@/utils/cookies'
 import { BLUETOOTH_MESSAGES } from '@/constants/bluetooth-messages'
@@ -387,19 +389,17 @@ const useBluetoothHRM = (props: UseBluetoothHRMProps = {}) => {
   const useIsomorphicLayoutEffect =
     typeof window !== 'undefined' ? useLayoutEffect : useEffect
 
+  const testContext = useContext(BluetoothTestContext)
+
   useIsomorphicLayoutEffect(() => {
     isManualDisconnect.current = false
+    let unregister: (() => void) | undefined
 
-    if (
-      typeof window !== 'undefined' &&
-      (process.env.NEXT_PUBLIC_TESTING === 'true' ||
-        (window as unknown as { __TEST_MODE__?: boolean }).__TEST_MODE__)
-    ) {
-      window.TEST_CONTROLS = {
-        ...window.TEST_CONTROLS,
-        setHrmStatus: setStatus,
-        setCustomHrmStatusMessage: setCustomStatusMessage,
-      }
+    if (testContext) {
+      unregister = testContext.registerControls({
+        setStatus,
+        setCustomStatusMessage,
+      })
     }
 
     return () => {
@@ -415,24 +415,11 @@ const useBluetoothHRM = (props: UseBluetoothHRMProps = {}) => {
       // This allows auto-reconnect to work properly on component remount
       if (reconnectTimeoutRef.current) clearTimeout(reconnectTimeoutRef.current)
 
-      if (
-        typeof window !== 'undefined' &&
-        (process.env.NEXT_PUBLIC_TESTING === 'true' ||
-          (window as unknown as { __TEST_MODE__?: boolean }).__TEST_MODE__)
-      ) {
-        // Only delete if they are still the same functions we set
-        if (window.TEST_CONTROLS?.setHrmStatus === setStatus) {
-          delete window.TEST_CONTROLS.setHrmStatus
-        }
-        if (
-          window.TEST_CONTROLS?.setCustomHrmStatusMessage ===
-          setCustomStatusMessage
-        ) {
-          delete window.TEST_CONTROLS.setCustomHrmStatusMessage
-        }
+      if (unregister) {
+        unregister()
       }
     }
-  }, [])
+  }, [testContext])
 
   const connectToGatt = useCallback(
     async (device: BluetoothDevice, isReconnect = false) => {

--- a/hooks/useInterval.ts
+++ b/hooks/useInterval.ts
@@ -1,0 +1,23 @@
+import { useEffect, useRef } from 'react'
+
+/**
+ * Custom hook to handle intervals declaratively.
+ * @param callback The function to call on every interval.
+ * @param delay The delay in milliseconds, or null to stop the interval.
+ */
+export function useInterval(callback: () => void, delay: number | null) {
+  const savedCallback = useRef(callback)
+
+  // Remember the latest callback.
+  useEffect(() => {
+    savedCallback.current = callback
+  }, [callback])
+
+  // Set up the interval.
+  useEffect(() => {
+    if (delay === null) return
+
+    const id = setInterval(() => savedCallback.current(), delay)
+    return () => clearInterval(id)
+  }, [delay])
+}

--- a/types/websocket.ts
+++ b/types/websocket.ts
@@ -124,17 +124,20 @@ const IncomingHrmDataSchema = HrmCommonDataSchema.extend({
   value: z.number().nullable(),
   calories: z.number().optional(),
   percentage: z.number().optional(),
-  zone: z
-    .enum([
-      'ZONE_0',
-      'ZONE_1',
-      'ZONE_2',
-      'ZONE_3',
-      'ZONE_4',
-      'ZONE_5',
-      'ZONE_6',
-    ])
-    .optional(),
+  zone: z.preprocess(
+    (val) => (typeof val === 'string' ? val.toUpperCase() : val),
+    z
+      .enum([
+        'ZONE_0',
+        'ZONE_1',
+        'ZONE_2',
+        'ZONE_3',
+        'ZONE_4',
+        'ZONE_5',
+        'ZONE_6',
+      ])
+      .optional()
+  ),
 })
 
 // Exported to support legacy consumers and maintain backward compatibility


### PR DESCRIPTION
## Description

This PR addresses architectural directives by centralizing the `useInterval` hook, refactoring test controls out of `useBluetoothHRM` into a dedicated context/provider to avoid polluting production hooks with test logic, and hardening the WebSocket Zod schema to handle legacy client inputs gracefully.

## Change Type: 🏗️ Refactoring (code change that neither fixes bug nor adds feature)

## Related Issues

Closes #12828390355693329258

<details>
<summary>Original PR Body</summary>

This PR addresses architectural directives by centralizing the `useInterval` hook, refactoring test controls out of `useBluetoothHRM` into a dedicated context/provider to avoid polluting production hooks with test logic, and hardening the WebSocket Zod schema to handle legacy client inputs gracefully.

---
*PR created automatically by Jules for task [12828390355693329258](https://jules.google.com/task/12828390355693329258) started by @arii*
</details>