### PR TITLE
refactor: repair and polish audit vrt tools PR

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -296,32 +296,7 @@ This project prioritizes a lean and maintainable codebase. AI assistants should 
 
 ### 8. Visual Regression Testing (VRT) Stabilization Standards
 
-When working in Playwright VRT files, prioritize deterministic rendering and root-cause fixes over tolerance inflation.
-
-**NEVER suggest:**
-
-- Raising `maxDiffPixelRatio` as the first response to failing snapshots.
-- Using arbitrary sleeps (for example `waitForTimeout(500)` or `waitForTimeout(1000)`) for stabilization.
-- Masking stable layout regions to suppress legitimate visual regressions.
-
-**ALWAYS do:**
-
-- Keep baseline `maxDiffPixelRatio: 0.1` for standard captures.
-- Use at most `maxDiffPixelRatio: 0.15` for explicitly justified dynamic/complex captures (for example dense chart+HR overlays).
-- Keep `threshold: 0.2` and `scale: 'css'` in shared screenshot defaults.
-- Prefer deterministic readiness checks:
-  - `await page.evaluateHandle(() => document.fonts.ready)`
-  - `await page.waitForLoadState('networkidle')`
-  - explicit state assertions (`toBeVisible`, `toHaveCSS`, `toHaveText`)
-  - layout reads (`await page.evaluate(() => document.body.offsetHeight)`)
-- For responsive captures, set viewport explicitly and wait for width convergence:
-  - `await page.setViewportSize({ width, height })`
-  - `await page.waitForFunction((w) => document.body.clientWidth === w, width)`
-- Mask truly dynamic text/content through shared helpers (`getDynamicContentMasks`, `getHrMasks`) rather than increasing thresholds.
-- For MUI portal targets (menus/popovers/modals), avoid full-page scroll side effects on locator screenshots and allow `skipA11y: true` with rationale when portal detachment causes axe false positives.
-- Enforce deterministic state lifecycle:
-  - `resetServerState(request)` where shared server state can leak
-  - teardown hooks (for example `stopTimer(...)` in `afterEach`) for timer-driven specs
+See `.github/instructions/vrt-stability.instructions.md` for VRT Stabilization Standards.
 
 ## Quick Reference: Anti-Patterns to Avoid
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -296,7 +296,8 @@ This project prioritizes a lean and maintainable codebase. AI assistants should 
 
 ### 8. Visual Regression Testing (VRT) Stabilization Standards
 
-See `.github/instructions/vrt-stability.instructions.md` for VRT Stabilization Standards.
+Strictly adhere to the standards defined in:
+[.github/instructions/vrt-stability.instructions.md](.github/instructions/vrt-stability.instructions.md)
 
 ## Quick Reference: Anti-Patterns to Avoid
 

--- a/scripts/audit-vrt-changes.sh
+++ b/scripts/audit-vrt-changes.sh
@@ -20,7 +20,7 @@ echo "$prs" | jq -c '.[]' | while read -r pr; do
     branch=$(echo "$pr" | jq -r '.headRefName')
     title=$(echo "$pr" | jq -r '.title')
 
-    changed_files=$(gh pr diff "$pr_num" --name-only | grep -E "$VRT_PATTERN")
+    changed_files=$(gh pr diff "$pr_num" --name-only | grep -E "$VRT_PATTERN" | grep -v "\.png$")
 
     if [ -n "$changed_files" ]; then
         audit_file="$OUTPUT_DIR/pr-${pr_num}.md"

--- a/scripts/audit-vrt-changes.sh
+++ b/scripts/audit-vrt-changes.sh
@@ -1,64 +1,57 @@
 #!/bin/bash
 
-# Configuration: Target specs, helpers, and snapshots
-VRT_PATTERN="tests/playwright/.*spec\.ts|tests/playwright/lib/visual\.ts|tests/playwright/test-helpers\.ts"
+for cmd in gh jq; do
+  if ! command -v "$cmd" &> /dev/null; then
+    echo "Error: $cmd is not installed." >&2
+    exit 1
+  fi
+done
+
+VRT_PATTERN="tests/playwright/.*\.ts$"
 OUTPUT_DIR="vrt-file-audits"
 
-# Clean and recreate the output directory
 rm -rf "$OUTPUT_DIR"
 mkdir -p "$OUTPUT_DIR"
 
-echo "🔍 Fetching open pull requests..."
 prs=$(gh pr list --state open --json number,headRefName,title)
 
-# Process each PR
 echo "$prs" | jq -c '.[]' | while read -r pr; do
     pr_num=$(echo "$pr" | jq -r '.number')
     branch=$(echo "$pr" | jq -r '.headRefName')
     title=$(echo "$pr" | jq -r '.title')
 
-    # Find changed files matching our pattern (excluding images)
     changed_files=$(gh pr diff "$pr_num" --name-only | grep -E "$VRT_PATTERN")
 
