### PR TITLE
test(small): Fix VRT mocking: route shadowing and setup simplification

### DIFF
--- a/tests/playwright/lib/mocks.ts
+++ b/tests/playwright/lib/mocks.ts
@@ -241,7 +241,6 @@ export async function mockSpotifySDK(
               this._listeners = {};
             }
             connect() {
-              // Simulate async success
               Promise.resolve().then(() => {
                 if (this._listeners['ready']) {
                   this._listeners['ready'].forEach(cb => cb({ device_id: 'mock-device-id' }));
@@ -276,7 +275,7 @@ export async function mockSpotifySDK(
 
     // Allow the SDK script itself to be handled by the more specific route above
     if (url.includes('sdk.scdn.co/spotify-player.js')) {
-      return route.continue()
+      return route.fallback()
     }
 
     route.fulfill({

--- a/tests/playwright/lib/setup.ts
+++ b/tests/playwright/lib/setup.ts
@@ -147,30 +147,10 @@ export async function navigateAndWait(
 export async function resetServerState(
   request: APIRequestContext
 ): Promise<void> {
-  let lastError: Error | undefined
-  for (let attempt = 1; attempt <= 3; attempt++) {
-    try {
-      const response = await request.post(`${getBaseURL()}/api/debug/reset`, {
-        timeout: 30000,
-      })
-      if (response.ok()) {
-        return
-      }
-      console.warn(
-        `Attempt ${attempt}: Failed to reset server state. Status: ${response.status()}`
-      )
-    } catch (error) {
-      lastError = error as Error
-      console.warn(`Attempt ${attempt}: Error resetting server state:`, error)
-      // Short delay before retry
-      await new Promise((resolve) => setTimeout(resolve, 500))
-    }
-  }
-
-  console.error(
-    'Critical: All attempts to reset server state failed.',
-    lastError
-  )
+  const response = await request.post(`${getBaseURL()}/api/debug/reset`, {
+    timeout: 5000,
+  })
+  expect(response.ok()).toBeTruthy()
 }
 
 /**

--- a/tests/playwright/vrt-hr-components.spec.ts
+++ b/tests/playwright/vrt-hr-components.spec.ts
@@ -171,8 +171,8 @@ test.describe('Visual Regression Tests', () => {
         // Wait for the dashboard to reflect the new BPM value and zone color
         // Increased timeout to 10s to account for WebSocket latency in CI
         const firstHrTile = dashboardPage.getByTestId('hr-tile-card').first()
-        await expect(firstHrTile.getByTestId('bpm-value')).toHaveText(
-          new RegExp(`^${expectedBpm}`),
+        await expect(firstHrTile.getByTestId('bpm-value')).toContainText(
+          String(expectedBpm),
           { timeout: 15000 }
         )
 


### PR DESCRIPTION
## Description

Addressed Principal Engineer Directives to repair PR #9191.
- Fixed route handler shadowing in `mocks.ts` by using `route.fallback()` instead of `route.continue()`.
- Simplified `resetServerState` in `setup.ts` by removing the retry loop and using a single request with a 5000ms timeout.
- Improved assertion robustness in `vrt-hr-components.spec.ts` by using `.toContainText()` instead of fragile RegExp.
- Removed verbose comments as per Anti-AI-Slop directives.

Fixes #9191

## Change Type: 🐛 Bug fix (non-breaking change fixing an issue)

## Testing

Verified changes by running `tests/playwright/vrt-hr-components.spec.ts`.

## Related Issues

Closes #9191

<details>
<summary>Original PR Body</summary>

Addressed Principal Engineer Directives to repair PR #9191.
- Fixed route handler shadowing in `mocks.ts` by using `route.fallback()` instead of `route.continue()`.
- Simplified `resetServerState` in `setup.ts` by removing the retry loop and using a single request with a 5000ms timeout.
- Improved assertion robustness in `vrt-hr-components.spec.ts` by using `.toContainText()` instead of fragile RegExp.
- Removed verbose comments as per Anti-AI-Slop directives.
- Verified changes by running `tests/playwright/vrt-hr-components.spec.ts`.

---
*PR created automatically by Jules for task [12817658912095890852](https://jules.google.com/task/12817658912095890852) started by @arii*
</details>