### PR TITLE
ci: support VRT snapshots in conflict resolver and fix 403 errors

### DIFF
--- a/.github/conflict-resolver.yml
+++ b/.github/conflict-resolver.yml
@@ -16,3 +16,7 @@ rules:
     strategy: 'ours'
   - paths: '*.generated.js'
     strategy: 'ours'
+
+  # For Playwright VRT snapshots, prefer the incoming version from the feature branch
+  - paths: '**/*.spec.ts-snapshots/*.png'
+    strategy: 'theirs'

--- a/.github/workflows/conflict-resolver.yml
+++ b/.github/workflows/conflict-resolver.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           ref: ${{ env.SOURCE }}
           fetch-depth: 0
-          token: ${{ secrets.ARI_PAT || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT_TOKEN || secrets.ARI_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Validate branches
         id: validate_branches
@@ -118,7 +118,7 @@ jobs:
       - name: Trigger Gemini Orchestrator
         if: steps.validate_branches.outputs.skipped != 'true' && steps.resolve.outputs.unresolved-files == '' && env.PR_NUMBER && env.PR_NUMBER != '0'
         env:
-          GH_TOKEN: ${{ secrets.ARI_PAT || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PAT_TOKEN || secrets.ARI_PAT || secrets.GITHUB_TOKEN }}
           HEAD_SHA: ${{ steps.commit_push.outputs.resolved_sha }}
           BASE_SHA: ${{ steps.validate_branches.outputs.base_sha }}
         run: |


### PR DESCRIPTION
- Updated `.github/conflict-resolver.yml` to include a strategy for Playwright snapshots (`**/*.spec.ts-snapshots/*.png`) using 'theirs'.
- Updated `.github/workflows/conflict-resolver.yml` to use a more robust token fallback (`PAT_TOKEN || ARI_PAT || GITHUB_TOKEN`) for `actions/checkout` and `GH_TOKEN` to resolve 403 Permission Denied errors during git push operations.

## Description

Please include a summary of the change and which issue is fixed.

Fixes # (issue)

## Change Type

- 🐛 Bug fix (non-breaking change fixing an issue)
- ✨ New feature (non-breaking change adding functionality)
- 💥 Breaking change (fix/feature causing existing functionality to break)
- 🏗️ Refactoring (code change that neither fixes bug nor adds feature)
- 📚 Documentation (changes only affecting documentation)
- 🎨 Styling (changes that do not affect functionality)

## Related Issues

Closes #(issue_number)
