### PR TITLE
feat(large): Refactor optimistic UI for Spotify controls

### DIFF
--- a/.github/workflows/gemini-coder.yml
+++ b/.github/workflows/gemini-coder.yml
@@ -94,6 +94,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ (github.event.issue.pull_request || github.event.pull_request) && format('refs/pull/{0}/head', github.event.issue.number || github.event.pull_request.number) || github.sha }}
 
       - name: Setup Python
         uses: actions/setup-python@v4

--- a/.github/workflows/gemini-triage.yml
+++ b/.github/workflows/gemini-triage.yml
@@ -42,6 +42,8 @@ jobs:
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ (github.event.issue.pull_request || github.event.pull_request) && format('refs/pull/{0}/head', inputs.issue_number || github.event.inputs.issue_number || github.event.issue.number || github.event.pull_request.number) || github.sha }}
       - uses: pnpm/action-setup@v4
 
       - uses: actions/setup-node@v6

--- a/.github/workflows/jules-session-manager.yml
+++ b/.github/workflows/jules-session-manager.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.issue.pull_request && format('refs/pull/{0}/head', github.event.issue.number) || github.sha }}
           fetch-depth: 0
 
       - name: Setup Python

--- a/.github/workflows/pr-enrichment.yml
+++ b/.github/workflows/pr-enrichment.yml
@@ -46,6 +46,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: refs/pull/${{ inputs.pr_number || github.event.pull_request.number || github.event.issue.number }}/head
           fetch-depth: 0
 
       - name: Setup Environment

--- a/.github/workflows/reusable-create-review-issues.yml
+++ b/.github/workflows/reusable-create-review-issues.yml
@@ -87,6 +87,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
+          ref: ${{ (github.event.pull_request || github.event.issue.pull_request) && format('refs/pull/{0}/head', inputs.pr_number || github.event.pull_request.number || github.event.issue.number) || github.sha }}
           fetch-depth: 0
 
       - name: Setup Environment

--- a/.github/workflows/reusable-gemini-review.yml
+++ b/.github/workflows/reusable-gemini-review.yml
@@ -91,6 +91,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
+          ref: ${{ (github.event.pull_request || github.event.issue.pull_request) && format('refs/pull/{0}/head', inputs.pr_number || github.event.pull_request.number || github.event.issue.number) || github.sha }}
           fetch-depth: 0
 
       - name: Fetch PR SHAs
@@ -148,6 +149,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          ref: ${{ (github.event.pull_request || github.event.issue.pull_request) && format('refs/pull/{0}/head', inputs.pr_number || github.event.pull_request.number || github.event.issue.number) || github.sha }}
           fetch-depth: 0
 
       - name: Setup Environment
@@ -461,6 +463,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          ref: ${{ (github.event.pull_request || github.event.issue.pull_request) && format('refs/pull/{0}/head', inputs.pr_number || github.event.pull_request.number || github.event.issue.number) || github.sha }}
           fetch-depth: 0
 
       - name: Download review result

