### PR TITLE
feat(medium): Fix review feedback: Restore weak signal watchdog, remove duplicate types, refactor duplicate connection states

### DIFF
--- a/app/client/connect/ConnectView.tsx
+++ b/app/client/connect/ConnectView.tsx
@@ -17,7 +17,7 @@ import UserSettings from './UserSettings'
 import { SignalQualityIndicator } from './SignalQualityIndicator'
 import WorkoutControls from './WorkoutControls'
 import ResetSection from './components/ResetSection'
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
 import logger from '@/utils/logger'
 import { WorkoutStatus } from '../../../types/workout'
 import { UserProfileState, HrZoneData } from '@/types/connect'
@@ -36,6 +36,7 @@ interface ConnectViewProps {
   isResetting: boolean
   isSupported: boolean
   signalPeriodMs: number
+  lastPeriodMs?: number
   currentHR: number
   hrZoneData: HrZoneData
   connectionStatus: string
@@ -62,6 +63,7 @@ export default function ConnectView({
   isResetting,
   isSupported,
   signalPeriodMs,
+  lastPeriodMs,
   currentHR,
   hrZoneData,
   connectionStatus,
@@ -73,6 +75,14 @@ export default function ConnectView({
   onEndWorkout,
 }: ConnectViewProps) {
   const { data } = userProfile
+
+  const isBusy = useMemo(
+    () =>
+      ['Connecting', 'Scanning', 'Checking'].some((status) =>
+        deviceStatus.includes(status)
+      ),
+    [deviceStatus]
+  )
 
   useEffect(() => {
     if (isConnected) {
@@ -186,22 +196,10 @@ export default function ConnectView({
               variant="contained"
               size="large"
               onClick={onConnect}
-              disabled={
-                !data.userName.trim() ||
-                !data.userAge.trim() ||
-                deviceStatus.includes('Connecting') ||
-                deviceStatus.includes('Scanning') ||
-                deviceStatus.includes('Checking')
-              }
-              aria-busy={
-                deviceStatus.includes('Connecting') ||
-                deviceStatus.includes('Scanning') ||
-                deviceStatus.includes('Checking')
-              }
+              disabled={!data.userName.trim() || !data.userAge.trim() || isBusy}
+              aria-busy={isBusy}
             >
-              {deviceStatus.includes('Connecting') ||
-              deviceStatus.includes('Scanning') ||
-              deviceStatus.includes('Checking') ? (
+              {isBusy ? (
                 <Stack direction="row" spacing={1} alignItems="center">
                   <CircularProgress size={20} color="inherit" />
                   <span>
@@ -239,6 +237,7 @@ export default function ConnectView({
                 )}
                 <SignalQualityIndicator
                   periodMs={signalPeriodMs}
+                  lastPeriodMs={lastPeriodMs}
                   isConnected={isConnected}
                 />
               </Box>

--- a/app/client/connect/page.tsx
+++ b/app/client/connect/page.tsx
@@ -15,6 +15,7 @@ import { useConnectUserProfile } from '@/hooks/useConnectUserProfile'
 import throttle from 'lodash.throttle'
 import { HrmInputMessage } from '@/types/websocket'
 import logger from '@/utils/logger'
+import { useAppSnackbar } from '@/hooks/useAppSnackbar'
 
 export default function ConnectPage() {
   const userProfile = useConnectUserProfile()
@@ -106,6 +107,8 @@ export default function ConnectPage() {
     [workoutStatus, setCurrentHR, addHrData]
   )
 
+  const { showWarning } = useAppSnackbar()
+
   const [isResetting, setIsResetting] = useState(false)
 
   const {
@@ -119,6 +122,8 @@ export default function ConnectPage() {
     isDataStale,
     isSupported,
     signalPeriodMs,
+    lastPeriodMs,
+    consecutiveSlowPackets,
     connectionAttempted,
   } = useBluetoothHRM({
     userName,
@@ -199,6 +204,11 @@ export default function ConnectPage() {
     })
   }, [currentHR, caloriesBurned, percentage, heartRateZone, throttledSend])
 
+  useEffect(() => {
+    if (consecutiveSlowPackets === 3)
+      showWarning('HRM Signal Weak: Check device placement')
+  }, [consecutiveSlowPackets, showWarning])
+
   const handleConnect = () => {
     connectAndStream(userName, userAge || 0)
   }
@@ -221,6 +231,7 @@ export default function ConnectPage() {
       isResetting={isResetting}
       isSupported={isSupported}
       signalPeriodMs={signalPeriodMs}
+      lastPeriodMs={lastPeriodMs}
       currentHR={currentHR}
       hrZoneData={{
         percentage,

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -15,12 +15,6 @@ import {
 import { ClientCommandMessage, ServerMessage } from '../types/websocket'
 import { getWebSocketURL } from '../utils/urls'
 
-// Define a type for the test controls to avoid using 'any'
-interface TestControls {
-  dispatch: (message: ServerMessage) => void
-  disconnect: () => void
-  connect: () => void
-}
 import { INITIAL_STATE, WebSocketState, reducer } from './webSocketReducer'
 import { ConnectedHrmData as HrmData } from '../types/websocket'
 
@@ -121,16 +115,11 @@ export const WebSocketProvider = ({
       }
 
       if (isTestEnvironment()) {
-        const testEnvironmentWindow = window as Window & {
-          __TEST_CONTROLS__?: TestControls
-        }
-        testEnvironmentWindow.__TEST_CONTROLS__ = {
-          ...testEnvironmentWindow.__TEST_CONTROLS__,
+        window.__TEST_CONTROLS__ = {
+          ...window.__TEST_CONTROLS__,
           dispatch,
-          disconnect:
-            testEnvironmentWindow.__TEST_CONTROLS__?.disconnect || (() => {}),
-          connect:
-            testEnvironmentWindow.__TEST_CONTROLS__?.connect || (() => {}),
+          disconnect: window.__TEST_CONTROLS__?.disconnect || (() => {}),
+          connect: window.__TEST_CONTROLS__?.connect || (() => {}),
         }
       }
     }
@@ -326,12 +315,9 @@ export const WebSocketProvider = ({
     connect()
 
     if (isTestEnvironment()) {
-      const testControls = (
-        window as Window & { __TEST_CONTROLS__?: TestControls }
-      ).__TEST_CONTROLS__
-      if (testControls) {
-        testControls.disconnect = disconnect
-        testControls.connect = connect
+      if (window.__TEST_CONTROLS__) {
+        window.__TEST_CONTROLS__.disconnect = disconnect
+        window.__TEST_CONTROLS__.connect = connect
       }
     }
 

--- a/hooks/useBluetoothHRM.ts
+++ b/hooks/useBluetoothHRM.ts
@@ -20,6 +20,7 @@ import {
   MISSED_PACKET_THRESHOLD_BUFFER_MS,
   MIN_MISSED_PACKET_THRESHOLD_MS,
   ROLLING_AVG_HISTORY_LENGTH,
+  STABILITY_THRESHOLD_MS,
 } from '@/constants/bluetooth'
 
 const HR_SERVICE_UUID = 'heart_rate'
@@ -47,6 +48,8 @@ const parseHeartRate = (value: DataView): number => {
   const is16Bit = flags & 0x1
   return is16Bit ? value.getUint16(1, true) : value.getUint8(1)
 }
+
+const ERR_NO_SAVED_DEVICE = 'NO_SAVED_DEVICE'
 
 interface UseBluetoothHRMProps {
   dataLivenessTimeoutMs?: number
@@ -79,6 +82,8 @@ const useBluetoothHRM = (props: UseBluetoothHRMProps = {}) => {
   const [isDataStale, setIsDataStale] = useState(false)
   const [signalPeriodMs, setSignalPeriodMs] = useState<number>(0)
   const [connectionAttempted, setConnectionAttempted] = useState(false)
+  const [signalStatus, setSignalStatus] = useState({ last: 0, slow: 0 })
+  const lastWatchdogMark = useRef(0)
   const [isSupported] = useState(
     () => typeof navigator !== 'undefined' && !!navigator.bluetooth
   )
@@ -189,6 +194,25 @@ const useBluetoothHRM = (props: UseBluetoothHRMProps = {}) => {
 
         if (timeSinceLastData > threshold) {
           updateSignalPeriod(timeSinceLastData)
+
+          // Only increment slow count if we've crossed a new stability window
+          // and haven't already marked this window.
+          const currentStabilityWindows = Math.floor(
+            timeSinceLastData / STABILITY_THRESHOLD_MS
+          )
+          const lastMarkedWindows = Math.floor(
+            lastWatchdogMark.current / STABILITY_THRESHOLD_MS
+          )
+
+          if (currentStabilityWindows > lastMarkedWindows) {
+            setSignalStatus((s) => ({
+              last: timeSinceLastData,
+              slow: s.slow + (currentStabilityWindows - lastMarkedWindows),
+            }))
+            lastWatchdogMark.current = timeSinceLastData
+          } else {
+            setSignalStatus((s) => ({ ...s, last: timeSinceLastData }))
+          }
         }
       }
 
@@ -567,6 +591,29 @@ const useBluetoothHRM = (props: UseBluetoothHRMProps = {}) => {
             if (lastDataTime.current > 0) {
               const delta = now - lastDataTime.current
               updateSignalPeriod(delta)
+
+              const isSlow = delta > STABILITY_THRESHOLD_MS
+              const watchdogWindows = Math.floor(
+                lastWatchdogMark.current / STABILITY_THRESHOLD_MS
+              )
+
+              setSignalStatus((s) => {
+                // If the packet arrived and was slow, but the watchdog already counted it,
+                // we don't increment again. If it's fast, we reset the slow counter.
+                let nextSlow = isSlow ? s.slow : 0
+                if (isSlow && watchdogWindows === 0) {
+                  nextSlow = s.slow + 1
+                }
+
+                return {
+                  last: delta,
+                  slow: nextSlow,
+                }
+              })
+
+              // Synchronize watchdog mark with arrival to prevent double-counting
+              // when the watchdog timer next fires.
+              lastWatchdogMark.current = delta
             }
 
             const e = event as Event
@@ -580,6 +627,7 @@ const useBluetoothHRM = (props: UseBluetoothHRMProps = {}) => {
             }
             const heartRate = parseHeartRate(value)
             lastDataTime.current = now // Update timestamp for next delta
+            lastWatchdogMark.current = 0 // Reset watchdog mark for new packet
             logger.debug(
               { heartRate },
               'Heart rate data received from Bluetooth'
@@ -710,7 +758,7 @@ const useBluetoothHRM = (props: UseBluetoothHRMProps = {}) => {
           // Abort silent connection if no device ID is found, to prevent looping.
           if (silent && !savedDeviceId) {
             // Error will be handled in catch block which also resets status for silent connections
-            throw new Error('NO_SAVED_DEVICE')
+            throw new Error(ERR_NO_SAVED_DEVICE)
           }
 
           logger.info(
@@ -775,7 +823,7 @@ const useBluetoothHRM = (props: UseBluetoothHRMProps = {}) => {
           handleConnectionError(error)
         } else {
           const isNoSavedDevice =
-            error instanceof Error && error.message === 'NO_SAVED_DEVICE'
+            error instanceof Error && error.message === ERR_NO_SAVED_DEVICE
 
           if (!isNoSavedDevice) {
             const errorMsg =
@@ -832,7 +880,7 @@ const useBluetoothHRM = (props: UseBluetoothHRMProps = {}) => {
       })
     } catch (error) {
       const isNoSavedDevice =
-        error instanceof Error && error.message === 'NO_SAVED_DEVICE'
+        error instanceof Error && error.message === ERR_NO_SAVED_DEVICE
       if (!isNoSavedDevice) {
         setCustomStatusMessage(BLUETOOTH_MESSAGES.autoConnectFailed)
       }
@@ -851,6 +899,8 @@ const useBluetoothHRM = (props: UseBluetoothHRMProps = {}) => {
     isDataStale,
     isSupported, // Export this flag
     signalPeriodMs,
+    lastPeriodMs: signalStatus.last,
+    consecutiveSlowPackets: signalStatus.slow,
     connectionAttempted,
   }
 }


### PR DESCRIPTION
## Description

This PR addresses the remaining issues outlined by the principal engineer review for PR #9315, specifically correcting:
- **Critical Functional Regression:** Restored the inadvertently removed watchdog timeout mechanism that tracks signal instability (`consecutiveSlowPackets`) to properly trigger the "Weak Signal: Check device placement" warnings.
- **Type Consolidation:** Removed duplicate TypeScript interfaces for `TestControls` in favor of standardizing on the shared global type declaration, cutting down on arbitrary casting logic within context providers.
- **Refactoring & Clean up:** Condensed redundant `deviceStatus` string matching occurrences across multiple props (disabled, aria-busy) into a single, efficient `useMemo` calculation (`isBusy`).
- **Control Flow Robustness:** Swapped literal magic strings determining early connection abortion ('NO_SAVED_DEVICE') with defined constant variables to reduce runtime brittleness and improve maintainability.

Fixes #9315

## Change Type: 🐛 Bug fix (non-breaking change fixing an issue)

## Related Issues

Closes #9315

<details>
<summary>Original PR Body</summary>

This PR addresses the remaining issues outlined by the principal engineer review for PR #9315, specifically correcting:
- **Critical Functional Regression:** Restored the inadvertently removed watchdog timeout mechanism that tracks signal instability (`consecutiveSlowPackets`) to properly trigger the "Weak Signal: Check device placement" warnings.
- **Type Consolidation:** Removed duplicate TypeScript interfaces for `TestControls` in favor of standardizing on the shared global type declaration, cutting down on arbitrary casting logic within context providers.
- **Refactoring & Clean up:** Condensed redundant `deviceStatus` string matching occurrences across multiple props (disabled, aria-busy) into a single, efficient `useMemo` calculation (`isBusy`).
- **Control Flow Robustness:** Swapped literal magic strings determining early connection abortion ('NO_SAVED_DEVICE') with defined constant variables to reduce runtime brittleness and improve maintainability.

---
*PR created automatically by Jules for task [11529019384819981320](https://jules.google.com/task/11529019384819981320) started by @arii*
</details>