### PR TITLE
Fix dev container bloat and broken debug ports

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,13 +1,11 @@
 {
   "name": "HRM Development Environment",
-  "image": "mcr.microsoft.com/devcontainers/typescript-node:20",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:20-bullseye",
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {},
-    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
-    "ghcr.io/devcontainers/features/vim:1": {},
     "ghcr.io/devcontainers/features/jq:1": {}
   },
-  "forwardPorts": [3000, 8080],
+  "forwardPorts": [3000, 8080, 9229],
   "postCreateCommand": "bash .devcontainer/post-create.sh",
   "customizations": {
     "vscode": {
@@ -16,10 +14,7 @@
         "esbenp.prettier-vscode",
         "bradlc.vscode-tailwindcss",
         "ms-playwright.playwright",
-        "vscodevim.vim",
         "github.vscode-pull-request-github",
-        "GitHub.copilot",
-        "GitHub.copilot-chat",
         "firsttris.vscode-jest-runner"
       ],
       "settings": {
@@ -27,9 +22,7 @@
         "editor.defaultFormatter": "esbenp.prettier-vscode",
         "editor.codeActionsOnSave": {
           "source.fixAll.eslint": "explicit"
-        },
-        "vim.useSystemClipboard": true,
-        "vim.hlsearch": true
+        }
       }
     }
   }

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -11,15 +11,3 @@ echo "Installing Playwright browsers..."
 npx playwright install --with-deps
 
 echo "Dev container setup complete."
-
-# Generate Vim Configuration
-cat <<EOF > ~/.vimrc
-set expandtab      " Override: Use 4 spaces (default is 8-char tabs)
-set shiftwidth=4   " Override: Indent size
-set tabstop=4      " Override: Tab visual size
-set cmdheight=2    " Override: Extra space for UI messages
-set wmw=0          " Override: Allow ultra-thin window splits
-set foldmethod=indent " Override: Enable indent-based code folding
-EOF
-
-echo "✅ Vim configuration deployed."


### PR DESCRIPTION
Revert problematic dev container changes and remove personal tooling bloat while preserving intended fixes. This restores the debugging port and uses an OS-pinned base image to prevent CI/CD build issues with Playwright dependencies.

---
*PR created automatically by Jules for task [5000339495138055942](https://jules.google.com/task/5000339495138055942) started by @arii*