### PR TITLE
refactor: polish SpotifyControls PR by removing verbose comments

### DIFF
--- a/app/client/control/components/SpotifyControls.tsx
+++ b/app/client/control/components/SpotifyControls.tsx
@@ -113,13 +113,10 @@ const SpotifyControls = () => {
     const activeDevice = devices.find((d) => d.is_active)
     const activeId = activeDevice?.id
 
-    // Helper: determine if device should be updated to activeId
     const shouldUpdateToActive = () => {
-      // Initial sync or active device changed externally
       if (!prevActiveIdRef.current || activeId !== prevActiveIdRef.current) {
         return Boolean(activeId)
       }
-      // Selected device no longer exists or no device selected
       const selectedStillExists = devices.some((d) => d.id === selectedDeviceId)
       return (!selectedDeviceId || !selectedStillExists) && Boolean(activeId)
     }
@@ -129,7 +126,6 @@ const SpotifyControls = () => {
     }
     prevActiveIdRef.current = activeId
 
-    // Sync Volume (if not dragging and not within grace period after send)
     // We rely on the server as the source of truth for volume, but use a grace period
     // to prevent local sliders from "jumping" while the user is actively adjusting them.
     const playbackVolume = spotifyData.playback.volume_percent
@@ -149,7 +145,6 @@ const SpotifyControls = () => {
       return
     }
 
-    // Clear pending flag after grace period
     if (
       hasPendingSendRef.current &&
       timeSinceLastVolumeSend >= VOLUME_SYNC_GRACE_PERIOD_MS
@@ -164,9 +159,8 @@ const SpotifyControls = () => {
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [devices]) // Rely on devices update to trigger sync
+  }, [devices])
 
-  // Auto-select HRM Web Player if no active device is available
   useEffect(() => {
     if (
       devices.length > 0 &&
@@ -239,7 +233,6 @@ const SpotifyControls = () => {
       setVolume(val)
       if (connectionStatus !== 'Connected') {
         const now = Date.now()
-        // Throttle warning to once every 3 seconds to avoid spam during sliding
         if (now - lastWarningTimeRef.current > 3000) {
           showWarning('Changes not saved: Offline')
           lastWarningTimeRef.current = now
@@ -254,7 +247,6 @@ const SpotifyControls = () => {
       if (connectionStatus !== 'Connected') return
       const targetDeviceId = resolveTargetDeviceId()
 
-      // Prevent sending volume command if no device is targeted
       if (!targetDeviceId) return
 
       const sanitized = clampVolume(value)


### PR DESCRIPTION
This PR repairs and polishes the SpotifyControls component in PR #9549 according to the directives. Specifically, it strips out verbose inline comments that simply narrate what the code is doing ("how"), while preserving the underlying functionality and crucial comments that explain the business logic reasoning ("why", e.g., avoiding slider snap-back with a grace period). Tests have been run to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [15929287848476389414](https://jules.google.com/task/15929287848476389414) started by @arii*