### PR TITLE
ci(medium): fix: manual bot trigger review strategy refactor and scope creep cleanup

### DIFF
--- a/.github/workflows/reusable-gemini-review.yml
+++ b/.github/workflows/reusable-gemini-review.yml
@@ -130,7 +130,7 @@ jobs:
           COMMENT_BODY: ${{ inputs.comment_body }}
           PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number || github.event.issue.number }}
           BASE_SHA: ${{ inputs.base_sha }}
-          HEAD_SHA: ${{ inputs.head_sha }}
+          HEAD_SHA: ${{ inputs.head_sha || steps.resolve_ref.outputs.ref }}
           GH_TOKEN: ${{ secrets.ARI_PAT }}
           PR_QUALITY_RESULT: ${{ inputs.pr_quality_result }}
           MAX_COMMENTS: 60

--- a/scripts/decide-review-strategy.sh
+++ b/scripts/decide-review-strategy.sh
@@ -60,6 +60,16 @@ rm -f "$PR_DATA_FILE" gh_error.log
 if [ -z "$BASE_SHA" ] || [ "$BASE_SHA" == "null" ]; then BASE_SHA=$(echo "$PR_DATA" | jq -r '.baseRefOid // ""'); fi
 if [ -z "$HEAD_SHA" ] || [ "$HEAD_SHA" == "null" ]; then HEAD_SHA=$(echo "$PR_DATA" | jq -r '.headRefOid // ""'); fi
 
+# Address edge case: If API failed and inputs were empty, ensure SHAs are not empty
+if [ -z "$BASE_SHA" ]; then
+  echo "::warning::BASE_SHA is empty, falling back to HEAD^"
+  BASE_SHA="HEAD^"
+fi
+if [ -z "$HEAD_SHA" ]; then
+  echo "::warning::HEAD_SHA is empty, falling back to HEAD"
+  HEAD_SHA="HEAD"
+fi
+
 # Check 1: Manual Override (PRIORITIZED)
 # Bypasses all other checks including global enablement.
 # Matches @bot-handle at start of string or after space, case-insensitively.

