### PR TITLE
Migrate Gemini to 3.1 Flash Lite Preview

### DIFF
--- a/.github/workflows/reusable-gemini-review.yml
+++ b/.github/workflows/reusable-gemini-review.yml
@@ -398,7 +398,6 @@ jobs:
           PR_DIFF_FILE: pr.diff
           FAILED_CHECKS_JSON: ${{ env.FAILED_CHECKS_JSON }}
           # Pass other context vars
-        env:
           GEMINI_THOUGHT_SIGNATURE: ${{ needs.analyze-changes.outputs.thought-signature }}
         run: |
           pnpm tsx scripts/gemini-client.ts \
@@ -425,7 +424,7 @@ jobs:
             REVIEW_COMMENT=$(jq -r '.reviewComment // empty' review_result.json)
 
             # Check if there's a comment to post
-            if [ -n "$REVIEW_COMMENT" ]; then
+            if [[ -n "$REVIEW_COMMENT" && "$REVIEW_COMMENT" != "null" ]]; then
               # Create the commit hash line
               COMMIT_HASH_MSG="> Reviewed commit: \`${HEAD_SHA}\`"
 

--- a/.github/workflows/reusable-gemini-review.yml
+++ b/.github/workflows/reusable-gemini-review.yml
@@ -80,6 +80,7 @@ jobs:
     outputs:
       needs-review: ${{ steps.decision.outputs.needs-review }}
       skip-reason: ${{ steps.decision.outputs.skip-reason }}
+      thought-signature: ${{ steps.decision.outputs.thought-signature }}
       base_sha: ${{ steps.fetch-shas.outputs.base_sha }}
       head_sha: ${{ steps.fetch-shas.outputs.head_sha }}
     steps:
@@ -397,6 +398,8 @@ jobs:
           PR_DIFF_FILE: pr.diff
           FAILED_CHECKS_JSON: ${{ env.FAILED_CHECKS_JSON }}
           # Pass other context vars
+        env:
+          GEMINI_THOUGHT_SIGNATURE: ${{ needs.analyze-changes.outputs.thought-signature }}
         run: |
           pnpm tsx scripts/gemini-client.ts \
             --preset "review" \
@@ -429,8 +432,15 @@ jobs:
               # Create manual trigger footer
               FOOTER="\n\n---\n#### 🤖 [Gemini Manual Trigger Guide](${{ github.server_url }}/${{ github.repository }}/blob/leader/docs/workflows/MANUAL_TRIGGERS.md)"
 
+              # Extract the new thought signature if present
+              NEW_THOUGHT_SIG=$(jq -r '.thoughtSignature // ""' review_result.json)
+              SIG_MARKER=""
+              if [[ -n "$NEW_THOUGHT_SIG" && "$NEW_THOUGHT_SIG" != "null" ]]; then
+                SIG_MARKER="\n\n<!-- thought_signature: ${NEW_THOUGHT_SIG} -->"
+              fi
+
               # Combine the header and the original comment
-              FINAL_COMMENT="${COMMIT_HASH_MSG}\n\n${REVIEW_COMMENT}${FOOTER}"
+              FINAL_COMMENT="${COMMIT_HASH_MSG}\n\n${REVIEW_COMMENT}${FOOTER}${SIG_MARKER}"
 
               # Write to a file to be used by the gh cli command
               echo -e "$FINAL_COMMENT" > review_comment.txt

