### PR TITLE
Fixes typing issues and null check in github workflow

### DIFF
--- a/.github/workflows/reusable-gemini-review.yml
+++ b/.github/workflows/reusable-gemini-review.yml
@@ -398,7 +398,6 @@ jobs:
           PR_DIFF_FILE: pr.diff
           FAILED_CHECKS_JSON: ${{ env.FAILED_CHECKS_JSON }}
           # Pass other context vars
-        env:
           GEMINI_THOUGHT_SIGNATURE: ${{ needs.analyze-changes.outputs.thought-signature }}
         run: |
           pnpm tsx scripts/gemini-client.ts \

--- a/.github/workflows/reusable-gemini-review.yml
+++ b/.github/workflows/reusable-gemini-review.yml
@@ -425,7 +425,7 @@ jobs:
             REVIEW_COMMENT=$(jq -r '.reviewComment // empty' review_result.json)
 
             # Check if there's a comment to post
-            if [ -n "$REVIEW_COMMENT" ]; then
+            if [[ -n "$REVIEW_COMMENT" && "$REVIEW_COMMENT" != "null" ]]; then
               # Create the commit hash line
               COMMIT_HASH_MSG="> Reviewed commit: \`${HEAD_SHA}\`"
 

--- a/scripts/gemini-client.ts
+++ b/scripts/gemini-client.ts
@@ -340,7 +340,13 @@ export async function generateContentWithFallback({
       const text = result.response.text()
 
       // Capture thought signature from the response if present
-      const capturedSignature = (result.response.candidates?.[0] as any)?.thought_signature
+      const capturedSignature = (
+        result.response.candidates?.[0] as NonNullable<
+          typeof result.response.candidates
+        >[number] & {
+          thought_signature?: string
+        }
+      )?.thought_signature
 
       return { text, thoughtSignature: capturedSignature }
     } catch (error: unknown) {


### PR DESCRIPTION
- Fixed any cast with proper typescript intersection type in `scripts/gemini-client.ts`.
- Replaced a `[ -n "$REVIEW_COMMENT" ]` with an explicit check for the literal string "null" `[[ -n "$REVIEW_COMMENT" && "$REVIEW_COMMENT" != "null" ]]` in `.github/workflows/reusable-gemini-review.yml`.

---
*PR created automatically by Jules for task [2904124573259627833](https://jules.google.com/task/2904124573259627833) started by @arii*