### PR TITLE
feat(small): Fix build errors by adding missing error classes to lib/errors.ts

### DIFF
--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -7,3 +7,26 @@ export class NoSavedDeviceError extends Error {
     this.name = 'NoSavedDeviceError'
   }
 }
+
+/**
+ * Custom error class for API errors.
+ */
+export class ApiError extends Error {
+  statusCode: number
+
+  constructor(statusCode: number, message: string) {
+    super(message)
+    this.name = 'ApiError'
+    this.statusCode = statusCode
+  }
+}
+
+/**
+ * Error thrown when a service fails to initialize.
+ */
+export class ServiceInitializationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ServiceInitializationError'
+  }
+}


### PR DESCRIPTION
## Description

This PR fixes build errors by adding the missing `ApiError` and `ServiceInitializationError` classes to `lib/errors.ts`. It addresses TypeScript compilation failures caused by these classes being imported but not defined.

Fixes #

## Changes Made

- Added `ApiError` class extending `Error` with a `statusCode` property.
- Added `ServiceInitializationError` class extending `Error`.
These classes were being imported in `lib/middleware/errorHandler.ts` and `services/spotifyPolling.ts` but were not defined, leading to TypeScript compilation errors.

## Testing

- `pnpm run build` passed.
- `pnpm run lint` passed.
- `pnpm run type-check` passed.
- `pnpm run test:unit` passed.

## Change Type: 🐛 Bug fix (non-breaking change fixing an issue)

## Related Issues

Closes #

<details>
<summary>Original PR Body</summary>

This PR addresses build failures caused by missing `ApiError` and `ServiceInitializationError` exports in `lib/errors.ts`.

Changes:
- Added `ApiError` class extending `Error` with a `statusCode` property.
- Added `ServiceInitializationError` class extending `Error`.

These classes were being imported in `lib/middleware/errorHandler.ts` and `services/spotifyPolling.ts` but were not defined, leading to TypeScript compilation errors.

Verification:
- `pnpm run build` passed.
- `pnpm run lint` passed.
- `pnpm run type-check` passed.
- `pnpm run test:unit` passed.

---
*PR created automatically by Jules for task [13165123673362395644](https://jules.google.com/task/13165123673362395644) started by @arii*
</details>