--- a/tests/playwright/lib/visual.ts
+++ b/tests/playwright/lib/visual.ts
@@ -26,7 +26,7 @@ import { getHrMasks, getTimerMasks, waitForFontsLoaded } from '.'
  * @property {number} maxDiffPixelRatio - Allowed ratio of differing pixels.
  */
 export const SCREENSHOT_OPTIONS = {
-  fullPage: false,
+  fullPage: true,
   animations: 'disabled' as const,
   caret: 'hide' as const,
   threshold: 0.2,

--- a/tests/playwright/vrt-components.spec.ts
+++ b/tests/playwright/vrt-components.spec.ts
@@ -41,12 +41,7 @@ test.describe('Component-Specific VRT', () => {
     })
     const loadingIndicator = dashboardPage.getByTestId('loading-indicator')
     await expect(loadingIndicator).toBeVisible()
-
-    // Mask the circular progress to avoid flakes from small animation differences
-    // or rendering variations of the spinner itself.
-    await takeScreenshot(loadingIndicator, 'loading-indicator.png', {
-      mask: [loadingIndicator.locator('.MuiCircularProgress-root')],
-    })
+    await takeScreenshot(loadingIndicator, 'loading-indicator.png')
   })
 
   test('GoogleDocViewer shrunk state', async ({ dashboardPage }) => {
@@ -59,9 +54,7 @@ test.describe('Component-Specific VRT', () => {
     const viewer = dashboardPage
       .getByTestId('google-doc-viewer-iframe')
       .locator('..')
-    await takeScreenshot(viewer, 'google-doc-viewer-shrunk.png', {
-      fullPage: false,
-    })
+    await takeScreenshot(viewer, 'google-doc-viewer-shrunk.png')
   })
 
   test('WorkoutTableHeader rendering', async ({ dashboardPage }) => {

--- a/tests/playwright/vrt-connect-page.spec.ts
+++ b/tests/playwright/vrt-connect-page.spec.ts
@@ -28,9 +28,6 @@ test.describe('Visual Regression Tests for /client/connect Page', () => {
   })
 
   test('scanning state', async ({ connectPage }) => {
-    // Capture the layout container instead of the whole page to ensure stable dimensions
-    const layoutContainer = connectPage.getByTestId('main-content-layout')
-
     await connectPage.evaluate((status) => {
       window.__TEST_CONTROLS__!.setHrmStatus!(status)
       window.__TEST_CONTROLS__!.setCustomHrmStatusMessage!(
@@ -42,15 +39,12 @@ test.describe('Visual Regression Tests for /client/connect Page', () => {
     await expect(
       connectPage.getByTestId('connection-status-alert')
     ).toContainText('Checking saved devices...')
-    await takeScreenshot(layoutContainer, 'connect-page-scanning.png', {
+    await takeScreenshot(connectPage, 'connect-page-scanning.png', {
       mask: [connectPage.getByTestId('user-settings-form')],
     })
   })
 
   test('connected state', async ({ connectPage }) => {
-    // Capture the layout container instead of the whole page to ensure stable dimensions
-    const layoutContainer = connectPage.getByTestId('main-content-layout')
-
     await connectPage
       .getByRole('button', { name: 'Connect Bluetooth HRM' })
       .click()
@@ -61,17 +55,13 @@ test.describe('Visual Regression Tests for /client/connect Page', () => {
     await expect(
       connectPage.getByText('Connected! Heart rate data is being streamed')
     ).toBeVisible()
-
-    await takeScreenshot(layoutContainer, 'connect-page-connected.png', {
+    await takeScreenshot(connectPage, 'connect-page-connected.png', {
       mask: [connectPage.getByTestId('hr-tile')],
       maxDiffPixelRatio: 0.1,
     })
   })
 
   test('connection error state', async ({ connectPage }) => {
-    // Capture the layout container instead of the whole page to ensure stable dimensions
-    const layoutContainer = connectPage.getByTestId('main-content-layout')
-
     await connectPage.evaluate((status) => {
       window.__TEST_CONTROLS__!.setHrmStatus!(status)
       window.__TEST_CONTROLS__!.setCustomHrmStatusMessage!(
@@ -81,8 +71,9 @@ test.describe('Visual Regression Tests for /client/connect Page', () => {
     await expect(
       connectPage.getByText(/Connection Failed: GATT server not found/)
     ).toBeVisible()
-    await takeScreenshot(layoutContainer, 'connect-page-connection-error.png', {
+    await takeScreenshot(connectPage, 'connect-page-connection-error.png', {
       mask: [connectPage.getByTestId('user-settings-form')],
+      fullPage: false,
       maxDiffPixelRatio: 0.05,
       // Performance: Skip repeated a11y checks for error states as the core UI is already validated
       skipA11y: true,
@@ -90,9 +81,6 @@ test.describe('Visual Regression Tests for /client/connect Page', () => {
   })
 
   test('no devices found state', async ({ connectPage }) => {
-    // Capture the layout container instead of the whole page to ensure stable dimensions
-    const layoutContainer = connectPage.getByTestId('main-content-layout')
-
     await connectPage.evaluate(
       (status) => window.__TEST_CONTROLS__!.setHrmStatus!(status),
       BluetoothConnectionStatus.DISCONNECTED
@@ -101,7 +89,7 @@ test.describe('Visual Regression Tests for /client/connect Page', () => {
     await expect(
       connectPage.getByRole('button', { name: 'Connect Bluetooth HRM' })
     ).toBeVisible()
-    await takeScreenshot(layoutContainer, 'connect-page-no-devices-found.png', {
+    await takeScreenshot(connectPage, 'connect-page-no-devices-found.png', {
       mask: [connectPage.getByTestId('user-settings-form')],
       // Performance: Skip redundant a11y checks for similar disconnected states
       skipA11y: true,
@@ -109,9 +97,6 @@ test.describe('Visual Regression Tests for /client/connect Page', () => {
   })
 
   test('auto-connect failed state', async ({ connectPage }) => {
-    // Capture the layout container instead of the whole page to ensure stable dimensions
-    const layoutContainer = connectPage.getByTestId('main-content-layout')
-
     await connectPage.evaluate((status) => {
       window.__TEST_CONTROLS__!.setHrmStatus!(status)
       window.__TEST_CONTROLS__!.setCustomHrmStatusMessage!(
@@ -119,23 +104,18 @@ test.describe('Visual Regression Tests for /client/connect Page', () => {
       )
     }, BluetoothConnectionStatus.DISCONNECTED)
     await expect(connectPage.getByText(/Auto-connect failed/)).toBeVisible()
-    await takeScreenshot(
-      layoutContainer,
-      'connect-page-auto-connect-failed.png',
-      {
-        mask: [connectPage.getByTestId('user-settings-form')],
-        maxDiffPixelRatio: 0.05,
-        // Performance: Skip a11y check for this specific error variant; primary state is covered
-        skipA11y: true,
-      }
-    )
+    await takeScreenshot(connectPage, 'connect-page-auto-connect-failed.png', {
+      mask: [connectPage.getByTestId('user-settings-form')],
+      fullPage: false,
+      maxDiffPixelRatio: 0.05,
+      // Performance: Skip a11y check for this specific error variant; primary state is covered
+      skipA11y: true,
+    })
   })
 
   test('mobile viewport', async ({ connectPage }) => {
     await connectPage.setViewportSize(MOBILE_VIEWPORT)
-    // Capture the layout container instead of the whole page to ensure stable dimensions
-    const layoutContainer = connectPage.getByTestId('main-content-layout')
-    await takeScreenshot(layoutContainer, 'connect-page-mobile.png', {
+    await takeScreenshot(connectPage, 'connect-page-mobile.png', {
       mask: [connectPage.getByTestId('hr-tile')],
     })
   })

--- a/tests/playwright/vrt-hr-components.spec.ts
+++ b/tests/playwright/vrt-hr-components.spec.ts
@@ -93,7 +93,6 @@ test.describe('Visual Regression Tests', () => {
           ...getDynamicContentMasks(dashboardPage),
           ...getHrMasks(dashboardPage),
         ],
-        fullPage: false,
       })
     })
 
@@ -139,7 +138,6 @@ test.describe('Visual Regression Tests', () => {
           ...getDynamicContentMasks(dashboardPage),
           ...getHrMasks(dashboardPage),
         ],
-        fullPage: false,
       })
     })
 
@@ -162,9 +160,6 @@ test.describe('Visual Regression Tests', () => {
             ...getDynamicContentMasks(dashboardPage),
             ...getHrMasks(dashboardPage),
           ],
-          // Ensure we don't capture full page if the content exceeds viewport,
-          // which can cause dimension mismatches in CI.
-          fullPage: false,
         })
       })
     }
@@ -179,7 +174,6 @@ test.describe('Visual Regression Tests', () => {
           ...getDynamicContentMasks(dashboardPage),
           ...getHrMasks(dashboardPage),
         ],
-        fullPage: false,
       })
     })
   })

--- a/tests/unit/decide-review-strategy.bats
+++ b/tests/unit/decide-review-strategy.bats
@@ -52,12 +52,16 @@ setup() {
   export COMMENT_BODY="@gemini-bot"
   export BASE_SHA=""
   export HEAD_SHA=""
+  export MOCK_GH_BASE_REF=""
+  export MOCK_GH_HEAD_REF=""
 
   run_script
 
   [ "$status" -eq 0 ]
   assert_output "needs-review" "true"
   assert_output "skip-reason" ""
+  assert_output "base-sha" "HEAD^"
+  assert_output "head-sha" "HEAD"
 }
 
 @test "should trigger review on manual override (workflow_dispatch)" {

--- a/tests/unit/test_helper.bash
+++ b/tests/unit/test_helper.bash
@@ -7,7 +7,7 @@ gh() {
         return 1
     fi
     # For the refactored script, we primarily handle: gh pr view ... --json comments
-    echo "{\"comments\": ${MOCK_GH_COMMENTS_JSON:-[]}}"
+    echo "{\"comments\": ${MOCK_GH_COMMENTS_JSON:-[]}, \"baseRefOid\": \"${MOCK_GH_BASE_REF:-}\", \"headRefOid\": \"${MOCK_GH_HEAD_REF:-}\"}"
 }
 export -f gh
 
@@ -19,14 +19,27 @@ run_script() {
     export ACTION_TYPE="${ACTION_TYPE:-synchronize}"
     export COMMENT_BODY="${COMMENT_BODY:-}"
     export PR_NUMBER="${PR_NUMBER:-123}"
-    export BASE_SHA="${BASE_SHA:-base}"
-    export HEAD_SHA="${HEAD_SHA:-head}"
+
+    if [ -z "${BASE_SHA+x}" ]; then
+        export BASE_SHA="base"
+    fi
+    if [ -z "${HEAD_SHA+x}" ]; then
+        export HEAD_SHA="head"
+    fi
     export PR_QUALITY_RESULT="${PR_QUALITY_RESULT:-success}"
     export MAX_COMMENTS="${MAX_COMMENTS:-60}"
     export REVIEW_THROTTLE_MINUTES="${REVIEW_THROTTLE_MINUTES:-30}"
     export BOT_USERNAME="${BOT_USERNAME:-test-bot}"
     export QUALITY_GATE_BOT_USERNAMES="${QUALITY_GATE_BOT_USERNAMES:-github-actions[bot]}"
     export MOCK_GH_COMMENTS_JSON="${MOCK_GH_COMMENTS_JSON:-[]}"
+
+    # Only set defaults if they aren't explicitly exported, allowing empty strings via explicit unset or empty export
+    if [ -z "${MOCK_GH_BASE_REF+x}" ]; then
+        export MOCK_GH_BASE_REF="mock-base-sha"
+    fi
+    if [ -z "${MOCK_GH_HEAD_REF+x}" ]; then
+        export MOCK_GH_HEAD_REF="mock-head-sha"
+    fi
 
     # Get the directory of the test helper script itself
     local helper_dir

--- a/utils/socketManager.ts
+++ b/utils/socketManager.ts
@@ -238,22 +238,9 @@ export const resetSocketManager = () => {
 
   // Disconnect all clients to force them to re-register and re-initialize their sessions
   if (wsServerInstance) {
-    logger.info(
-      { clientCount: wsServerInstance.clients.size },
-      'Resetting socket manager: Disconnecting all clients.'
-    )
     wsServerInstance.clients.forEach((client) => {
-      // Use terminate() for a more forceful disconnection during reset to ensure
-      // resources are freed immediately and we don't hang on closure handshakes.
-      try {
-        if (
-          client.readyState === WebSocket.OPEN ||
-          client.readyState === WebSocket.CONNECTING
-        ) {
-          client.terminate()
-        }
-      } catch (err) {
-        logger.error({ err }, 'Error terminating client during reset')
+      if (client.readyState === WebSocket.OPEN) {
+        client.close(1001, 'Server Reset')
       }
     })
   }


### PR DESCRIPTION
## Description

This PR addresses several fixes and improvements related to the manual bot trigger review strategy, including refactoring and cleaning up scope creep. It specifically implements directives from the Principal Engineer:

1.  **Scope Creep Reverted**: Unrelated changes to Visual Regression Test masking/snapshots (`tests/playwright/*`) and WebSocket management (`utils/socketManager.ts`) were reverted back to their state on `leader`.
2.  **Incomplete Test Mocks Fixed**: The `gh` CLI mock in `test_helper.bash` now returns `baseRefOid` and `headRefOid` keys alongside the comments array. This allowed testing the empty SHA scenarios reliably.
3.  **Missing SHA Edge Case Addressed**: `scripts/decide-review-strategy.sh` now sets `BASE_SHA` to `HEAD^` and `HEAD_SHA` to `HEAD` if the API fails and the context environment variables are empty. This prevents git commands from crashing downstream during manual overrides.
4.  **Workflow Optimized**: `.github/workflows/reusable-gemini-review.yml` now passes the resolved GitHub ref from the checkout step directly to `scripts/decide-review-strategy.sh` via the `HEAD_SHA` input, skipping redundant `gh` API calls.

Fixes #9109068996673116621

## Change Type: 🐛 Bug fix (non-breaking change fixing an issue)

## Related Issues

Closes #9109068996673116621

<details>
<summary>Original PR Body</summary>

This PR applies fixes and improvements requested in the Principal Engineer Directives:

1.  **Scope Creep Reverted**: Unrelated changes to Visual Regression Test masking/snapshots (`tests/playwright/*`) and WebSocket management (`utils/socketManager.ts`) were reverted back to their state on `leader`.
2.  **Incomplete Test Mocks Fixed**: The `gh` CLI mock in `test_helper.bash` now returns `baseRefOid` and `headRefOid` keys alongside the comments array. This allowed testing the empty SHA scenarios reliably.
3.  **Missing SHA Edge Case Addressed**: `scripts/decide-review-strategy.sh` now sets `BASE_SHA` to `HEAD^` and `HEAD_SHA` to `HEAD` if the API fails and the context environment variables are empty. This prevents git commands from crashing downstream during manual overrides.
4.  **Workflow Optimized**: `.github/workflows/reusable-gemini-review.yml` now passes the resolved GitHub ref from the checkout step directly to `scripts/decide-review-strategy.sh` via the `HEAD_SHA` input, skipping redundant `gh` API calls.

---
*PR created automatically by Jules for task [9109068996673116621](https://jules.google.com/task/9109068996673116621) started by @arii*
</details>