-    for file_path in $changed_files; do
-        # Create a safe filename based on the source file path
-        # e.g., tests/playwright/vrt.spec.ts -> tests-playwright-vrt-spec-ts.md
-        safe_name=$(echo "$file_path" | tr '/' '-' | tr '.' '-')
-        audit_file="$OUTPUT_DIR/${safe_name}.md"
+    if [ -n "$changed_files" ]; then
+        audit_file="$OUTPUT_DIR/pr-${pr_num}.md"
 
-        # Initialize file with header if it doesn't exist
-        if [ ! -f "$audit_file" ]; then
-            {
-                echo "# Cumulative Audit: \`$file_path\`"
-                echo "This file tracks all pending PR changes affecting this specific test asset."
-                echo ""
-                echo "#### [[TODO]] Global Feedback"
-                echo "- [ ] Reconcile conflicting \`maxDiffPixelRatio\` changes"
-                echo "- [ ] Ensure consistent masking strategy across all PRs"
-                echo ""
-                echo "---"
-            } > "$audit_file"
-        fi
-
-        # Append the PR-specific changes to this file
         {
-            echo "## PR #$pr_num: $title"
+            echo "# PR #$pr_num: $title"
             echo "**Branch:** \`$branch\`"
             echo ""
-            echo "\`\`\`diff"
-            # Use awk to extract the specific file hunk from the patch safely
-            gh pr diff "$pr_num" --patch | awk -v path="$file_path" '
-                $0 ~ "diff --git a/"path" " {hunk=1; print; next}
-                $0 ~ "diff --git a/" {hunk=0}
-                hunk {print}
-            '
-            echo "\`\`\`"
+            echo "#### [[TODO]] Global Feedback"
+            echo "- [ ] Reconcile conflicting \`maxDiffPixelRatio\` changes"
+            echo "- [ ] Ensure consistent masking strategy across all PRs"
             echo ""
             echo "---"
-        } >> "$audit_file"
+        } > "$audit_file"
+
+        for file_path in $changed_files; do
+            {
+                echo "### \`$file_path\`"
+                echo "\`\`\`diff"
+                gh pr diff "$pr_num" --patch | awk -v path="$file_path" '
+                    $0 ~ "diff --git a/"path" " {hunk=1; print; next}
+                    $0 ~ "diff --git a/" {hunk=0}
+                    hunk {print}
+                '
+                echo "\`\`\`"
+                echo ""
+            } >> "$audit_file"
+        done
         
-        echo "   ✅ Logged PR #$pr_num changes to ${safe_name}.md"
-    done
+        echo "   ✅ Logged PR #$pr_num changes to pr-${pr_num}.md"
+    fi
 done
 
 echo "🎉 File-based audit complete. View reports in /$OUTPUT_DIR"

--- a/scripts/audit-vrt-changes.sh
+++ b/scripts/audit-vrt-changes.sh
@@ -7,7 +7,7 @@ for cmd in gh jq; do
   fi
 done
 
-VRT_PATTERN="tests/playwright/.*\.ts$"
+VRT_PATTERN="tests/playwright/.*(spec\.ts|visual\.ts|test-helpers\.ts)"
 OUTPUT_DIR="vrt-file-audits"
 
 rm -rf "$OUTPUT_DIR"
@@ -36,11 +36,12 @@ echo "$prs" | jq -c '.[]' | while read -r pr; do
             echo "---"
         } > "$audit_file"
 
+        pr_diff=$(gh pr diff "$pr_num" --patch)
         for file_path in $changed_files; do
             {
                 echo "### \`$file_path\`"
                 echo "\`\`\`diff"
-                gh pr diff "$pr_num" --patch | awk -v path="$file_path" '
+                echo "$pr_diff" | awk -v path="$file_path" '
                     $0 ~ "diff --git a/"path" " {hunk=1; print; next}
                     $0 ~ "diff --git a/" {hunk=0}
                     hunk {print}

--- a/scripts/audit-vrt-changes.sh
+++ b/scripts/audit-vrt-changes.sh
@@ -20,7 +20,7 @@ echo "$prs" | jq -c '.[]' | while read -r pr; do
     branch=$(echo "$pr" | jq -r '.headRefName')
     title=$(echo "$pr" | jq -r '.title')
 
-    changed_files=$(gh pr diff "$pr_num" --name-only | grep -E "$VRT_PATTERN" | grep -v "\.png$")
+    changed_files=$(gh pr diff "$pr_num" --name-only | grep -E "$VRT_PATTERN")
 
     if [ -n "$changed_files" ]; then
         audit_file="$OUTPUT_DIR/pr-${pr_num}.md"


### PR DESCRIPTION
This PR implements architectural improvements and fixes identified in the previous audit of PR #9592. It repairs the `audit-vrt-changes.sh` script by adding necessary dependency checks, simplifying the matching logic, removing verbose comments, and refactoring output aggregation to avoid generating hundreds of files for large repositories. It also resolves a documentation duplication issue in `.github/copilot-instructions.md` by referencing the existing `.github/instructions/vrt-stability.instructions.md` file directly. No manual VRT checklists were found in `CONTRIBUTING.md`. Tests run and pass cleanly.

---
*PR created automatically by Jules for task [2189911283084012697](https://jules.google.com/task/2189911283084012697) started by @arii*