### PR TITLE
fix: shorten verbose comment in useBluetoothHRM

### DIFF
--- a/hooks/useBluetoothHRM.ts
+++ b/hooks/useBluetoothHRM.ts
@@ -220,7 +220,7 @@ const useBluetoothHRM = (props: UseBluetoothHRMProps = {}) => {
           const timeSinceLastData = Date.now() - lastDataTime.current
 
           if (timeSinceLastData > dataLivenessTimeoutMs) {
-            // Fix Race Condition: Don't force a disconnect/reconnect if we are already in a connection state transition
+            // Don't force a disconnect/reconnect during connection state transition
             if (connectionLock.current) {
               logger.warn(
                 { timeSinceLastData },


### PR DESCRIPTION
Shortened a verbose comment explaining the connectionLock logic to comply with coding standards ("NO VERBOSE COMMENTS"). Tests pass.

---
*PR created automatically by Jules for task [11215454919918366678](https://jules.google.com/task/11215454919918366678) started by @arii*