### PR TITLE
fix(spotify): extract useSyncLock hook and fix throttle anti-pattern

### DIFF
--- a/app/client/control/components/SpotifyControls.tsx
+++ b/app/client/control/components/SpotifyControls.tsx
@@ -11,7 +11,14 @@ import MenuItem from '@mui/material/MenuItem'
 import Select from '@mui/material/Select'
 import Typography from '@mui/material/Typography'
 import { useRouter } from 'next/navigation'
-import { useCallback, useEffect, useLayoutEffect, useRef, useState, useMemo } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  useMemo,
+} from 'react'
 import useVolumePreference, { clampVolume } from '@/hooks/useVolumePreference'
 import { useAppSnackbar } from '@/hooks/useAppSnackbar'
 import { useWebSocket } from '@/context/WebSocketContext'

--- a/app/client/control/components/SpotifyControls.tsx
+++ b/app/client/control/components/SpotifyControls.tsx
@@ -11,7 +11,7 @@ import MenuItem from '@mui/material/MenuItem'
 import Select from '@mui/material/Select'
 import Typography from '@mui/material/Typography'
 import { useRouter } from 'next/navigation'
-import { useCallback, useEffect, useRef, useState, useMemo } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, useMemo } from 'react'
 import useVolumePreference, { clampVolume } from '@/hooks/useVolumePreference'
 import { useAppSnackbar } from '@/hooks/useAppSnackbar'
 import { useWebSocket } from '@/context/WebSocketContext'
@@ -202,7 +202,7 @@ const SpotifyControls = () => {
   )
 
   const sendCommandRef = useRef(sendVolumeCommand)
