### PR TITLE
refactor(GoogleDocViewer): simplify URL parsing logic

### DIFF
--- a/components/GoogleDocViewer.tsx
+++ b/components/GoogleDocViewer.tsx
@@ -11,7 +11,7 @@ import CardContent from '@mui/material/CardContent'
 import IconButton from '@mui/material/IconButton'
 import Skeleton from '@mui/material/Skeleton'
 import { alpha } from '@mui/material/styles'
-import { memo, useEffect, useState } from 'react'
+import { memo, useEffect, useMemo, useState } from 'react'
 import RefreshIconButton from './RefreshIconButton'
 
 interface GoogleDocViewerProps {
@@ -25,17 +25,6 @@ interface GoogleDocViewerProps {
   onRefresh?: () => void
 }
 
-const getEmbedUrl = (url?: string) => {
-  if (!url) return ''
-  try {
-    const u = new URL(url)
-    u.searchParams.set('embedded', 'true')
-    return u.toString()
-  } catch {
-    return ''
-  }
-}
-
 const GoogleDocViewer = ({
   title,
   embedUrl,
@@ -47,7 +36,12 @@ const GoogleDocViewer = ({
 }: GoogleDocViewerProps) => {
   const [iframeLoading, setIframeLoading] = useState(true)
 
-  const finalEmbedUrl = getEmbedUrl(embedUrl)
+  const finalEmbedUrl = useMemo(() => {
+    if (!embedUrl) return ''
+    const u = new URL(embedUrl)
+    u.searchParams.set('embedded', 'true')
+    return u.toString()
+  }, [embedUrl])
 
   const dynamicHeight = isShrunk ? 200 : height // Use a smaller height when shrunk
 

--- a/tests/unit/components/GoogleDocViewer.test.tsx
+++ b/tests/unit/components/GoogleDocViewer.test.tsx
@@ -47,13 +47,6 @@ describe('GoogleDocViewer', () => {
     )
   })
 
-  it('renders nothing if embedUrl is invalid', () => {
-    const { container } = render(
-      <GoogleDocViewer title="Test Doc" embedUrl="invalid-url" />
-    )
-    expect(container).toBeEmptyDOMElement()
-  })
-
   it('renders nothing if embedUrl is empty', () => {
     const { container } = render(
       <GoogleDocViewer title="Test Doc" embedUrl="" />


### PR DESCRIPTION
## Description

Refactor `GoogleDocViewer` component to remove defensive `try-catch` block for URL parsing, trusting upstream environment variable validation.

## Change Type: 🏗️ Refactoring (code change that neither fixes bug nor adds feature)

## Testing

Updated unit tests to align with this change.

<details>
<summary>Original PR Body</summary>

Refactor `GoogleDocViewer` component to remove defensive `try-catch` block for URL parsing, trusting upstream environment variable validation. Update unit tests to align with this change. This addresses the feedback from PR #9162.

---
*PR created automatically by Jules for task [14559175694947055776](https://jules.google.com/task/14559175694947055776) started by @arii*
</details>