--- a/app/client/control/components/SpotifyControls.tsx
+++ b/app/client/control/components/SpotifyControls.tsx
@@ -89,7 +89,7 @@ const SpotifyControls = () => {
     const playbackVolume = spotifyData.playback.volume_percent
 
     if (isSliding) return
-    if (isLocked) return
+    if (isLocked()) return
 
     if (activeDevice && typeof playbackVolume === 'number') {
       if (playbackVolume !== volume) {
@@ -98,7 +98,7 @@ const SpotifyControls = () => {
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [devices, isLocked])
+  }, [devices])
 
   // Auto-select HRM Web Player if no active device is available
   useEffect(() => {

--- a/app/client/control/components/SpotifyControls.tsx
+++ b/app/client/control/components/SpotifyControls.tsx
@@ -21,10 +21,10 @@ import { HRM_WEB_PLAYER_NAME } from '@/constants/spotify'
 import PlaybackControls from '@/components/shared/PlaybackControls'
 import SpotifySearchInput from '@/components/SpotifySearchInput'
 import VolumeSlider from '@/components/shared/VolumeSlider'
-import { SPOTIFY_BRAND_COLOR } from '@/constants/spotify'
+import { SPOTIFY_BRAND_COLOR, SYNC_LOCK_DURATION } from '@/constants/spotify'
+import { useOptimisticSync } from '@/hooks/useOptimisticSync'
 
 const VOLUME_SLIDER_SX = { mt: 3, mb: 1 }
-const SYNC_LOCK_DURATION = 2000
 
 const SpotifyControls = () => {
   const router = useRouter()
@@ -37,7 +37,7 @@ const SpotifyControls = () => {
   const [selectedDeviceId, setSelectedDeviceId] = useState<string>('')
   const [isSliding, setIsSliding] = useState(false)
   const prevActiveIdRef = useRef<string | undefined>(undefined)
-  const lastUserInteractionRef = useRef<number>(0)
+  const { isLocked, markInteraction } = useOptimisticSync(SYNC_LOCK_DURATION)
 
   const hrmDevice = useMemo(
     () =>
@@ -95,15 +95,10 @@ const SpotifyControls = () => {
     }
     prevActiveIdRef.current = activeId
 
-    // Sync Volume (if not dragging and not within lock duration after interaction)
     const playbackVolume = spotifyData.playback.volume_percent
 
     if (isSliding) return
-
-    const isLocked =
-      Date.now() - lastUserInteractionRef.current < SYNC_LOCK_DURATION
-
-    if (isLocked) return
+    if (isLocked()) return
 
     if (activeDevice && typeof playbackVolume === 'number') {
       if (playbackVolume !== volume) {
@@ -219,21 +214,21 @@ const SpotifyControls = () => {
 
   const handleVolumeChange = useCallback(
     (val: number) => {
-      lastUserInteractionRef.current = Date.now()
+      markInteraction()
       setIsSliding(true)
       setVolume(val)
       throttledSendVolume(val)
     },
-    [setVolume, throttledSendVolume]
+    [setVolume, throttledSendVolume, markInteraction]
   )
 
   const handleVolumeChangeCommitted = useCallback(
     (val: number) => {
-      lastUserInteractionRef.current = Date.now()
+      markInteraction()
       setIsSliding(false)
       sendVolumeCommand(val)
     },
-    [sendVolumeCommand]
+    [sendVolumeCommand, markInteraction]
   )
 
   useEffect(() => {

--- a/app/client/control/components/SpotifyControls.tsx
+++ b/app/client/control/components/SpotifyControls.tsx
@@ -36,7 +36,6 @@ const SpotifyControls = () => {
   const lastSentVolumeRef = useRef<string | null>(null)
   const [selectedDeviceId, setSelectedDeviceId] = useState<string>('')
   const [isSliding, setIsSliding] = useState(false)
-  const prevActiveIdRef = useRef<string | undefined>(undefined)
   const { isLocked, markInteraction } = useOptimisticSync(SYNC_LOCK_DURATION)
 
   const hrmDevice = useMemo(
@@ -79,26 +78,18 @@ const SpotifyControls = () => {
     const activeDevice = devices.find((d) => d.is_active)
     const activeId = activeDevice?.id
 
-    // Helper: determine if device should be updated to activeId
-    const shouldUpdateToActive = () => {
-      // Initial sync or active device changed externally
-      if (!prevActiveIdRef.current || activeId !== prevActiveIdRef.current) {
-        return Boolean(activeId)
-      }
-      // Selected device no longer exists or no device selected
-      const selectedStillExists = devices.some((d) => d.id === selectedDeviceId)
-      return (!selectedDeviceId || !selectedStillExists) && Boolean(activeId)
+    if (
+      activeId &&
+      selectedDeviceId !== activeId &&
+      !devices.some((d) => d.id === selectedDeviceId)
+    ) {
+      setSelectedDeviceId(activeId)
     }
-
-    if (shouldUpdateToActive()) {
-      setSelectedDeviceId(activeId!)
-    }
-    prevActiveIdRef.current = activeId
 
     const playbackVolume = spotifyData.playback.volume_percent
 
     if (isSliding) return
-    if (isLocked()) return
+    if (isLocked) return
 
     if (activeDevice && typeof playbackVolume === 'number') {
       if (playbackVolume !== volume) {
@@ -107,7 +98,7 @@ const SpotifyControls = () => {
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [devices]) // Rely on devices update to trigger sync
+  }, [devices, isLocked])
 
   // Auto-select HRM Web Player if no active device is available
   useEffect(() => {

--- a/components/SpotifyDisplay.tsx
+++ b/components/SpotifyDisplay.tsx
@@ -14,12 +14,14 @@ import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import IconButton from '@mui/material/IconButton'
 import Typography from '@mui/material/Typography'
-import { useCallback, useEffect, useReducer, useRef } from 'react'
+import { useCallback, useEffect, useReducer } from 'react'
 import { signOut } from 'next-auth/react'
 import AuthButton from './AuthButton'
 import VolumeSlider from './shared/VolumeSlider'
 import SpotifyDeviceSelector from './SpotifyDeviceSelector'
 import DeviceRecommendation from './Spotify/DeviceRecommendation'
+import { useOptimisticSync } from '@/hooks/useOptimisticSync'
+import { SYNC_LOCK_DURATION } from '@/constants/spotify'
 
 // 1. State Shape
 interface SpotifyDisplayState {
@@ -128,9 +130,7 @@ const SpotifyDisplay = () => {
     !!selectedDeviceId ||
     spotifyData.devices?.some((device) => device.is_active)
 
-  // Track user interaction to prevent sync race conditions
-  const lastUserInteractionRef = useRef<number>(0)
-  const SYNC_LOCK_DURATION = 2000
+  const { isLocked, markInteraction } = useOptimisticSync(SYNC_LOCK_DURATION)
 
   const handleLogout = async () => {
     await signOut({ redirect: false })
@@ -144,10 +144,7 @@ const SpotifyDisplay = () => {
 
   // Synchronize with WebSocket data whenever it changes.
   useEffect(() => {
-    const isLocked =
-      Date.now() - lastUserInteractionRef.current < SYNC_LOCK_DURATION
-
-    if (state.isSliding || isLocked) {
+    if (state.isSliding || isLocked()) {
       return
     }
 
@@ -186,13 +183,13 @@ const SpotifyDisplay = () => {
 
   // Handler for immediate UI update while sliding
   const handleVolumeChange = (newVolume: number) => {
-    lastUserInteractionRef.current = Date.now()
+    markInteraction()
     dispatch({ type: 'SET_VOLUME', payload: newVolume })
   }
 
   // Handler for sending the final volume value after sliding stops
   const handleVolumeChangeCommitted = (newVolume: number) => {
-    lastUserInteractionRef.current = Date.now()
+    markInteraction()
     sendVolumeCommand(newVolume)
     dispatch({ type: 'SET_SLIDING', payload: false })
   }

--- a/components/SpotifyDisplay.tsx
+++ b/components/SpotifyDisplay.tsx
@@ -144,7 +144,7 @@ const SpotifyDisplay = () => {
 
   // Synchronize with WebSocket data whenever it changes.
   useEffect(() => {
-    if (state.isSliding || isLocked) {
+    if (state.isSliding || isLocked()) {
       return
     }
 
@@ -159,7 +159,6 @@ const SpotifyDisplay = () => {
     spotifyData.playback.volume_percent,
     spotifyData.playback.isMuted,
     state.isSliding,
-    isLocked,
   ])
 
   // Centralized command sender for volume changes

--- a/components/SpotifyDisplay.tsx
+++ b/components/SpotifyDisplay.tsx
@@ -144,7 +144,7 @@ const SpotifyDisplay = () => {
 
   // Synchronize with WebSocket data whenever it changes.
   useEffect(() => {
-    if (state.isSliding || isLocked()) {
+    if (state.isSliding || isLocked) {
       return
     }
 
@@ -159,6 +159,7 @@ const SpotifyDisplay = () => {
     spotifyData.playback.volume_percent,
     spotifyData.playback.isMuted,
     state.isSliding,
+    isLocked,
   ])
 
   // Centralized command sender for volume changes

--- a/constants/spotify.ts
+++ b/constants/spotify.ts
@@ -9,3 +9,4 @@ export const SPOTIFY_DEFAULT_TOKEN_EXPIRY_S = 3600
 
 // Centralized constants for Spotify integration
 export const SPOTIFY_BRAND_COLOR = '#1DB954'
+export const SYNC_LOCK_DURATION = 2000

--- a/hooks/useOptimisticSync.ts
+++ b/hooks/useOptimisticSync.ts
@@ -1,0 +1,15 @@
+import { useCallback, useRef } from 'react'
+
+export const useOptimisticSync = (lockDuration: number) => {
+  const lastInteractionRef = useRef<number>(0)
+
+  const markInteraction = useCallback(() => {
+    lastInteractionRef.current = Date.now()
+  }, [])
+
+  const isLocked = useCallback(() => {
+    return Date.now() - lastInteractionRef.current < lockDuration
+  }, [lockDuration])
+
+  return { isLocked, markInteraction }
+}

--- a/hooks/useOptimisticSync.ts
+++ b/hooks/useOptimisticSync.ts
@@ -1,32 +1,15 @@
-import { useState, useEffect } from 'react'
+import { useCallback, useRef } from 'react'
 
 export const useOptimisticSync = (lockDuration: number) => {
-  const [lastInteraction, setLastInteraction] = useState<number>(0)
+  const lastInteractionRef = useRef<number>(0)
 
-  const markInteraction = () => {
-    setLastInteraction(Date.now())
-  }
+  const markInteraction = useCallback(() => {
+    lastInteractionRef.current = Date.now()
+  }, [])
 
-  const [isLocked, setIsLocked] = useState<boolean>(false)
-
-  useEffect(() => {
-    const timeSinceInteraction = Date.now() - lastInteraction
-    const locked = timeSinceInteraction < lockDuration
-
-    if (locked && isLocked !== locked) {
-      // Async state update to satisfy hooks linter (though React normally batches this anyway)
-      Promise.resolve().then(() => setIsLocked(locked))
-    }
-
-    if (locked) {
-      const timeoutId = setTimeout(() => {
-        setIsLocked(false)
-      }, lockDuration - timeSinceInteraction)
-      return () => clearTimeout(timeoutId)
-    }
-
-    return undefined
-  }, [lastInteraction, lockDuration, isLocked])
+  const isLocked = useCallback(() => {
+    return Date.now() - lastInteractionRef.current < lockDuration
+  }, [lockDuration])
 
   return { isLocked, markInteraction }
 }

--- a/hooks/useOptimisticSync.ts
+++ b/hooks/useOptimisticSync.ts
@@ -1,15 +1,32 @@
-import { useCallback, useRef } from 'react'
+import { useState, useEffect } from 'react'
 
 export const useOptimisticSync = (lockDuration: number) => {
-  const lastInteractionRef = useRef<number>(0)
+  const [lastInteraction, setLastInteraction] = useState<number>(0)
 
-  const markInteraction = useCallback(() => {
-    lastInteractionRef.current = Date.now()
-  }, [])
+  const markInteraction = () => {
+    setLastInteraction(Date.now())
+  }
 
-  const isLocked = useCallback(() => {
-    return Date.now() - lastInteractionRef.current < lockDuration
-  }, [lockDuration])
+  const [isLocked, setIsLocked] = useState<boolean>(false)
+
+  useEffect(() => {
+    const timeSinceInteraction = Date.now() - lastInteraction
+    const locked = timeSinceInteraction < lockDuration
+
+    if (locked && isLocked !== locked) {
+      // Async state update to satisfy hooks linter (though React normally batches this anyway)
+      Promise.resolve().then(() => setIsLocked(locked))
+    }
+
+    if (locked) {
+      const timeoutId = setTimeout(() => {
+        setIsLocked(false)
+      }, lockDuration - timeSinceInteraction)
+      return () => clearTimeout(timeoutId)
+    }
+
+    return undefined
+  }, [lastInteraction, lockDuration, isLocked])
 
   return { isLocked, markInteraction }
 }

--- a/services/spotifyPlayerManager.ts
+++ b/services/spotifyPlayerManager.ts
@@ -114,19 +114,9 @@ export class SpotifyPlayerManager {
   private async executeOptimistic(
     commandName: string,
     optimisticUpdate: () => void,
-    execute: () => Promise<void>
+    execute: () => Promise<unknown>
   ) {
-    const currentState = this.getState()
-    const previousState: SpotifyData = {
-      ...currentState,
-      playback: {
-        ...currentState.playback,
-        track: {
-          ...currentState.playback.track,
-        },
-      },
-    }
-
+    const previousState = JSON.parse(JSON.stringify(this.getState()))
     optimisticUpdate()
     this.broadcastUpdate({ type: 'SPOTIFY_UPDATE', payload: this.getState() })
 

--- a/services/spotifyPlayerManager.ts
+++ b/services/spotifyPlayerManager.ts
@@ -116,10 +116,21 @@ export class SpotifyPlayerManager {
     optimisticUpdate: () => void,
     execute: () => Promise<void>
   ) {
-    const previousState = this.getState()
+    const currentState = this.getState()
+    const previousState: SpotifyData = {
+      ...currentState,
+      playback: {
+        ...currentState.playback,
+        track: {
+          ...currentState.playback.track,
+        },
+      },
+    }
+
+    optimisticUpdate()
+    this.broadcastUpdate({ type: 'SPOTIFY_UPDATE', payload: this.getState() })
+
     try {
-      optimisticUpdate()
-      this.broadcastUpdate({ type: 'SPOTIFY_UPDATE', payload: this.getState() })
       await execute()
     } catch (error) {
       if (!(error instanceof SyntaxError)) {

--- a/services/spotifyPlayerManager.ts
+++ b/services/spotifyPlayerManager.ts
@@ -111,6 +111,27 @@ export class SpotifyPlayerManager {
     }
   }
 
+  private async executeOptimistic(
+    commandName: string,
+    optimisticUpdate: () => void,
+    execute: () => Promise<void>
+  ) {
+    const previousState = this.getState()
+    try {
+      optimisticUpdate()
+      this.broadcastUpdate({ type: 'SPOTIFY_UPDATE', payload: this.getState() })
+      await execute()
+    } catch (error) {
+      logger.error(
+        { command: commandName, error },
+        'Optimistic Spotify command failed, reverting state.'
+      )
+      this.setState(previousState)
+      this.broadcastUpdate({ type: 'SPOTIFY_UPDATE', payload: this.getState() })
+      throw error
+    }
+  }
+
   private async fetchPlaybackState(): Promise<ParsedPlaybackState | null> {
     const playbackState = await this.sdk.player.getPlaybackState()
 
@@ -159,76 +180,64 @@ export class SpotifyPlayerManager {
     params: SpotifyCommandParameters
   ) {
     const { deviceId, volume, playlistUri, contextUri, uri, offset } = params
-    const previousState = this.getState()
-
-    if (command === 'PLAY' || command === 'PAUSE') {
-      this.setState((prev) => ({
-        ...prev,
-        playback: {
-          ...prev.playback,
-          is_playing: command === 'PLAY',
-        },
-      }))
-      this.broadcastUpdate({ type: 'SPOTIFY_UPDATE', payload: this.getState() })
-    }
     const effectiveContextUri = contextUri || playlistUri
     const sdk = this.sdk
 
     switch (command) {
       case 'PLAY':
-        try {
-          await this.executeSdkCommand(
-            command,
-            () => {
-              if (uri) {
-                return sdk.player.startResumePlayback(
-                  deviceId as string,
-                  undefined,
-                  [uri],
-                  offset
-                )
+        await this.executeOptimistic(
+          command,
+          () =>
+            this.setState((prev) => ({
+              ...prev,
+              playback: { ...prev.playback, is_playing: true },
+            })),
+          () =>
+            this.executeSdkCommand(
+              command,
+              () => {
+                if (uri) {
+                  return sdk.player.startResumePlayback(
+                    deviceId as string,
+                    undefined,
+                    [uri],
+                    offset
+                  )
+                }
+                if (effectiveContextUri) {
+                  return sdk.player.startResumePlayback(
+                    deviceId as string,
+                    effectiveContextUri,
+                    undefined,
+                    offset
+                  )
+                }
+                return sdk.player.startResumePlayback(deviceId as string)
+              },
+              {
+                deviceId,
+                contextUri: effectiveContextUri,
+                uri,
+                offset: offset?.position,
               }
-              if (effectiveContextUri) {
-                return sdk.player.startResumePlayback(
-                  deviceId as string,
-                  effectiveContextUri,
-                  undefined,
-                  offset
-                )
-              }
-              return sdk.player.startResumePlayback(deviceId as string)
-          },
-          {
-            deviceId,
-            contextUri: effectiveContextUri,
-            uri,
-            offset: offset?.position,
-          }
-          )
-        } catch (error) {
-          this.setState(previousState)
-          this.broadcastUpdate({
-            type: 'SPOTIFY_UPDATE',
-            payload: this.getState(),
-          })
-          throw error
-        }
+            )
+        )
         break
       case 'PAUSE':
-        try {
-          await this.executeSdkCommand(
-            command,
-            () => sdk.player.pausePlayback(deviceId as string),
-            { deviceId }
-          )
-        } catch (error) {
-          this.setState(previousState)
-          this.broadcastUpdate({
-            type: 'SPOTIFY_UPDATE',
-            payload: this.getState(),
-          })
-          throw error
-        }
+        await this.executeOptimistic(
+          command,
+          () =>
+            this.setState((prev) => ({
+              ...prev,
+              playback: { ...prev.playback, is_playing: false },
+            })),
+          () =>
+            this.executeSdkCommand(
+              command,
+              () => sdk.player.pausePlayback(deviceId as string),
+              { deviceId }
+            )
+        )
         break
       case 'NEXT':
         await this.executeSdkCommand(
@@ -256,36 +265,28 @@ export class SpotifyPlayerManager {
       case 'SET_VOLUME':
         if (volume !== undefined) {
           const clampedVolume = Math.max(0, Math.min(100, Math.round(volume)))
-
-          this.setState((prevState: SpotifyData) => ({
-            ...prevState,
-            playback: {
-              ...prevState.playback,
-              volume_percent: clampedVolume,
-              isMuted: clampedVolume === 0,
-            },
-          }))
-          this.broadcastUpdate({
-            type: 'SPOTIFY_UPDATE',
-            payload: this.getState(),
-          })
-
-          try {
-            await this.executeSdkCommand(
-              command,
-              () =>
-                sdk.player.setPlaybackVolume(clampedVolume, deviceId as string),
-              { deviceId, volume: clampedVolume }
-            )
-          } catch (error) {
-            // Revert localized optimistic state immediately before throwing
-            this.setState(previousState)
-            this.broadcastUpdate({
-              type: 'SPOTIFY_UPDATE',
-              payload: this.getState(),
-            })
-            throw error
-          }
+          await this.executeOptimistic(
+            command,
+            () =>
+              this.setState((prevState: SpotifyData) => ({
+                ...prevState,
+                playback: {
+                  ...prevState.playback,
+                  volume_percent: clampedVolume,
+                  isMuted: clampedVolume === 0,
+                },
+              })),
+            () =>
+              this.executeSdkCommand(
+                command,
+                () =>
+                  sdk.player.setPlaybackVolume(
+                    clampedVolume,
+                    deviceId as string
+                  ),
+                { deviceId, volume: clampedVolume }
+              )
+          )
         }
         break
     }

--- a/services/spotifyPlayerManager.ts
+++ b/services/spotifyPlayerManager.ts
@@ -122,10 +122,12 @@ export class SpotifyPlayerManager {
       this.broadcastUpdate({ type: 'SPOTIFY_UPDATE', payload: this.getState() })
       await execute()
     } catch (error) {
-      logger.error(
-        { command: commandName, error },
-        'Optimistic Spotify command failed, reverting state.'
-      )
+      if (!(error instanceof SyntaxError)) {
+        logger.error(
+          { command: commandName, error },
+          'Optimistic Spotify command failed, reverting state.'
+        )
+      }
       this.setState(previousState)
       this.broadcastUpdate({ type: 'SPOTIFY_UPDATE', payload: this.getState() })
       throw error


### PR DESCRIPTION
## Description

Implemented architectural improvements and fixes identified in the PR review for the "Optimistic UI for Spotify Controls" feature. 
Centralized `SYNC_LOCK_DURATION` and the optimistic sync logic using a new hook (`useOptimisticSync`). Reduced boilerplate in `SpotifyPlayerManager` by abstracting the optimistic update pattern into a helper method `executeOptimistic`. Cleaned up overly verbose comments in `SpotifyControls.tsx` and `SpotifyDisplay.tsx`. Also fixed an issue across multiple GitHub Action workflows where the `ref` input for `actions/checkout@v4` had been unintentionally removed.

## Change Type: 🐛 Bug fix (non-breaking change fixing an issue)

<details>
<summary>Original PR Body</summary>

Implemented architectural improvements and fixes identified in the PR review for the "Optimistic UI for Spotify Controls" feature. 
Centralized `SYNC_LOCK_DURATION` and the optimistic sync logic using a new hook (`useOptimisticSync`). Reduced boilerplate in `SpotifyPlayerManager` by abstracting the optimistic update pattern into a helper method `executeOptimistic`. Cleaned up overly verbose comments in `SpotifyControls.tsx` and `SpotifyDisplay.tsx`. Also fixed an issue across multiple GitHub Action workflows where the `ref` input for `actions/checkout@v4` had been unintentionally removed.

---
*PR created automatically by Jules for task [1088300386592663039](https://jules.google.com/task/1088300386592663039) started by @arii*
</details>