### PR TITLE
feat(medium): Refactor duplicate hooks and fix test leakage in useBluetoothHRM

### DIFF
--- a/app/client/connect/layout.tsx
+++ b/app/client/connect/layout.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from 'next'
+import { BluetoothTestProvider } from '@/context/BluetoothTestContext'
 
 export const metadata: Metadata = {
   title: 'HRM Connect',
@@ -10,5 +11,5 @@ export default function ConnectLayout({
 }: {
   children: React.ReactNode
 }) {
-  return children
+  return <BluetoothTestProvider>{children}</BluetoothTestProvider>
 }

--- a/app/client/mock/page.tsx
+++ b/app/client/mock/page.tsx
@@ -9,9 +9,10 @@ import Container from '@mui/material/Container'
 import Grid from '@mui/material/Grid'
 import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import BottomNavBar from '../../../components/BottomNavBar'
 import { useWebSocket } from '@/context/WebSocketContext'
+import { useInterval } from '@/hooks/useInterval'
 import {
   HrmInputMessage,
   HrmMetadataUpdateMessage,
@@ -21,28 +22,6 @@ import { calculateMaxHr } from '@/utils/hrCalculations'
 import { estimateCaloriesBurned } from '@/lib/calorie-estimation'
 import { Gender } from '@/types/core'
 import MenuItem from '@mui/material/MenuItem'
-
-/**
- * Custom hook to handle intervals declaratively.
- * @param callback The function to call on every interval.
- * @param delay The delay in milliseconds, or null to stop the interval.
- */
-function useInterval(callback: () => void, delay: number | null) {
-  const savedCallback = useRef(callback)
-
-  // Remember the latest callback.
-  useEffect(() => {
-    savedCallback.current = callback
-  }, [callback])
-
-  // Set up the interval.
-  useEffect(() => {
-    if (delay === null) return
-
-    const id = setInterval(() => savedCallback.current(), delay)
-    return () => clearInterval(id)
-  }, [delay])
-}
 
 export default function MockPage() {
   const { sendData, connectionStatus } = useWebSocket()

--- a/context/BluetoothTestContext.tsx
+++ b/context/BluetoothTestContext.tsx
@@ -1,0 +1,95 @@
+'use client'
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  Dispatch,
+  SetStateAction,
+} from 'react'
+import { BluetoothConnectionStatus } from '@/types/bluetooth'
+
+interface BluetoothTestControls {
+  setHrmStatus: Dispatch<SetStateAction<BluetoothConnectionStatus>>
+  setCustomHrmStatusMessage: Dispatch<SetStateAction<string | null>>
+}
+
+interface BluetoothTestContextType {
+  registerTestControls: (controls: BluetoothTestControls) => void
+}
+
+const BluetoothTestContext = createContext<BluetoothTestContextType | null>(null)
+
+export const BluetoothTestProvider = ({
+  children,
+}: {
+  children: React.ReactNode
+}) => {
+  const controlsRef = useRef<BluetoothTestControls | null>(null)
+
+  const registerTestControls = useCallback(
+    (controls: BluetoothTestControls) => {
+      controlsRef.current = controls
+
+      if (
+        typeof window !== 'undefined' &&
+        (process.env.NEXT_PUBLIC_TESTING === 'true' ||
+          (window as unknown as { __TEST_MODE__?: boolean }).__TEST_MODE__)
+      ) {
+        window.TEST_CONTROLS = {
+          ...window.TEST_CONTROLS,
+          ...controls,
+        }
+      }
+    },
+    []
+  )
+
+  const value = useMemo(
+    () => ({ registerTestControls }),
+    [registerTestControls]
+  )
+
+  return (
+    <BluetoothTestContext.Provider value={value}>
+      {children}
+    </BluetoothTestContext.Provider>
+  )
+}
+
+/**
+ * Custom hook to register test controls if the BluetoothTestProvider is present.
+ * This decouples the test logic from the production hook.
+ */
+export const useBluetoothTestControls = (controls: BluetoothTestControls) => {
+  const context = useContext(BluetoothTestContext)
+
+  useEffect(() => {
+    if (context) {
+      context.registerTestControls(controls)
+    }
+
+    return () => {
+      // Cleanup: Remove the specific controls from window.TEST_CONTROLS?
+      if (
+        context &&
+        typeof window !== 'undefined' &&
+        (process.env.NEXT_PUBLIC_TESTING === 'true' ||
+          (window as unknown as { __TEST_MODE__?: boolean }).__TEST_MODE__)
+      ) {
+        if (window.TEST_CONTROLS?.setHrmStatus === controls.setHrmStatus) {
+          delete window.TEST_CONTROLS.setHrmStatus
+        }
+        if (
+          window.TEST_CONTROLS?.setCustomHrmStatusMessage ===
+          controls.setCustomHrmStatusMessage
+        ) {
+          delete window.TEST_CONTROLS.setCustomHrmStatusMessage
+        }
+      }
+    }
+  }, [context, controls.setHrmStatus, controls.setCustomHrmStatusMessage])
+}

--- a/context/BluetoothTestContext.tsx
+++ b/context/BluetoothTestContext.tsx
@@ -21,7 +21,9 @@ interface BluetoothTestContextType {
   registerTestControls: (controls: BluetoothTestControls) => void
 }
 
-const BluetoothTestContext = createContext<BluetoothTestContextType | null>(null)
+const BluetoothTestContext = createContext<BluetoothTestContextType | null>(
+  null
+)
 
 export const BluetoothTestProvider = ({
   children,
@@ -91,5 +93,5 @@ export const useBluetoothTestControls = (controls: BluetoothTestControls) => {
         }
       }
     }
-  }, [context, controls.setHrmStatus, controls.setCustomHrmStatusMessage])
+  }, [context, controls])
 }

