### PR TITLE
Support Playwright Snapshots in Conflict Resolver

### DIFF
--- a/.github/conflict-resolver.yml
+++ b/.github/conflict-resolver.yml
@@ -16,3 +16,7 @@ rules:
     strategy: 'ours'
   - paths: '*.generated.js'
     strategy: 'ours'
+
+  # For Playwright VRT snapshots, prefer the incoming version from the feature branch
+  - paths: '**/*.spec.ts-snapshots/*.png'
+    strategy: 'theirs'


### PR DESCRIPTION
This change updates the `.github/conflict-resolver.yml` configuration to handle conflicts in Playwright visual regression snapshots. By setting the strategy to `theirs` for files matching `**/*.spec.ts-snapshots/*.png`, the conflict resolver will now automatically accept the incoming version from the feature branch, which is the desired behavior for UI updates. This prevents manual intervention and workflow failures when binary image files are modified in both branches.

Fixes #9687

---
*PR created automatically by Jules for task [3969048629015505026](https://jules.google.com/task/3969048629015505026) started by @arii*