### PR TITLE
test(small): Finalize PR #9190: Remove legacy routes and verify VRT cleanup

### DIFF
--- a/tests/playwright/lib/index.ts
+++ b/tests/playwright/lib/index.ts
@@ -99,7 +99,6 @@ export {
 export {
   // Constants
   HRM_ROUTES,
-  LEGACY_ROUTES,
   // Warmup and page creation
   warmupEndpoints,
   createTestPage,

--- a/tests/playwright/lib/setup.ts
+++ b/tests/playwright/lib/setup.ts
@@ -37,19 +37,6 @@ export const HRM_ROUTES = {
 } as const
 
 /**
- * Legacy routes for backward compatibility
- * @deprecated Use HRM_ROUTES instead for new code
- */
-export const LEGACY_ROUTES = {
-  /** @deprecated Use HRM_ROUTES.CONTROL instead */
-  PHONE: '/phone',
-  /** @deprecated Use HRM_ROUTES.MOCK instead */
-  MOCK: '/mock',
-  /** @deprecated Use HRM_ROUTES.CONNECT instead */
-  CONNECT: '/connect',
-} as const
-
-/**
  * Warmup server endpoints to ensure fast subsequent requests.
  * Useful for parallel test execution.
  *
@@ -275,13 +262,11 @@ export async function setupComprehensiveTest(options: {
   const mockTab = await context.newPage()
   const connectTab = await context.newPage()
 
-  // Note: Uses LEGACY_ROUTES for control/mock/connect for backward compatibility with existing tests.
-  // Dashboard uses HRM_ROUTES.DASHBOARD since it's just '/'.
   await Promise.all([
     dashboardTab.goto(`${baseUrl}${HRM_ROUTES.DASHBOARD}`),
-    controlTab.goto(`${baseUrl}${LEGACY_ROUTES.PHONE}`),
-    mockTab.goto(`${baseUrl}${LEGACY_ROUTES.MOCK}`),
-    connectTab.goto(`${baseUrl}${LEGACY_ROUTES.CONNECT}`),
+    controlTab.goto(`${baseUrl}${HRM_ROUTES.CONTROL}`),
+    mockTab.goto(`${baseUrl}${HRM_ROUTES.MOCK}`),
+    connectTab.goto(`${baseUrl}${HRM_ROUTES.CONNECT}`),
   ])
 
   await Promise.all([


### PR DESCRIPTION
## Description

Finalized PR #9190 by removing deprecated legacy routing constants (`LEGACY_ROUTES`) and updating test infrastructure to use `HRM_ROUTES`. This reduces code bloat and ensures consistent routing across the test suite.

Fixes #9190

## Change Type: 🏗️ Refactoring (code change that neither fixes bug nor adds feature)

## Changes Made
- Removed deprecated legacy routing constants (`LEGACY_ROUTES`).
- Updated test infrastructure to use `HRM_ROUTES`.

## Testing
- Verified that all previous merge conflicts are resolved.
- Verified that VRTs pass.

## Related Issues

Closes #9190

<details>
<summary>Original PR Body</summary>

Finalized PR #9190 by removing deprecated legacy routing constants (`LEGACY_ROUTES`) and updating test infrastructure to use `HRM_ROUTES`. This reduces code bloat and ensures consistent routing across the test suite. Also verified that all previous merge conflicts are resolved and VRTs pass.

---
*PR created automatically by Jules for task [12134608941061059016](https://jules.google.com/task/12134608941061059016) started by @arii*
</details>