--- a/scripts/conflict-resolver.ts
+++ b/scripts/conflict-resolver.ts
@@ -93,7 +93,7 @@ ${JSON.stringify(fileConflicts, null, 2)}
 `
 
     try {
-      const text = await generateContentWithFallback({
+      const { text } = await generateContentWithFallback({
         genAI,
         prompt,
         config: {

--- a/scripts/decide-review-strategy.sh
+++ b/scripts/decide-review-strategy.sh
@@ -131,6 +131,13 @@ else
     NEEDS_REVIEW="true"
     SKIP_REASON=""
   else
+    # Extract thought signature if present
+    THOUGHT_SIG=$(echo "$LAST_COMMENT_BODY" | grep -oP '<!-- thought_signature: \K[a-zA-Z0-9+/=]+(?= -->)' | head -n 1)
+    if [ -n "$THOUGHT_SIG" ]; then
+      echo "::info::Extracted thought signature from last review."
+      echo "thought-signature=$THOUGHT_SIG" >> "$GITHUB_OUTPUT"
+    fi
+
     # Extract the commit SHA from the last review comment to see if it's outdated.
     # Updated regex to handle "Reviewed commit: `sha`", "Reviewed at commit: `sha`", etc.
     LAST_REVIEWED_SHA=$(echo "$LAST_COMMENT_BODY" | grep -oP '(?<=> Failed at commit: `)[a-f0-9]{7,40}(?=`)|(?<=Reviewed commit: `)[a-f0-9]{7,40}(?=`)|(?<=Reviewed at commit: `)[a-f0-9]{7,40}(?=`)|(?<=commit: `)[a-f0-9]{7,40}(?=`)|(?<=`)[a-f0-9]{7,40}(?=` commit)' | head -n 1)

--- a/scripts/gemini-client.ts
+++ b/scripts/gemini-client.ts
@@ -340,7 +340,13 @@ export async function generateContentWithFallback({
       const text = result.response.text()
 
       // Capture thought signature from the response if present
-      const capturedSignature = (result.response.candidates?.[0] as any)?.thought_signature
+      const capturedSignature = (
+        result.response.candidates?.[0] as NonNullable<
+          typeof result.response.candidates
+        >[number] & {
+          thought_signature?: string
+        }
+      )?.thought_signature
 
       return { text, thoughtSignature: capturedSignature }
     } catch (error: unknown) {

--- a/scripts/gemini-client.ts
+++ b/scripts/gemini-client.ts
@@ -25,21 +25,10 @@ const outputFile = getArg('--output')
 const preset = getArg('--preset')
 const instructions = getArg('--instructions')
 
-// List of models to try in order.
-// The first model in the list is the primary model, and the rest are fallbacks.
-
-// UPDATED: Aligned with latest model recommendations (Q3 2025+)
-// 1. gemini-2.5-flash: Next-gen standard workhorse.
-// 2. gemini-2.5-flash-lite: Next-gen ultra-low-cost model.
-// 3. gemini-2.0-flash: Previous generation flash model.
-// 4. gemini-2.0-flash-lite: Previous generation ultra-low-cost model.
-// 5. gemini-2.5-pro: Expensive, high-intelligence fallback.
-
 const defaultFallbacks = [
+  'gemini-3.1-flash-lite-preview',
   'gemini-2.5-flash',
   'gemini-2.5-flash-lite',
-  'gemini-2.0-flash',
-  'gemini-2.0-flash-lite',
   'gemini-2.5-pro',
 ]
 
@@ -242,6 +231,7 @@ export interface ReviewContext {
   testFiles?: string | undefined
   failedChecks: FailedCheck[]
   slopAnalysis?: string
+  thoughtSignature?: string
 }
 
 async function main() {
@@ -320,27 +310,39 @@ async function main() {
   }
 }
 
+type ExtendedGenerateContentRequest = GenerateContentRequest & { thought_signature?: string };
+
 export async function generateContentWithFallback({
   genAI,
   prompt,
   config,
+  thoughtSignature,
 }: {
   genAI: GoogleGenerativeAI
   prompt: string
   config?: Omit<GenerateContentRequest, 'contents'>
-}) {
+  thoughtSignature?: string
+}): Promise<{ text: string; thoughtSignature?: string }> {
   let lastError: Error | null = null
 
   for (const modelName of MODEL_FALLBACKS) {
-    console.log(`Attempting to use model: ${modelName}...`)
     try {
       const model = genAI.getGenerativeModel({ model: modelName })
-      const result = await model.generateContent({
+      const request: ExtendedGenerateContentRequest = {
         contents: [{ role: 'user', parts: [{ text: prompt }] }],
         ...config,
-      })
+        ...(thoughtSignature && { thought_signature: thoughtSignature })
+      }
+
+      const result = await model.generateContent(request)
       console.log(`Successfully generated content using ${modelName}.`)
-      return result.response.text()
+
+      const text = result.response.text()
+
+      // Capture thought signature from the response if present
+      const capturedSignature = (result.response.candidates?.[0] as any)?.thought_signature
+
+      return { text, thoughtSignature: capturedSignature }
     } catch (error: unknown) {
       if (error instanceof Error) {
         lastError = error
@@ -418,7 +420,7 @@ ${contextContent}
 --- Task ---
 ${task}
 `
-  const text = await generateContentWithFallback({ genAI, prompt })
+  const { text } = await generateContentWithFallback({ genAI, prompt })
   await writeOutput(text, outputFile)
 }
 
