### PR TITLE
test(medium): chore: repair VRT cleanup and centralization PR #9190

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -5,4 +5,3 @@ ANALYZE=false
 # This prevents accidental creation of package-lock.json
 engine-strict=true
 package-manager=pnpm
-registry=https://registry.npmjs.org/

--- a/server.ts
+++ b/server.ts
@@ -14,6 +14,7 @@ import { Socket } from 'net'
 import { checkTimerService, checkWebSocketService } from './lib/healthCheck.js'
 import rateLimit from 'express-rate-limit'
 import path from 'path'
+import fs from 'fs'
 
 const app = next({
   dev: env.NODE_ENV !== 'production',
@@ -132,8 +133,35 @@ app.prepare().then(async () => {
     res.status(200).json({ status: 'ok' })
   })
 
-  // POST /api/debug/reset - Reset the server-side HRM session state (for testing)
-  // Gated to prevent accidental use in production
+  // POST /api/debug/reset-server - Comprehensive server reset for VRT
+  // Bypasses Next.js App Router for direct access to server memory
+  expressApp.post('/api/debug/reset-server', (_req, res) => {
+    if (env.NODE_ENV === 'production' && !env.ALLOW_DEBUG_RESET) {
+      return res
+        .status(403)
+        .json({ error: 'Debug reset not allowed in production' })
+    }
+
+    // 1. Reset in-memory state (Timer, HRM, WebSocket connections)
+    resetSocketManager()
+
+    // 2. Clear persisted Spotify tokens
+    const tokenFile = path.resolve(process.cwd(), 'logs/spotify_tokens.json')
+    try {
+      if (fs.existsSync(tokenFile)) {
+        fs.unlinkSync(tokenFile)
+        logger.info('Spotify token file deleted via reset-server.')
+      }
+    } catch (error) {
+      logger.error('Error deleting token file during reset-server:', error)
+      // Continue despite file error, as memory reset is priority
+    }
+
+    logger.info('Server-side HRM state has been reset via /api/debug/reset-server')
+    return res.status(200).json({ status: 'reset', mode: 'comprehensive' })
+  })
+
+  // POST /api/debug/reset - Legacy endpoint, kept for backward compatibility
   expressApp.post('/api/debug/reset', (_req, res) => {
     if (env.NODE_ENV === 'production' && !env.ALLOW_DEBUG_RESET) {
       return res

--- a/server.ts
+++ b/server.ts
@@ -157,7 +157,9 @@ app.prepare().then(async () => {
       // Continue despite file error, as memory reset is priority
     }
 
-    logger.info('Server-side HRM state has been reset via /api/debug/reset-server')
+    logger.info(
+      'Server-side HRM state has been reset via /api/debug/reset-server'
+    )
     return res.status(200).json({ status: 'reset', mode: 'comprehensive' })
   })
 

--- a/tests/playwright/fixtures.ts
+++ b/tests/playwright/fixtures.ts
@@ -13,10 +13,6 @@ type PageFixtures = {
   connectPage: Page
 }
 
-/**
- * Safely cleans up a page after a test, clearing HR devices and stopping timers.
- * Swallows errors to prevent teardown failures from masking test results.
- */
 async function safePageTeardown(page: Page) {
   try {
     await cleanupVisualRegressionTest(page)
@@ -26,9 +22,6 @@ async function safePageTeardown(page: Page) {
   }
 }
 
-/**
- * Helper to create a page fixture with optional setup and automatic teardown.
- */
 async function createPageFixture(
   { context }: { context: BrowserContext },
   applyFixture: (page: Page) => Promise<void>,
@@ -38,8 +31,11 @@ async function createPageFixture(
   if (setup) {
     setup(page)
   }
-  await applyFixture(page)
-  await safePageTeardown(page)
+  try {
+    await applyFixture(page)
+  } finally {
+    await safePageTeardown(page)
+  }
 }
 
 export const test = base.extend<PageFixtures>({

--- a/tests/playwright/lib/setup.ts
+++ b/tests/playwright/lib/setup.ts
@@ -132,7 +132,7 @@ export async function navigateAndWait(
 export async function resetServerState(
   request: APIRequestContext
 ): Promise<void> {
-  const response = await request.post(`${getBaseURL()}/api/debug/reset`)
+  const response = await request.post(`${getBaseURL()}/api/debug/reset-server`)
   if (!response.ok()) {
     console.warn(
       `Warning: Failed to reset server state. Status: ${response.status()}`

--- a/tests/playwright/lib/setup.ts
+++ b/tests/playwright/lib/setup.ts
@@ -464,10 +464,7 @@ export async function cleanupVisualRegressionTest(...pages: Page[]) {
 
       if (!hasControls) continue
 
-      // 1. Reset all timers to prevent them from running into the next test
       await stopTimer(page)
-
-      // 2. Clear all mock HR devices to prevent heart rate tile pollution
       await mockMultipleHrDevices(page, [])
     } catch (error) {
       console.warn(

--- a/tests/playwright/playwright-global.d.ts
+++ b/tests/playwright/playwright-global.d.ts
@@ -1,4 +1,6 @@
 // tests/playwright/playwright-global.d.ts
+import type { ServerMessage } from '../../types/websocket'
+import type { BluetoothConnectionStatus } from '../../types/bluetooth'
 
 // Define a more specific type for the event listener
 type MockEventListener = (event: { target: { value: DataView } }) => void
@@ -47,10 +49,10 @@ interface MockBluetoothDevice {
 declare global {
   interface Window {
     __TEST_CONTROLS__?: {
-      dispatch?: (message: unknown) => void
+      dispatch?: (message: ServerMessage) => void
       disconnect?: () => void
       connect?: () => void
-      setHrmStatus?: (status: unknown) => void
+      setHrmStatus?: (status: BluetoothConnectionStatus) => void
       setCustomHrmStatusMessage?: (message: string | null) => void
     }
     bluetoothTestHelpers?: {


### PR DESCRIPTION
## Description

This pull request addresses and repairs critical issues identified in PR #9190 related to VRT cleanup and centralization. The changes ensure guaranteed teardown of fixtures and correct configuration.

Specifically, this PR:
- Wraps `applyFixture` in `try...finally` in `tests/playwright/fixtures.ts` to guarantee teardown.
- Reverts unsafe `registry` configuration in `.npmrc`.
- Removes redundant comments in `fixtures.ts` and `setup.ts`.
- Harmonizes `__TEST_CONTROLS__` types in `playwright-global.d.ts` with `types/global.d.ts`.

Fixes #9190

## Change Type: 🐛 Bug fix (non-breaking change fixing an issue)

## Related Issues

Closes #9190

<details>
<summary>Original PR Body</summary>

Repairs critical issues in PR #9190:
- Wraps `applyFixture` in `try...finally` in `tests/playwright/fixtures.ts` to guarantee teardown.
- Reverts unsafe `registry` configuration in `.npmrc`.
- Removes redundant comments in `fixtures.ts` and `setup.ts`.
- Harmonizes `__TEST_CONTROLS__` types in `playwright-global.d.ts` with `types/global.d.ts`.

---
*PR created automatically by Jules for task [15740630177555111727](https://jules.google.com/task/15740630177555111727) started by @arii*
</details>