### PR TITLE
feat(small): Add data-testid to SpotifyDeviceSelector

### DIFF
--- a/components/SpotifyDeviceSelector.tsx
+++ b/components/SpotifyDeviceSelector.tsx
@@ -32,7 +32,7 @@ const SpotifyDeviceSelector = ({
           '&:hover': { backgroundColor: 'grey.800' },
         }}
         aria-label="Select playback device"
-        data-testid="spotify-device-selector-button"
+        data-testid="spotify-device-select"
       >
         <SpeakerIcon fontSize="small" />
       </IconButton>
@@ -59,7 +59,7 @@ const SpotifyDeviceSelector = ({
               key={device.id}
               onClick={() => onDeviceSelect(device.id)}
               selected={device.is_active}
-              data-testid={`spotify-device-selector-item-${device.id}`}
+              data-testid={`spotify-device-select-option-${device.id}`}
             >
               {device.name} {device.is_active && '✓'}
             </MenuItem>

--- a/tests/playwright/vrt-components.spec.ts
+++ b/tests/playwright/vrt-components.spec.ts
@@ -132,9 +132,7 @@ test.describe('Component-Specific VRT', () => {
       ],
     })
 
-    const selectorButton = dashboardPage.getByTestId(
-      'spotify-device-selector-button'
-    )
+    const selectorButton = dashboardPage.getByTestId('spotify-device-select')
     await expect(selectorButton).toBeVisible({
       timeout: VRT_TIMEOUTS.STANDARD,
     })


### PR DESCRIPTION
## Description

The `SpotifyDeviceSelector` component was updated to include standardized `data-testid` attributes. Specifically:
- The `IconButton` trigger now has `data-testid="spotify-device-select"`.
- Each `MenuItem` for devices now has `data-testid={`spotify-device-select-option-${device.id}`}`.

These changes ensure compatibility with unit tests (like `SpotifyControls.test.tsx`) that use these IDs to locate device selection elements. Additionally, `tests/playwright/vrt-components.spec.ts` was updated to reflect the new test ID for the selector button, maintaining the integrity of the visual regression suite.

Fixes #9345

## Change Type: ✨ New feature (non-breaking change adding functionality)

## Related Issues

Closes #9345

<details>
<summary>Original PR Body</summary>

The `SpotifyDeviceSelector` component was updated to include standardized `data-testid` attributes. Specifically:
- The `IconButton` trigger now has `data-testid="spotify-device-select"`.
- Each `MenuItem` for devices now has `data-testid={`spotify-device-select-option-${device.id}`}`.

These changes ensure compatibility with unit tests (like `SpotifyControls.test.tsx`) that use these IDs to locate device selection elements. Additionally, `tests/playwright/vrt-components.spec.ts` was updated to reflect the new test ID for the selector button, maintaining the integrity of the visual regression suite.

Fixes #9345

---
*PR created automatically by Jules for task [10248183229037656262](https://jules.google.com/task/10248183229037656262) started by @arii*
</details>