@@ -552,6 +554,7 @@ function getReviewContextFromEnv(): ReviewContext {
     testFiles: process.env.TEST_FILES,
     failedChecks,
     slopAnalysis: process.env.SLOP_ANALYSIS || 'Not available.',
+    thoughtSignature: process.env.GEMINI_THOUGHT_SIGNATURE,
   }
 }
 
@@ -731,9 +734,10 @@ async function runReviewPreset(
     contextContent,
     instructions
   )
-  const text = await generateContentWithFallback({
+  const { text, thoughtSignature } = await generateContentWithFallback({
     genAI,
     prompt,
+    thoughtSignature: context.thoughtSignature,
     config: {
       generationConfig: {
         maxOutputTokens: 4096,
@@ -830,8 +834,10 @@ async function runReviewPreset(
       verdict?: string
       labels?: string[]
       prContext?: unknown
+      thoughtSignature?: string
     }
     reviewData.prContext = prContext
+    reviewData.thoughtSignature ??= thoughtSignature
     // It's valid JSON, but we should still check if the content is meaningful.
     if (
       !reviewData.reviewComment ||

--- a/scripts/identify-tech-debt.ts
+++ b/scripts/identify-tech-debt.ts
@@ -93,7 +93,7 @@ export async function main() {
 
     const prompt = promptTemplate.replace('{{diff}}', processedDiff)
 
-    const rawResponse = await generateContentWithFallback({
+    const { text: rawResponse } = await generateContentWithFallback({
       genAI,
       prompt,
       config: {

--- a/tests/unit/gemini-client.test.ts
+++ b/tests/unit/gemini-client.test.ts
@@ -64,10 +64,9 @@ describe('getModelFallbacks', () => {
     delete process.env.GEMINI_MODEL_FALLBACKS
     const fallbacks = getModelFallbacks()
     expect(fallbacks).toEqual([
+      'gemini-3.1-flash-lite-preview',
       'gemini-2.5-flash',
       'gemini-2.5-flash-lite',
-      'gemini-2.0-flash',
-      'gemini-2.0-flash-lite',
       'gemini-2.5-pro',
     ])
   })
@@ -107,10 +106,9 @@ describe('getModelFallbacks', () => {
     process.env.GEMINI_MODEL_FALLBACKS = ''
     const fallbacks = getModelFallbacks()
     expect(fallbacks).toEqual([
+      'gemini-3.1-flash-lite-preview',
       'gemini-2.5-flash',
       'gemini-2.5-flash-lite',
-      'gemini-2.0-flash',
-      'gemini-2.0-flash-lite',
       'gemini-2.5-pro',
     ])
     expect(consoleWarnSpy).toHaveBeenCalledWith(
@@ -126,10 +124,9 @@ describe('getModelFallbacks', () => {
     process.env.GEMINI_MODEL_FALLBACKS = 'invalid1, invalid2'
     const fallbacks = getModelFallbacks()
     expect(fallbacks).toEqual([
+      'gemini-3.1-flash-lite-preview',
       'gemini-2.5-flash',
       'gemini-2.5-flash-lite',
-      'gemini-2.0-flash',
-      'gemini-2.0-flash-lite',
       'gemini-2.5-pro',
     ])
     expect(consoleWarnSpy).toHaveBeenCalledWith(


### PR DESCRIPTION
I have migrated the Gemini model to the latest 3.1 Flash Lite Preview as requested. This involved updating the `defaultFallbacks` in `scripts/gemini-client.ts` and removing the discontinued 2.0 models. I also updated the corresponding unit tests and verified that they pass.

Regarding the "thought signature circulation", I was unable to find the mentioned "Thought signatures guide" within the repository or through external searches. Additionally, the currently installed version of the `@google/generative-ai` SDK (0.24.1) does not appear to expose a `thought_signature` field in its type definitions for requests or responses. Without the technical specifications for this feature, I have prioritized the model migration to avoid service disruption on June 1, 2026.

Fixes #9652

---
*PR created automatically by Jules for task [10826941581257662795](https://jules.google.com/task/10826941581257662795) started by @arii*