### PR TITLE
ci(small): Fix comment-ops CI failures and refine action script

### DIFF
--- a/.github/workflows/comment-ops.yml
+++ b/.github/workflows/comment-ops.yml
@@ -20,6 +20,7 @@ jobs:
     name: 🔍 Route Comment
     runs-on: ubuntu-latest
     outputs:
+      is_command_triggered: ${{ steps.route.outputs.is_command_triggered || 'false' }}
       is_review: ${{ steps.route.outputs.is_review || 'false' }}
       is_squash: ${{ steps.route.outputs.is_squash || 'false' }}
       is_resolve: ${{ steps.route.outputs.is_resolve || 'false' }}
@@ -35,24 +36,17 @@ jobs:
           # Use case-insensitive grep and ensure outputs are always set if matched.
           # We check for commands starting at the beginning of a line to avoid accidental triggers
           # from quotes or descriptive text mentioning the bots.
-          if echo "$BODY" | grep -qiE "^@gemini-bot"; then echo "is_review=true" >> $GITHUB_OUTPUT; fi
-          if echo "$BODY" | grep -qiE "(^|\r?\n)@pr-squash"; then echo "is_squash=true" >> $GITHUB_OUTPUT; fi
-          if echo "$BODY" | grep -qiE "(^|\r?\n)@conflict-resolve"; then echo "is_resolve=true" >> $GITHUB_OUTPUT; fi
-          if echo "$BODY" | grep -qiE "^@gemini-triage"; then echo "is_triage=true" >> $GITHUB_OUTPUT; fi
-          if echo "$BODY" | grep -qiE "^@gemini-coder"; then echo "is_coder=true" >> $GITHUB_OUTPUT; fi
-          if echo "$BODY" | grep -qiE "^@create-review-issues"; then echo "is_review_issues=true" >> $GITHUB_OUTPUT; fi
-          if echo "$BODY" | grep -qiE "^@gemini-help"; then echo "is_help=true" >> $GITHUB_OUTPUT; fi
+          if echo "$BODY" | grep -qiE "^@gemini-bot"; then echo "is_review=true" >> $GITHUB_OUTPUT; echo "is_command_triggered=true" >> $GITHUB_OUTPUT; fi
+          if echo "$BODY" | grep -qiE "(^|\r?\n)@pr-squash"; then echo "is_squash=true" >> $GITHUB_OUTPUT; echo "is_command_triggered=true" >> $GITHUB_OUTPUT; fi
+          if echo "$BODY" | grep -qiE "(^|\r?\n)@conflict-resolve"; then echo "is_resolve=true" >> $GITHUB_OUTPUT; echo "is_command_triggered=true" >> $GITHUB_OUTPUT; fi
+          if echo "$BODY" | grep -qiE "^@gemini-triage"; then echo "is_triage=true" >> $GITHUB_OUTPUT; echo "is_command_triggered=true" >> $GITHUB_OUTPUT; fi
+          if echo "$BODY" | grep -qiE "^@gemini-coder"; then echo "is_coder=true" >> $GITHUB_OUTPUT; echo "is_command_triggered=true" >> $GITHUB_OUTPUT; fi
+          if echo "$BODY" | grep -qiE "^@create-review-issues"; then echo "is_review_issues=true" >> $GITHUB_OUTPUT; echo "is_command_triggered=true" >> $GITHUB_OUTPUT; fi
+          if echo "$BODY" | grep -qiE "^@gemini-help"; then echo "is_help=true" >> $GITHUB_OUTPUT; echo "is_command_triggered=true" >> $GITHUB_OUTPUT; fi
 
   init-status:
     needs: [router]
-    if: |
-      needs.router.outputs.is_review == 'true' ||
-      needs.router.outputs.is_squash == 'true' ||
-      needs.router.outputs.is_resolve == 'true' ||
-      needs.router.outputs.is_triage == 'true' ||
-      needs.router.outputs.is_coder == 'true' ||
-      needs.router.outputs.is_review_issues == 'true' ||
-      needs.router.outputs.is_help == 'true'
+    if: needs.router.outputs.is_command_triggered == 'true'
     runs-on: ubuntu-latest
     outputs:
       comment_id: ${{ steps.post-comment.outputs.comment-id }}
@@ -295,13 +289,12 @@ jobs:
       - execute-help
       - execute-squash
       - execute-resolve
-    if: always()
+    if: always() && needs.init-status.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Determine Final Status
         id: status
         run: |
-          # Build status report
           REPORT="### 🤖 Command Operation Status\n\n"
 
           check_job() {
@@ -328,13 +321,11 @@ jobs:
           check_job "Squash" "${{ needs.execute-squash.result }}" "${{ needs.router.outputs.is_squash }}"
           check_job "Resolve" "${{ needs.execute-resolve.result }}" "${{ needs.router.outputs.is_resolve }}"
 
-          # Append footer
           REPORT="${REPORT}\n---\nTriggered by: @${{ github.actor }} via [comment](${{ github.event.comment.html_url }})"
           REPORT="${REPORT}\n\n<!-- id: comment-op-status-${{ github.event.comment.id }} -->"
 
-          # Use HEREDOC for multiline output
           echo "REPORT<<EOF" >> $GITHUB_OUTPUT
-          echo -e "$REPORT" >> $GITHUB_OUTPUT
+          printf "%b\n" "$REPORT" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Update Status Comment


### PR DESCRIPTION
## Description
This pull request addresses and fixes CI failures in `comment-ops` and refines the associated action script.
It implements structural updates to `comment-ops.yml` following audit directives.
Specifically, it resolves the issue where the `finalize-status` job fails on normal, non-command issue comments because `init-status` is skipped.
The changes also consolidate boolean logic in the `router` for `init-status` usage and enhance bash script portability.

## Change Type: 🐛 Bug fix (non-breaking change fixing an issue)

<details>
<summary>Original PR Body</summary>

- Implement structural updates to `comment-ops.yml` following audit directives.
- Resolves issue where `finalize-status` job fails on normal, non-command issue comments because `init-status` is skipped.
- Consolidates boolean logic in `router` for `init-status` usage.
- Enhances bash script portability.

---
*PR created automatically by Jules for task [16157669690902370631](https://jules.google.com/task/16157669690902370631) started by @arii*
</details>