### PR TITLE
ci(comment-ops): fix stale-state and sync issues in finalize-status

### DIFF
--- a/.github/workflows/comment-ops.yml
+++ b/.github/workflows/comment-ops.yml
@@ -292,11 +292,10 @@ jobs:
       - execute-triage
       - execute-coder
       - execute-create-review-issues
-      - create-review-issues
       - execute-help
       - execute-squash
       - execute-resolve
-    if: always() && needs.init-status.result == 'success'
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Determine Final Status
@@ -324,11 +323,6 @@ jobs:
           check_job "Triage" "${{ needs.execute-triage.result }}" "${{ needs.router.outputs.is_triage }}"
           check_job "Coder" "${{ needs.execute-coder.result }}" "${{ needs.router.outputs.is_coder }}"
           check_job "Create Review Issues (Manual)" "${{ needs.execute-create-review-issues.result }}" "${{ needs.router.outputs.is_review_issues }}"
-
-          # create-review-issues is the automatic follow-up to execute-review
-          if [ "${{ needs.router.outputs.is_review }}" == "true" ]; then
-             check_job "Follow-up Issues (Auto)" "${{ needs.create-review-issues.result }}" "true"
-          fi
 
           check_job "Help" "${{ needs.execute-help.result }}" "${{ needs.router.outputs.is_help }}"
           check_job "Squash" "${{ needs.execute-squash.result }}" "${{ needs.router.outputs.is_squash }}"


### PR DESCRIPTION
## Description

This PR fixes stale-state and sync issues in the `finalize-status` job within `comment-ops`.

- Removed `create-review-issues` from the `needs` array of the `finalize-status` job, resolving a rebase discrepancy/overlap issue.
- Removed the duplicated Bash check for `create-review-issues` logic inside `finalize-status`, mitigating phantom changes.
- Changed the `if` condition for `finalize-status` to `always()`, preventing the entire status reporting step from being skipped if the initial comment job fails.

## Change Type: 🐛 Bug fix (non-breaking change fixing an issue)

## Related Issues

Closes #5060235974971069793

<details>
<summary>Original PR Body</summary>

- Removed `create-review-issues` from the `needs` array of the `finalize-status` job, resolving a rebase discrepancy/overlap issue.
- Removed the duplicated Bash check for `create-review-issues` logic inside `finalize-status`, mitigating phantom changes.
- Changed the `if` condition for `finalize-status` to `always()`, preventing the entire status reporting step from being skipped if the initial comment job fails.

---
*PR created automatically by Jules for task [5060235974971069793](https://jules.google.com/task/5060235974971069793) started by @arii*
</details>