### PR TITLE
ci(small): ci: refactor gemini review strategy and enforce kill-switch

### DIFF
--- a/.github/workflows/reusable-gemini-review.yml
+++ b/.github/workflows/reusable-gemini-review.yml
@@ -103,24 +103,12 @@ jobs:
       - name: Resolve Checkout Ref
         id: resolve_ref
         env:
-          GH_TOKEN: ${{ secrets.ARI_PAT }}
-          PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number || github.event.issue.number }}
           HEAD_SHA_INPUT: ${{ inputs.head_sha }}
         run: |
           if [ -n "$HEAD_SHA_INPUT" ]; then
             echo "ref=$HEAD_SHA_INPUT" >> $GITHUB_OUTPUT
-          elif [ -n "$PR_NUMBER" ] && [ "$PR_NUMBER" != "null" ]; then
-            PR_JSON=$(gh pr view "$PR_NUMBER" --json headRefOid,baseRefOid 2>/dev/null || echo "{}")
-            REF=$(echo "$PR_JSON" | jq -r '.headRefOid // ""')
-            BASE_REF=$(echo "$PR_JSON" | jq -r '.baseRefOid // ""')
-            if [ -n "$REF" ]; then
-              echo "ref=$REF" >> $GITHUB_OUTPUT
-            else
-              echo "ref=${{ github.ref }}" >> $GITHUB_OUTPUT
-            fi
-            if [ -n "$BASE_REF" ]; then
-              echo "base_ref=$BASE_REF" >> $GITHUB_OUTPUT
-            fi
+          elif [ -n "${{ github.event.pull_request.head.sha }}" ]; then
+            echo "ref=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
           else
             echo "ref=${{ github.ref }}" >> $GITHUB_OUTPUT
           fi
@@ -137,8 +125,8 @@ jobs:
           ACTION_TYPE: ${{ github.event.action }}
           COMMENT_BODY: ${{ inputs.comment_body }}
           PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number || github.event.issue.number }}
-          BASE_SHA: ${{ inputs.base_sha || github.event.pull_request.base.sha || steps.resolve_ref.outputs.base_ref || 'HEAD^' }}
-          HEAD_SHA: ${{ inputs.head_sha || steps.resolve_ref.outputs.ref || 'HEAD' }}
+          BASE_SHA: ${{ inputs.base_sha || github.event.pull_request.base.sha || 'HEAD^' }}
+          HEAD_SHA: ${{ inputs.head_sha || github.event.pull_request.head.sha || 'HEAD' }}
           GH_TOKEN: ${{ secrets.ARI_PAT }}
           PR_QUALITY_RESULT: ${{ inputs.pr_quality_result }}
           MAX_COMMENTS: 60

--- a/scripts/decide-review-strategy.sh
+++ b/scripts/decide-review-strategy.sh
@@ -13,7 +13,6 @@ set -e
 : "${PR_NUMBER:?}"
 : "${PR_QUALITY_RESULT:?}"
 
-# Optional variables (may be missing in some trigger contexts)
 BASE_SHA="${BASE_SHA:-}"
 HEAD_SHA="${HEAD_SHA:-}"
 COMMENT_BODY="${COMMENT_BODY:-}"
@@ -67,30 +66,24 @@ if [ -z "$HEAD_SHA" ]; then
   HEAD_SHA="HEAD"
 fi
 
-# Check 1: Manual Override (PRIORITIZED)
-# Bypasses all other checks including global enablement.
-# Matches @bot-handle at start of string or after space, case-insensitively.
-if [[ "$TRIGGER_EVENT" == "comment" ]] && echo "$COMMENT_BODY" | grep -qiE "(^|[[:space:]])(@gemini-bot|@jules)"; then
-  echo "::info::Manual review triggered via comment. Bypassing all checks."
-  echo "needs-review=true" >> "$GITHUB_OUTPUT"
-  echo "skip-reason=" >> "$GITHUB_OUTPUT"
-  echo "base-sha=$BASE_SHA" >> "$GITHUB_OUTPUT"
-  echo "head-sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
-  exit 0
-elif [[ "$TRIGGER_EVENT" == "workflow_dispatch" ]] || [[ "$FORCE_REVIEW" == "true" ]]; then
-  echo "::info::Manual review triggered via UI/force. Bypassing all checks."
-  echo "needs-review=true" >> "$GITHUB_OUTPUT"
-  echo "skip-reason=" >> "$GITHUB_OUTPUT"
-  echo "base-sha=$BASE_SHA" >> "$GITHUB_OUTPUT"
-  echo "head-sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
-  exit 0
-fi
-
 # Check 0: Gemini Review Enablement
 if [[ "${GEMINI_ENABLE_PR_REVIEW:-true}" == "false" ]]; then
   echo "::info::Gemini review is disabled via GEMINI_ENABLE_PR_REVIEW."
   echo "needs-review=false" >> "$GITHUB_OUTPUT"
   echo "skip-reason=Gemini review is disabled" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+# Check 1: Manual Override
