### PR TITLE
ci(medium): fix: implement architectural improvements from PR #9422 audit

### DIFF
--- a/.github/workflows/comment-ops.yml
+++ b/.github/workflows/comment-ops.yml
@@ -90,7 +90,7 @@ jobs:
             exit 1
           fi
 
-          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          EOF="EOF-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           echo "task<<$EOF" >> $GITHUB_OUTPUT
           echo "$TASK" >> $GITHUB_OUTPUT
           echo "$EOF" >> $GITHUB_OUTPUT
@@ -144,7 +144,6 @@ jobs:
     if: github.event.issue.pull_request && needs.router.outputs.is_review_issues == 'true'
     uses: ./.github/workflows/reusable-create-review-issues.yml
     with:
-      trigger_event: 'comment'
       pr_number: ${{ format('{0}', github.event.issue.number) }}
       run_id: ${{ needs.prepare-review-issues-manual.outputs.run_id }}
     secrets:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,7 +95,7 @@ jobs:
           GOOGLE_DOC_WORKOUT_URL="${{ secrets.GOOGLE_DOC_WORKOUT_URL }}"
           SPOTIFY_DEBUG=false
           CI=false
-          NEXT_PUBLIC_USE_NATIVE_TABLE="${{ env.NEXT_PUBLIC_USE_NATIVE_TABLE }}"
+          NEXT_PUBLIC_USE_NATIVE_TABLE="${{ vars.NEXT_PUBLIC_USE_NATIVE_TABLE }}"
           NEXT_PUBLIC_API_URL=
           NEXT_PUBLIC_WS_URL=
           RATE_LIMIT_WINDOW_MS=60000

--- a/.github/workflows/gemini-triage.yml
+++ b/.github/workflows/gemini-triage.yml
@@ -63,7 +63,7 @@ jobs:
           echo "title=$(echo "$JSON" | jq -r .title)" >> $GITHUB_OUTPUT
 
           # Use a multi-line output for the body
-          EOF_MARKER=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          EOF_MARKER="EOF-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           echo "body<<$EOF_MARKER" >> $GITHUB_OUTPUT
           echo "$JSON" | jq -r .body >> $GITHUB_OUTPUT
           echo "$EOF_MARKER" >> $GITHUB_OUTPUT

--- a/.github/workflows/reusable-gemini-review.yml
+++ b/.github/workflows/reusable-gemini-review.yml
@@ -28,15 +28,15 @@ on:
         required: false
         type: string
       pr_number:
-        description: 'PR Number (override for workflow_dispatch)'
+        description: 'PR Number'
         required: false
         type: string
       base_sha:
-        description: 'Base SHA (override for workflow_dispatch)'
+        description: 'Base SHA'
         required: false
         type: string
       head_sha:
-        description: 'Head SHA (override for workflow_dispatch)'
+        description: 'Head SHA'
         required: false
         type: string
     secrets:


### PR DESCRIPTION
## Description

Implemented all architectural improvements and fixes identified in the PR #9422 audit directives:
- Simplified the EOF marker generation logic in `comment-ops.yml` and `gemini-triage.yml` to adhere to Anti-AI-Slop directives, replacing `/dev/urandom` with a simpler string based on `GITHUB_RUN_ID` and `GITHUB_RUN_ATTEMPT`.
- Fixed the `vars.NEXT_PUBLIC_USE_NATIVE_TABLE` environment mapping in `deploy.yml` which was erroneously switched to `env.`.
- Cleaned up the `workflow_dispatch` references in the descriptions of inputs within `reusable-gemini-review.yml` since `workflow_dispatch` was removed.
- Validated the GitHub Actions workflows with `actionlint` and corrected a syntax error where `trigger_event` was passed to a reusable workflow that did not expect it.

Fixes #9422

## Change Type: 🐛 Bug fix (non-breaking change fixing an issue)

## Related Issues

Closes #9422

<details>
<summary>Original PR Body</summary>

Implemented all architectural improvements and fixes identified in the PR #9422 audit directives:
- Simplified the EOF marker generation logic in `comment-ops.yml` and `gemini-triage.yml` to adhere to Anti-AI-Slop directives, replacing `/dev/urandom` with a simpler string based on `GITHUB_RUN_ID` and `GITHUB_RUN_ATTEMPT`.
- Fixed the `vars.NEXT_PUBLIC_USE_NATIVE_TABLE` environment mapping in `deploy.yml` which was erroneously switched to `env.`.
- Cleaned up the `workflow_dispatch` references in the descriptions of inputs within `reusable-gemini-review.yml` since `workflow_dispatch` was removed.
- Validated the GitHub Actions workflows with `actionlint` and corrected a syntax error where `trigger_event` was passed to a reusable workflow that did not expect it.

---
*PR created automatically by Jules for task [4414926990580621421](https://jules.google.com/task/4414926990580621421) started by @arii*
</details>