### PR TITLE
Refactor VRT Tests to Fix Flakiness and Over-engineering

### DIFF
--- a/tests/playwright/lib/bluetooth-mocks.ts
+++ b/tests/playwright/lib/bluetooth-mocks.ts
@@ -3,6 +3,11 @@ import { Page } from '@playwright/test'
 
 export const injectBluetoothMocks = async (page: Page) => {
   await page.addInitScript(() => {
+    window.__TEST_CONTROLS__ = window.__TEST_CONTROLS__ || {
+      setHrmStatus: () => {},
+      setCustomHrmStatusMessage: () => {},
+    }
+
     // 2. Internal State for the Mock
     const _pairedDevices: MockBluetoothDevice[] = []
     let _connectedDevice: MockBluetoothDevice | null = null

--- a/tests/playwright/vrt-components.spec.ts
+++ b/tests/playwright/vrt-components.spec.ts
@@ -31,7 +31,6 @@ test.describe('Component-Specific VRT', () => {
   })
 
   test('LoadingIndicator visibility', async ({ dashboardPage }) => {
-    // Force visibility and pause animation for VRT
     await dashboardPage.evaluate(() => {
       const el = document.querySelector(
         '[data-testid="loading-indicator"]'
@@ -39,9 +38,7 @@ test.describe('Component-Specific VRT', () => {
       if (el) {
         el.style.opacity = '1'
         el.style.visibility = 'visible'
-        // Force an opaque background to prevent pixel leakage from underlying content
         el.style.backgroundColor = 'rgb(0, 0, 0)'
-        // Pause any CSS animations/transitions specifically on this element
         el.style.animationPlayState = 'paused'
         el.style.transition = 'none'
       }
@@ -49,7 +46,6 @@ test.describe('Component-Specific VRT', () => {
     const loadingIndicator = dashboardPage.getByTestId('loading-indicator')
     await expect(loadingIndicator).toBeVisible()
 
-    // Mask the animated progress circle as it's highly flaky in VRT
     const progress = loadingIndicator.getByTestId('loading-indicator-progress')
 
     await takeScreenshot(loadingIndicator, 'loading-indicator.png', {
@@ -58,7 +54,6 @@ test.describe('Component-Specific VRT', () => {
   })
 
   test('GoogleDocViewer shrunk state', async ({ dashboardPage }) => {
-    // Ensure we are in non-native mode for this test, and enable testing mode
     await dashboardPage.goto('/?native=false&testing=true')
     await waitForPageReady(dashboardPage)
 
@@ -71,7 +66,6 @@ test.describe('Component-Specific VRT', () => {
   })
 
   test('WorkoutTableHeader rendering', async ({ dashboardPage }) => {
-    // Setup network interception first
     await dashboardPage.route('/api/workout*', async (route) => {
       await route.fulfill({
         json: {
@@ -80,7 +74,6 @@ test.describe('Component-Specific VRT', () => {
       })
     })
 
-    // Ensure we are in native mode for this test, and enable testing mode
     await dashboardPage.goto('/?native=true&testing=true')
     await waitForPageReady(dashboardPage)
 
@@ -94,12 +87,8 @@ test.describe('Component-Specific VRT', () => {
     await dashboardPage.reload()
     await waitForPageReady(dashboardPage)
 
-    // Wait for the WebSocket to fully reconnect after the reload
-    // before applying mocks, otherwise the server's initial STATE_SYNC
-    // will immediately overwrite the mock.
     await waitForWebSocketConnection(dashboardPage)
 
-    // Mock Spotify state with devices to show the component naturally
     await mockSpotifyPlaybackState(dashboardPage, {
       playback: {
         is_playing: true,
@@ -147,10 +136,8 @@ test.describe('Component-Specific VRT', () => {
       .last()
     await expect(menu).toBeVisible()
 
-    // Wait for the opacity transition to finish rendering
     await expect(menu).toHaveCSS('opacity', '1')
 
-    // Perform manual accessibility check on the specific menu element to ensure context validity
     await checkAccessibility(menu)
 
     await takeScreenshot(menu, 'spotify-device-selector-menu.png', {

--- a/tests/playwright/vrt-connect-page.spec.ts
+++ b/tests/playwright/vrt-connect-page.spec.ts
@@ -10,14 +10,6 @@ test.describe('Visual Regression Tests for /client/connect Page', () => {
   test.beforeEach(async ({ connectPage }) => {
     await injectBluetoothMocks(connectPage)
 
-    // Setup window.__TEST_CONTROLS__ before evaluating the function
-    await connectPage.addInitScript(() => {
-      window.__TEST_CONTROLS__ = window.__TEST_CONTROLS__ || {
-        setHrmStatus: () => {},
-        setCustomHrmStatusMessage: () => {},
-      }
-    })
-
     await connectPage.goto('/client/connect?testing=true')
     await waitForPageReady(connectPage, { timeout: VRT_TIMEOUTS.STANDARD })
     await connectPage.getByLabel('Your Name').fill('VRT Runner')

--- a/tests/playwright/vrt-dashboard.spec.ts
+++ b/tests/playwright/vrt-dashboard.spec.ts
@@ -4,7 +4,6 @@ import {
   getDynamicContentMasks,
   setupVisualRegressionTest,
   resetServerState,
-  mockLoggedInSession,
 } from './lib'
 import { takeScreenshot, assertFixedDimensions } from './lib/visual'
 import { waitForPageReady } from './lib/waits'
@@ -46,8 +45,6 @@ test.describe('Visual Regression Tests', () => {
       'https://sdk.scdn.co/spotify-player.js',
       (route) => route.abort()
     )
-
-    await mockLoggedInSession(context)
 
     await resetServerState(request)
 


### PR DESCRIPTION
This commit addresses PR review feedback to repair the VRT suite.

1. **Verbose comments**: Removed redundant comments explaining "how" code works in `vrt-components.spec.ts` to favor self-documenting code.
2. **Over-engineering**: Centralized the `__TEST_CONTROLS__` window mock setup in the `injectBluetoothMocks` utility, removing duplicate manual setups in the test files.
3. **Duplicate Hooks**: Removed an unnecessary `mockLoggedInSession` call in `vrt-dashboard.spec.ts` that was risking conflict with the existing `setupVisualRegressionTest` mocks.

---
*PR created automatically by Jules for task [17697096399863628832](https://jules.google.com/task/17697096399863628832) started by @arii*