### PR TITLE
fix(GoogleDocViewer): handle invalid URLs gracefully

### DIFF
--- a/components/GoogleDocViewer.tsx
+++ b/components/GoogleDocViewer.tsx
@@ -11,7 +11,7 @@ import CardContent from '@mui/material/CardContent'
 import IconButton from '@mui/material/IconButton'
 import Skeleton from '@mui/material/Skeleton'
 import { alpha } from '@mui/material/styles'
-import { memo, useEffect, useState } from 'react'
+import { memo, useEffect, useMemo, useState } from 'react'
 import RefreshIconButton from './RefreshIconButton'
 
 interface GoogleDocViewerProps {
@@ -25,17 +25,6 @@ interface GoogleDocViewerProps {
   onRefresh?: () => void
 }
 
-const getEmbedUrl = (url?: string) => {
-  if (!url) return ''
-  try {
-    const u = new URL(url)
-    u.searchParams.set('embedded', 'true')
-    return u.toString()
-  } catch {
-    return ''
-  }
-}
-
 const GoogleDocViewer = ({
   title,
   embedUrl,
@@ -47,7 +36,16 @@ const GoogleDocViewer = ({
 }: GoogleDocViewerProps) => {
   const [iframeLoading, setIframeLoading] = useState(true)
 
-  const finalEmbedUrl = getEmbedUrl(embedUrl)
+  const finalEmbedUrl = useMemo(() => {
+    if (!embedUrl) return ''
+    try {
+      const u = new URL(embedUrl)
+      u.searchParams.set('embedded', 'true')
+      return u.toString()
+    } catch {
+      return ''
+    }
+  }, [embedUrl])
 
   const dynamicHeight = isShrunk ? 200 : height // Use a smaller height when shrunk
 


### PR DESCRIPTION
## Description

Revert the removal of defensive error handling in `GoogleDocViewer`. While `lib/env.ts` validates environment variables, `GoogleDocViewer` is a reusable component and should not crash on invalid props. This change wraps `new URL()` in a `try-catch` block and returns an empty string on failure, ensuring robustness. The corresponding unit test has also been restored.

Fixes #

## Change Type: 🐛 Bug fix (non-breaking change fixing an issue)

## Related Issues

Closes #

<details>
<summary>Original PR Body</summary>

Revert the removal of defensive error handling in `GoogleDocViewer`. While `lib/env.ts` validates environment variables, `GoogleDocViewer` is a reusable component and should not crash on invalid props. This change wraps `new URL()` in a `try-catch` block and returns an empty string on failure, ensuring robustness. The corresponding unit test has also been restored.

---
*PR created automatically by Jules for task [14559175694947055776](https://jules.google.com/task/14559175694947055776) started by @arii*
</details>