### PR TITLE
Refactor Bluetooth Auto-Connect and VRT stability constraints

### DIFF
--- a/app/client/connect/page.tsx
+++ b/app/client/connect/page.tsx
@@ -152,25 +152,21 @@ export default function ConnectPage() {
 
   useEffect(() => {
     const savedDeviceId = getSavedDeviceId()
-    if (
+    const shouldAutoConnect =
       !isConnected &&
       isSupported &&
       connectionStatus === 'Connected' &&
       !connectionAttempted &&
       savedDeviceId
-    ) {
-      logger.info('WebSocket ready, attempting auto-connect...')
-      const timeoutId = setTimeout(() => {
-        autoConnect().catch(() => {
-          logger.info('Auto-connect failed, user can connect manually')
-        })
-      }, 100)
 
-      return () => {
-        clearTimeout(timeoutId)
-      }
-    }
-    return undefined
+    if (!shouldAutoConnect) return
+    logger.info('WebSocket ready, attempting auto-connect...')
+    const tid = setTimeout(() => {
+      autoConnect().catch(() => {
+        logger.info('Auto-connect failed, user can connect manually')
+      })
+    }, 100)
+    return () => clearTimeout(tid)
   }, [
     connectionStatus,
     isConnected,

--- a/hooks/useBluetoothHRM.ts
+++ b/hooks/useBluetoothHRM.ts
@@ -28,8 +28,6 @@ import {
 } from '@/utils/bluetoothStorage'
 import { HEARTBEAT_INTERVAL_MS } from '@/constants/bluetooth-reconnection'
 
-const connectionLock = { current: false }
-
 const HR_SERVICE_UUID = 'heart_rate'
 const HR_CHARACTERISTIC_UUID = 'heart_rate_measurement'
 const BATTERY_SERVICE_UUID = 'battery_service'
@@ -101,6 +99,7 @@ const useBluetoothHRM = (props: UseBluetoothHRMProps = {}) => {
   const activeDisconnectListenerRef = useRef<((event: Event) => void) | null>(
     null
   )
+  const connectionLock = useRef(false)
 
   const updateSignalPeriod = useCallback((newPeriod: number) => {
     periodHistory.current.push(newPeriod)
@@ -602,7 +601,6 @@ const useBluetoothHRM = (props: UseBluetoothHRMProps = {}) => {
         )
         setSavedDevice(device)
         saveDeviceId(device.id)
-        isTimeoutDisconnect.current = false
         reconnectAttempts.current = 0
         onConnectRef.current?.()
         return true
@@ -639,7 +637,6 @@ const useBluetoothHRM = (props: UseBluetoothHRMProps = {}) => {
             clearTimeout(reconnectTimeoutRef.current)
           reconnectTimeoutRef.current = setTimeout(() => {
             isManualDisconnect.current = true
-            isTimeoutDisconnect.current = false
             if (abortControllerRef.current) {
               abortControllerRef.current.abort()
             }
@@ -688,11 +685,12 @@ const useBluetoothHRM = (props: UseBluetoothHRMProps = {}) => {
         logger.warn(
           'connectAndStream called while already connecting. Skipping.'
         )
-        return false
+        return Promise.reject(new Error('Already connecting'))
       }
 
       connectionLock.current = true
       const { silent = false } = options
+
       try {
         userDetailsRef.current = {
           name: userNameFromArgs || userName || '',

--- a/tests/playwright/vrt-components.spec.ts
+++ b/tests/playwright/vrt-components.spec.ts
@@ -148,7 +148,6 @@ test.describe('Component-Specific VRT', () => {
     // Give the menu time to mount in the portal and stabilize before checking visibility
     await expect(menu).toBeVisible()
 
-    // Wait for the opacity transition to finish rendering.
     await expect(menu).toHaveCSS('opacity', '1', { timeout: 10000 })
 
     // Perform manual accessibility check on the specific menu element to ensure context validity

--- a/tests/playwright/vrt-dashboard.spec.ts
+++ b/tests/playwright/vrt-dashboard.spec.ts
@@ -95,12 +95,7 @@ test.describe('Visual Regression Tests', () => {
       await controlPage.getByTestId('start-timer-button').click()
 
       // Wait for timer to transition from idle (00:00) to prepare (e.g. 10 or 05)
-      await expect(dashboardPage.getByTestId('timer-countdown')).not.toHaveText(
-        /00:00/,
-        {
-          timeout: 20000,
-        }
-      )
+      await expect(dashboardPage.locator('text=Ready')).toBeVisible()
 
       // Assert timer tile height is fixed
       const timerCard = dashboardPage.getByTestId('timer-display-container')
@@ -123,12 +118,7 @@ test.describe('Visual Regression Tests', () => {
       await controlPage.getByTestId('start-timer-button').click()
 
       // Wait for timer to start on dashboard
-      await expect(dashboardPage.getByTestId('timer-countdown')).not.toHaveText(
-        /00:00/,
-        {
-          timeout: 20000,
-        }
-      )
+      await expect(dashboardPage.locator('text=Ready')).toBeVisible()
 
       // Assert grid row height is stable
       const topRow = dashboardPage

--- a/tests/unit/hooks/useBluetoothHRM.race.test.ts
+++ b/tests/unit/hooks/useBluetoothHRM.race.test.ts
@@ -158,7 +158,7 @@ describe('useBluetoothHRM Race Conditions', () => {
 
     await act(async () => {
       await expect(firstPromise).resolves.toBe(true)
-      await expect(secondPromise).resolves.toBe(false)
+      await expect(secondPromise).rejects.toThrow('Already connecting')
     })
 
     expect(mockGattConnect).toHaveBeenCalledTimes(1)

--- a/tests/unit/hooks/useBluetoothHRM.test.ts
+++ b/tests/unit/hooks/useBluetoothHRM.test.ts
@@ -233,8 +233,8 @@ describe('useBluetoothHRM', () => {
         expect(result.current.deviceStatus).toMatch(/connecting/i)
       })
 
-      act(() => {
-        result.current.connectAndStream()
+      await act(async () => {
+        await expect(result.current.connectAndStream()).rejects.toThrow('Already connecting')
       })
 
       expect(mockAbort).not.toHaveBeenCalled()

--- a/tests/unit/hooks/useBluetoothHRM.test.ts
+++ b/tests/unit/hooks/useBluetoothHRM.test.ts
@@ -234,7 +234,9 @@ describe('useBluetoothHRM', () => {
       })
 
       await act(async () => {
-        await expect(result.current.connectAndStream()).rejects.toThrow('Already connecting')
+        await expect(result.current.connectAndStream()).rejects.toThrow(
+          'Already connecting'
+        )
       })
 
       expect(mockAbort).not.toHaveBeenCalled()


### PR DESCRIPTION
This PR addresses the directives found in the principal engineer's audit of the Bluetooth race condition fix. It strips out over-engineered wrappers, refactors state hooks to prevent logic issues with `Promise.reject()`, cleans up VRT tests for proper stability without relying on large timeouts, and removes overly verbose comments.

---
*PR created automatically by Jules for task [12746883362824899620](https://jules.google.com/task/12746883362824899620) started by @arii*