+# Bypasses all other checks except global enablement.
+# Matches @bot-handle at start of string or after space, case-insensitively.
+if { [[ "$TRIGGER_EVENT" == "comment" ]] && echo "$COMMENT_BODY" | grep -qiE "(^|[[:space:]])(@gemini-bot|@jules)"; } || \
+   [[ "$TRIGGER_EVENT" == "workflow_dispatch" ]] || [[ "$FORCE_REVIEW" == "true" ]]; then
+  echo "::info::Manual review triggered. Bypassing all checks."
+  echo "needs-review=true" >> "$GITHUB_OUTPUT"
+  echo "skip-reason=" >> "$GITHUB_OUTPUT"
+  echo "base-sha=$BASE_SHA" >> "$GITHUB_OUTPUT"
+  echo "head-sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
   exit 0
 fi
 
@@ -142,7 +135,6 @@ if [[ "$PR_QUALITY_RESULT" != "success" ]]; then
       SKIP_REASON="static analysis failures only (knip/lint/build)"
     fi
   fi
-# Check 5: New Pull Request
 elif [[ "$TRIGGER_EVENT" == "pull_request" && "$ACTION_TYPE" == "opened" ]]; then
   NEEDS_REVIEW="true"
   SKIP_REASON=""

--- a/tests/unit/decide-review-strategy.bats
+++ b/tests/unit/decide-review-strategy.bats
@@ -86,7 +86,7 @@ setup() {
   assert_output "skip-reason" ""
 }
 
-@test "should bypass GEMINI_ENABLE_PR_REVIEW on manual override" {
+@test "should not bypass GEMINI_ENABLE_PR_REVIEW on manual override" {
   export TRIGGER_EVENT="comment"
   export COMMENT_BODY="@gemini-bot"
   export GEMINI_ENABLE_PR_REVIEW="false"
@@ -94,8 +94,8 @@ setup() {
   run_script
 
   [ "$status" -eq 0 ]
-  assert_output "needs-review" "true"
-  assert_output "skip-reason" ""
+  assert_output "needs-review" "false"
+  assert_output "skip-reason" "Gemini review is disabled"
 }
 
 @test "should skip review when comment limit is exceeded" {


### PR DESCRIPTION
## Description

This PR implements architectural improvements and resolves anti-AI-slop directives based on the principal engineer's audit of the Gemini review strategy bot. It refactors the Gemini review strategy and enforces the kill-switch, addressing security/cost risks and reducing over-engineering.

## Change Type: 🐛 Bug fix (non-breaking change fixing an issue)

## Changes Made

*   **Security/Cost Risk Fix:** The script now strictly enforces the global `GEMINI_ENABLE_PR_REVIEW` kill-switch. Manual triggers (`@gemini-bot`) can no longer bypass this setting, preventing unauthorized usage during budget limits or API downtime.
*   **Over-Engineering Fix:** Eliminated a duplicate network call (`gh pr view`) in the `Resolve Checkout Ref` step of `reusable-gemini-review.yml`. Ref resolution now elegantly utilizes the standard GitHub event payload context, falling back to safe defaults (`HEAD^` / `HEAD`) to preserve downstream visual/integration test stability during `issue_comment` events.
*   **DRY Enforcement:** Consolidated redundant manual override `if` blocks in `decide-review-strategy.sh` to remove duplicated script logic.
*   **Slop Reduction:** Deleted overly verbose inline comments explaining the obvious "how" rather than the "why".

## Testing

All unit, integration, and visual tests have been executed and passed successfully. Bats unit tests have been updated to assert the kill-switch enforcement behavior.

<details>
<summary>Original PR Body</summary>

This PR implements architectural improvements and resolves anti-AI-slop directives based on the principal engineer's audit of the Gemini review strategy bot.

Key Changes:
1. **Security/Cost Risk Fix:** The script now strictly enforces the global `GEMINI_ENABLE_PR_REVIEW` kill-switch. Manual triggers (`@gemini-bot`) can no longer bypass this setting, preventing unauthorized usage during budget limits or API downtime. Bats unit tests have been updated to assert this behavior.
2. **Over-Engineering Fix:** Eliminated a duplicate network call (`gh pr view`) in the `Resolve Checkout Ref` step of `reusable-gemini-review.yml`. Ref resolution now elegantly utilizes the standard GitHub event payload context, falling back to safe defaults (`HEAD^` / `HEAD`) to preserve downstream visual/integration test stability during `issue_comment` events.
3. **DRY Enforcement:** Consolidated redundant manual override `if` blocks in `decide-review-strategy.sh` to remove duplicated script logic.
4. **Slop Reduction:** Deleted overly verbose inline comments explaining the obvious "how" rather than the "why".

All unit, integration, and visual tests have been executed and passed successfully.

---
*PR created automatically by Jules for task [17507060206453548852](https://jules.google.com/task/17507060206453548852) started by @arii*
</details>