-  useEffect(() => {
+  useLayoutEffect(() => {
     sendCommandRef.current = sendVolumeCommand
   }, [sendVolumeCommand])
 

--- a/app/client/control/components/SpotifyControls.tsx
+++ b/app/client/control/components/SpotifyControls.tsx
@@ -11,14 +11,7 @@ import MenuItem from '@mui/material/MenuItem'
 import Select from '@mui/material/Select'
 import Typography from '@mui/material/Typography'
 import { useRouter } from 'next/navigation'
-import {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-  useMemo,
-} from 'react'
+import { useCallback, useEffect, useRef, useState, useMemo } from 'react'
 import useVolumePreference, { clampVolume } from '@/hooks/useVolumePreference'
 import { useAppSnackbar } from '@/hooks/useAppSnackbar'
 import { useWebSocket } from '@/context/WebSocketContext'
@@ -28,8 +21,8 @@ import { HRM_WEB_PLAYER_NAME, SYNC_LOCK_DURATION } from '@/constants/spotify'
 import PlaybackControls from '@/components/shared/PlaybackControls'
 import SpotifySearchInput from '@/components/SpotifySearchInput'
 import VolumeSlider from '@/components/shared/VolumeSlider'
-import throttle from 'lodash.throttle'
 import { useSyncLock } from '@/hooks/useSyncLock'
+import { useThrottledCallback } from '@/hooks/useThrottledCallback'
 
 const VOLUME_SLIDER_SX = { mt: 3, mb: 1 }
 
@@ -208,21 +201,10 @@ const SpotifyControls = () => {
     [connectionStatus, resolveTargetDeviceId, executeSpotify]
   )
 
-  const sendCommandRef = useRef(sendVolumeCommand)
-  useLayoutEffect(() => {
-    sendCommandRef.current = sendVolumeCommand
-  }, [sendVolumeCommand])
-
-  const throttledSendVolumeCommand = useMemo(
-    () => throttle((val: number) => sendCommandRef.current(val), 200),
-    []
+  const throttledSendVolumeCommand = useThrottledCallback(
+    sendVolumeCommand,
+    200
   )
-
-  useEffect(() => {
-    return () => {
-      throttledSendVolumeCommand.cancel()
-    }
-  }, [throttledSendVolumeCommand])
 
   const handleVolumeChange = useCallback(
     (val: number) => {

--- a/app/client/control/components/SpotifyControls.tsx
+++ b/app/client/control/components/SpotifyControls.tsx
@@ -111,7 +111,7 @@ const SpotifyControls = () => {
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [devices]) // Rely on devices update to trigger sync
+  }, [devices, isLocked]) // Rely on devices update to trigger sync
 
   // Auto-select HRM Web Player if no active device is available
   useEffect(() => {

--- a/app/client/control/components/SpotifyControls.tsx
+++ b/app/client/control/components/SpotifyControls.tsx
@@ -22,6 +22,9 @@ import PlaybackControls from '@/components/shared/PlaybackControls'
 import SpotifySearchInput from '@/components/SpotifySearchInput'
 import VolumeSlider from '@/components/shared/VolumeSlider'
 import throttle from 'lodash.throttle'
+import { useSyncLock } from '@/hooks/useSyncLock'
+
+const VOLUME_SLIDER_SX = { mt: 3, mb: 1 }
 
 const SpotifyControls = () => {
   const router = useRouter()
@@ -36,7 +39,7 @@ const SpotifyControls = () => {
   const [selectedDeviceId, setSelectedDeviceId] = useState<string>('')
   const [isSliding, setIsSliding] = useState(false)
   const prevActiveIdRef = useRef<string | undefined>(undefined)
-  const lastUserInteractionRef = useRef<number>(0)
+  const { isLocked, updateInteraction } = useSyncLock(SYNC_LOCK_DURATION)
 
   const hrmDevice = useMemo(
     () =>
@@ -99,10 +102,7 @@ const SpotifyControls = () => {
 
     if (isSliding) return
 
-    const isLocked =
-      Date.now() - lastUserInteractionRef.current < SYNC_LOCK_DURATION
-
-    if (isLocked) return
+    if (isLocked()) return
 
     if (activeDevice && typeof playbackVolume === 'number') {
       if (playbackVolume !== volume) {
@@ -201,9 +201,14 @@ const SpotifyControls = () => {
     [connectionStatus, resolveTargetDeviceId, executeSpotify]
   )
 
+  const sendCommandRef = useRef(sendVolumeCommand)
+  useEffect(() => {
+    sendCommandRef.current = sendVolumeCommand
+  }, [sendVolumeCommand])
+
   const throttledSendVolumeCommand = useMemo(
-    () => throttle(sendVolumeCommand, 200),
-    [sendVolumeCommand]
+    () => throttle((val: number) => sendCommandRef.current(val), 200),
+    []
   )
 
   useEffect(() => {
@@ -215,7 +220,7 @@ const SpotifyControls = () => {
   const handleVolumeChange = useCallback(
     (val: number) => {
       setIsSliding(true)
-      lastUserInteractionRef.current = Date.now()
+      updateInteraction()
       setVolume(val)
       throttledSendVolumeCommand(val)
 
@@ -228,16 +233,22 @@ const SpotifyControls = () => {
         }
       }
     },
-    [connectionStatus, showWarning, setVolume, throttledSendVolumeCommand]
+    [
+      connectionStatus,
+      showWarning,
+      setVolume,
+      throttledSendVolumeCommand,
+      updateInteraction,
+    ]
   )
 
   const handleVolumeChangeCommitted = useCallback(
     (val: number) => {
       setIsSliding(false)
-      lastUserInteractionRef.current = Date.now()
+      updateInteraction()
       sendVolumeCommand(val)
     },
-    [sendVolumeCommand]
+    [sendVolumeCommand, updateInteraction]
   )
 
   useEffect(() => {
@@ -315,7 +326,7 @@ const SpotifyControls = () => {
               onToggleMute={toggleMute}
               showValue
               size="medium"
-              sx={{ mt: 3, mb: 1 }}
+              sx={VOLUME_SLIDER_SX}
             />
 
             {devices.length > 0 && (

--- a/components/SpotifyDisplay.tsx
+++ b/components/SpotifyDisplay.tsx
@@ -14,13 +14,14 @@ import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import IconButton from '@mui/material/IconButton'
 import Typography from '@mui/material/Typography'
-import { useCallback, useEffect, useReducer, useRef } from 'react'
+import { useCallback, useEffect, useReducer } from 'react'
 import { signOut } from 'next-auth/react'
 import AuthButton from './AuthButton'
 import VolumeSlider from './shared/VolumeSlider'
 import SpotifyDeviceSelector from './SpotifyDeviceSelector'
 import { SPOTIFY_BRAND_COLOR, SYNC_LOCK_DURATION } from '@/constants/spotify'
 import DeviceRecommendation from './Spotify/DeviceRecommendation'
+import { useSyncLock } from '@/hooks/useSyncLock'
 
 // 1. State Shape
 interface SpotifyDisplayState {
@@ -135,7 +136,7 @@ const SpotifyDisplay = () => {
   }
 
   const { player, isReady, deviceId } = useSpotifyWebPlayback()
-  const lastUserInteractionRef = useRef<number>(0)
+  const { isLocked, updateInteraction } = useSyncLock(SYNC_LOCK_DURATION)
 
   // Enable remote Spotify control from controllers
   useDashboardRegistration(player)
@@ -146,9 +147,7 @@ const SpotifyDisplay = () => {
       return
     }
 
-    const isLocked =
-      Date.now() - lastUserInteractionRef.current < SYNC_LOCK_DURATION
-    if (isLocked) {
+    if (isLocked()) {
       return
     }
 
@@ -163,6 +162,7 @@ const SpotifyDisplay = () => {
     spotifyData.playback.volume_percent,
     spotifyData.playback.isMuted,
     state.isSliding,
+    isLocked,
   ])
 
   // Centralized command sender for volume changes
@@ -188,12 +188,12 @@ const SpotifyDisplay = () => {
   )
 
   const handleVolumeChange = (newVolume: number) => {
-    lastUserInteractionRef.current = Date.now()
+    updateInteraction()
     dispatch({ type: 'SET_VOLUME', payload: newVolume }) // Update UI immediately
   }
 
   const handleVolumeChangeCommitted = (newVolume: number) => {
-    lastUserInteractionRef.current = Date.now()
+    updateInteraction()
     sendVolumeCommand(newVolume)
     dispatch({ type: 'SET_SLIDING', payload: false }) // Reset sliding state
   }

--- a/components/SpotifyDisplay.tsx
+++ b/components/SpotifyDisplay.tsx
@@ -189,18 +189,16 @@ const SpotifyDisplay = () => {
 
   const handleVolumeChange = (newVolume: number) => {
     updateInteraction()
-    dispatch({ type: 'SET_VOLUME', payload: newVolume }) // Update UI immediately
+    dispatch({ type: 'SET_VOLUME', payload: newVolume })
   }
 
   const handleVolumeChangeCommitted = (newVolume: number) => {
     updateInteraction()
     sendVolumeCommand(newVolume)
-    dispatch({ type: 'SET_SLIDING', payload: false }) // Reset sliding state
+    dispatch({ type: 'SET_SLIDING', payload: false })
   }
 
-  // Handler for the VolumeSlider's mute button
   const handleToggleMute = useCallback(() => {
-    // Calculate the next state to determine the command payload
     const newMutedState = !isMuted
     const newVolume = newMutedState
       ? 0
@@ -208,8 +206,8 @@ const SpotifyDisplay = () => {
         ? state.lastVolume
         : 50
 
-    dispatch({ type: 'TOGGLE_MUTE' }) // Update UI
-    sendVolumeCommand(newVolume) // Send command with the new volume
+    dispatch({ type: 'TOGGLE_MUTE' })
+    sendVolumeCommand(newVolume)
   }, [isMuted, state.lastVolume, sendVolumeCommand])
 
   // Effect to auto-select the active device

--- a/hooks/useSyncLock.ts
+++ b/hooks/useSyncLock.ts
@@ -1,0 +1,15 @@
+import { useRef, useCallback } from 'react'
+
+export const useSyncLock = (duration: number) => {
+  const lastInteractionRef = useRef<number>(0)
+
+  const isLocked = useCallback(
+    () => Date.now() - lastInteractionRef.current < duration,
+    [duration]
+  )
+  const updateInteraction = useCallback(() => {
+    lastInteractionRef.current = Date.now()
+  }, [])
+
+  return { isLocked, updateInteraction }
+}

--- a/hooks/useThrottledCallback.ts
+++ b/hooks/useThrottledCallback.ts
@@ -1,0 +1,30 @@
+import { useLayoutEffect, useMemo, useRef, useEffect } from 'react'
+import throttle from 'lodash.throttle'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function useThrottledCallback<T extends (...args: any[]) => any>(
+  callback: T,
+  delay: number
+) {
+  const callbackRef = useRef(callback)
+
+  // Update the ref synchronously before render
+  useLayoutEffect(() => {
+    callbackRef.current = callback
+  }, [callback])
+
+  const throttledFunction = useMemo(() => {
+    const runCallback = (...args: Parameters<T>) => callbackRef.current(...args)
+    // eslint-disable-next-line react-hooks/refs
+    return throttle(runCallback, delay)
+  }, [delay])
+
+  // Clean up on unmount
+  useEffect(() => {
+    return () => {
+      throttledFunction.cancel()
+    }
+  }, [throttledFunction])
+
+  return throttledFunction
+}


### PR DESCRIPTION
## Description

Addresses Principal Engineer directives to remove the `throttle` anti-pattern, extract `lastUserInteractionRef` duplication into a reusable hook (`useSyncLock`), and restore the removed `VOLUME_SLIDER_SX` style constant.

Fixes #9447

## Change Type: 🐛 Bug fix (non-breaking change fixing an issue)

## Related Issues

Closes #9447

## Testing

Verified via automated tests and manual UI snapshot verification.

<details>
<summary>Original PR Body</summary>

Fixes PR #9447. Addresses Principal Engineer directives to remove the `throttle` anti-pattern, extract `lastUserInteractionRef` duplication into a reusable hook (`useSyncLock`), and restore the removed `VOLUME_SLIDER_SX` style constant. Verified via automated tests and manual UI snapshot verification.

---
*PR created automatically by Jules for task [11659658326387959191](https://jules.google.com/task/11659658326387959191) started by @arii*
</details>