--- a/hooks/useBluetoothHRM.ts
+++ b/hooks/useBluetoothHRM.ts
@@ -4,6 +4,7 @@ import {
   useRef,
   useEffect,
   useLayoutEffect,
+  useMemo,
 } from 'react'
 import {
   HrmMetadataUpdateMessage,
@@ -390,10 +391,15 @@ const useBluetoothHRM = (props: UseBluetoothHRMProps = {}) => {
   const useIsomorphicLayoutEffect =
     typeof window !== 'undefined' ? useLayoutEffect : useEffect
 
-  useBluetoothTestControls({
-    setHrmStatus: setStatus,
-    setCustomHrmStatusMessage: setCustomStatusMessage,
-  })
+  const testControls = useMemo(
+    () => ({
+      setHrmStatus: setStatus,
+      setCustomHrmStatusMessage: setCustomStatusMessage,
+    }),
+    []
+  )
+
+  useBluetoothTestControls(testControls)
 
   useIsomorphicLayoutEffect(() => {
     isManualDisconnect.current = false

--- a/hooks/useBluetoothHRM.ts
+++ b/hooks/useBluetoothHRM.ts
@@ -22,6 +22,7 @@ import {
   FAST_RECONNECT_DELAY_MS,
   FAST_RECONNECT_MAX_ATTEMPTS,
 } from '@/constants/bluetooth-reconnection'
+import { useBluetoothTestControls } from '@/context/BluetoothTestContext'
 
 const HR_SERVICE_UUID = 'heart_rate'
 const HR_CHARACTERISTIC_UUID = 'heart_rate_measurement'
@@ -389,20 +390,13 @@ const useBluetoothHRM = (props: UseBluetoothHRMProps = {}) => {
   const useIsomorphicLayoutEffect =
     typeof window !== 'undefined' ? useLayoutEffect : useEffect
 
+  useBluetoothTestControls({
+    setHrmStatus: setStatus,
+    setCustomHrmStatusMessage: setCustomStatusMessage,
+  })
+
   useIsomorphicLayoutEffect(() => {
     isManualDisconnect.current = false
-
-    if (
-      typeof window !== 'undefined' &&
-      (process.env.NEXT_PUBLIC_TESTING === 'true' ||
-        (window as unknown as { __TEST_MODE__?: boolean }).__TEST_MODE__)
-    ) {
-      window.TEST_CONTROLS = {
-        ...window.TEST_CONTROLS,
-        setHrmStatus: setStatus,
-        setCustomHrmStatusMessage: setCustomStatusMessage,
-      }
-    }
 
     return () => {
       // Clean up the disconnected listener to prevent leaks across remounts
@@ -416,23 +410,6 @@ const useBluetoothHRM = (props: UseBluetoothHRMProps = {}) => {
 
       // This allows auto-reconnect to work properly on component remount
       if (reconnectTimeoutRef.current) clearTimeout(reconnectTimeoutRef.current)
-
-      if (
-        typeof window !== 'undefined' &&
-        (process.env.NEXT_PUBLIC_TESTING === 'true' ||
-          (window as unknown as { __TEST_MODE__?: boolean }).__TEST_MODE__)
-      ) {
-        // Only delete if they are still the same functions we set
-        if (window.TEST_CONTROLS?.setHrmStatus === setStatus) {
-          delete window.TEST_CONTROLS.setHrmStatus
-        }
-        if (
-          window.TEST_CONTROLS?.setCustomHrmStatusMessage ===
-          setCustomStatusMessage
-        ) {
-          delete window.TEST_CONTROLS.setCustomHrmStatusMessage
-        }
-      }
     }
   }, [])
 

--- a/hooks/useInterval.ts
+++ b/hooks/useInterval.ts
@@ -1,0 +1,23 @@
+import { useEffect, useRef } from 'react'
+
+/**
+ * Custom hook to handle intervals declaratively.
+ * @param callback The function to call on every interval.
+ * @param delay The delay in milliseconds, or null to stop the interval.
+ */
+export function useInterval(callback: () => void, delay: number | null) {
+  const savedCallback = useRef(callback)
+
+  // Remember the latest callback.
+  useEffect(() => {
+    savedCallback.current = callback
+  }, [callback])
+
+  // Set up the interval.
+  useEffect(() => {
+    if (delay === null) return
+
+    const id = setInterval(() => savedCallback.current(), delay)
+    return () => clearInterval(id)
+  }, [delay])
+}

--- a/tests/playwright/vrt-components.spec.ts
+++ b/tests/playwright/vrt-components.spec.ts
@@ -116,15 +116,9 @@ test.describe('Component-Specific VRT', () => {
     await selectorButton.click()
 
     const menu = dashboardPage.getByTestId('spotify-device-selector-menu')
-<<<<<<< HEAD
     await expect(menu).toBeVisible({ timeout: VRT_TIMEOUTS.STANDARD })
     // Ensure the menu is fully rendered before accessibility check/screenshot
     await dashboardPage.waitForTimeout(500)
-    await takeScreenshot(menu, 'spotify-device-selector-menu.png', {
-      maxDiffPixelRatio: 0.1,
-      threshold: 0.2,
-=======
-    await expect(menu).toBeVisible()
 
     // Perform manual accessibility check on the specific menu element to ensure context validity
     await checkAccessibility(menu)
@@ -133,7 +127,6 @@ test.describe('Component-Specific VRT', () => {
       maxDiffPixelRatio: 0.15,
       threshold: 0.3,
       skipA11y: true, // Accessibility checked manually above
->>>>>>> origin/leader
     })
   })
 

--- a/types/websocket.ts
+++ b/types/websocket.ts
@@ -124,17 +124,25 @@ const IncomingHrmDataSchema = HrmCommonDataSchema.extend({
   value: z.number().nullable(),
   calories: z.number().optional(),
   percentage: z.number().optional(),
-  zone: z
-    .enum([
-      'ZONE_0',
-      'ZONE_1',
-      'ZONE_2',
-      'ZONE_3',
-      'ZONE_4',
-      'ZONE_5',
-      'ZONE_6',
-    ])
-    .optional(),
+  zone: z.preprocess(
+    (val) => {
+      if (typeof val === 'string') {
+        return val.toUpperCase()
+      }
+      return val
+    },
+    z
+      .enum([
+        'ZONE_0',
+        'ZONE_1',
+        'ZONE_2',
+        'ZONE_3',
+        'ZONE_4',
+        'ZONE_5',
+        'ZONE_6',
+      ])
+      .optional()
+  ),
 })
 
 // Exported to support legacy consumers and maintain backward compatibility


### PR DESCRIPTION
## Description

This PR refactors duplicate hooks and fixes test leakage in the `useBluetoothHRM` hook, addressing Principal Engineer directives. It centralizes `useInterval`, extracts test control logic using a new `BluetoothTestContext`, updates the Zod schema for case-insensitive zone values, and resolves a VRT merge conflict.

## Change Type: 🐛 Bug fix (non-breaking change fixing an issue)

## Changes Made

1.  **Duplicate Hooks:** Centralized `useInterval` in `hooks/useInterval.ts`.
2.  **Test Leakage:** Extracted test control logic from `hooks/useBluetoothHRM.ts` into a new `BluetoothTestContext`. This uses a Provider pattern to inject test controls only when the provider is present, decoupling the hook from the test environment.
3.  **Zod Schema:** Updated `IncomingHrmDataSchema` to accept case-insensitive `zone` values (e.g., `zone_1` -> `ZONE_1`) via `z.preprocess`.
4.  **VRT Fix:** Resolved a merge conflict in `tests/playwright/vrt-components.spec.ts`.

## Testing

Verified with `pnpm run type-check`, unit tests (`useBluetoothHRM.test.ts`), and system-wide VRT tests.

<details>
<summary>Original PR Body</summary>

This PR addresses the Principal Engineer's directives by refactoring duplicate code and removing test leakage from production hooks.

Changes:
1.  **Duplicate Hooks:** Centralized `useInterval` in `hooks/useInterval.ts`.
2.  **Test Leakage:** Extracted test control logic from `hooks/useBluetoothHRM.ts` into a new `BluetoothTestContext`. This uses a Provider pattern to inject test controls only when the provider is present, decoupling the hook from the test environment.
3.  **Zod Schema:** Updated `IncomingHrmDataSchema` to accept case-insensitive `zone` values (e.g., `zone_1` -> `ZONE_1`) via `z.preprocess`.
4.  **VRT Fix:** Resolved a merge conflict in `tests/playwright/vrt-components.spec.ts`.

Verified with `pnpm run type-check`, unit tests (`useBluetoothHRM.test.ts`), and system-wide VRT tests.

---
*PR created automatically by Jules for task [1245111242371377081](https://jules.google.com/task/1245111242371377081) started by @arii*
</details>