### PR TITLE
Repair PR #9547: Refactor Spotify Track Selection

### DIFF
--- a/app/api/spotify/playlists/[playlistId]/tracks/route.ts
+++ b/app/api/spotify/playlists/[playlistId]/tracks/route.ts
@@ -104,7 +104,6 @@ async function getPlaylistTracks(
           images: track.album.images,
         },
         duration_ms: track.duration_ms,
-        duration: track.duration_ms, // Legacy fallback
         uri: track.uri,
       }
     })

--- a/tests/unit/app/api/spotify/playlists/[playlistId]/tracks/route.test.ts
+++ b/tests/unit/app/api/spotify/playlists/[playlistId]/tracks/route.test.ts
@@ -59,7 +59,6 @@ describe('GET /api/spotify/playlists/[playlistId]/tracks', () => {
         name: 'Album 1',
       },
       duration_ms: 180000,
-      duration: 180000,
       uri: 'spotify:track:t1',
     })
   })

--- a/utils/socketManager.ts
+++ b/utils/socketManager.ts
@@ -12,7 +12,7 @@ import {
   ExtWebSocket,
   HrmInputMessage,
 } from '../types/websocket'
-import { HrmStreamData, SpotifyCommandParameters } from '../types/core'
+import { HrmStreamData } from '../types/core'
 import {
   MAX_CALORIE_JUMP_PER_UPDATE,
   MAX_INITIAL_CALORIES,
@@ -426,22 +426,9 @@ const handleIncomingMessage = (
         )
 
         const spotifyService = services.spotifyService
-        const spotifyCommandParams: SpotifyCommandParameters = {}
-        if (commandMsg.deviceId)
-          spotifyCommandParams.deviceId = commandMsg.deviceId
-        if (commandMsg.volume !== undefined)
-          spotifyCommandParams.volume = commandMsg.volume
-        if (commandMsg.playlistUri)
-          spotifyCommandParams.playlistUri = commandMsg.playlistUri
-        if (commandMsg.contextUri)
-          spotifyCommandParams.contextUri = commandMsg.contextUri
-        if (commandMsg.uri) spotifyCommandParams.uri = commandMsg.uri
-        if (commandMsg.offset) {
-          spotifyCommandParams.offset =
-            commandMsg.offset as SpotifyCommandParameters['offset']
-        }
+        const { type: _type, command, ...spotifyCommandParams } = commandMsg
 
-        spotifyService.handleCommand(commandMsg.command, spotifyCommandParams)
+        spotifyService.handleCommand(command, spotifyCommandParams)
         break
       }
       default: {


### PR DESCRIPTION
Repairs and polishes the feature branch. Fixes the Spotify track selection implementation to ensure it meets architecture directives, minimizes code complexity via object rest destructuring, and eliminates legacy duplicate properties.

---
*PR created automatically by Jules for task [3580716433680822571](https://jules.google.com/task/3580716433680822571) started by @arii*