### PR TITLE
Fix DevContainer Build by Resolving Invalid jq Feature

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,8 +2,7 @@
   "name": "HRM Development Environment",
   "image": "mcr.microsoft.com/devcontainers/typescript-node:20-bullseye",
   "features": {
-    "ghcr.io/devcontainers/features/github-cli:1": {},
-    "ghcr.io/devcontainers/features/jq:1": {}
+    "ghcr.io/devcontainers/features/github-cli:1": {}
   },
   "forwardPorts": [3000, 8080, 9229],
   "postCreateCommand": "bash .devcontainer/post-create.sh",

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -3,6 +3,9 @@ set -e
 
 echo "Starting post-create setup..."
 
+echo "Installing jq..."
+sudo apt-get update && sudo apt-get install -y jq
+
 # Run the main setup script
 bash scripts/setup.sh
 


### PR DESCRIPTION
The dev container was failing to build with an error `Feature 'ghcr.io/devcontainers/features/jq:1' could not be processed.` because there is no official `jq` feature in the `devcontainers/features` namespace.

This PR removes the invalid feature declaration and updates the `post-create.sh` script to install `jq` using the standard `apt-get` package manager since the base image is Debian-based (bullseye).

---
*PR created automatically by Jules for task [15418193859462815960](https://jules.google.com/task/15418193859462815960) started by @arii*