### PR TITLE
ci: support VRT snapshots and fix 403/ambiguous workflow errors

### DIFF
--- a/.github/conflict-resolver.yml
+++ b/.github/conflict-resolver.yml
@@ -16,3 +16,7 @@ rules:
     strategy: 'ours'
   - paths: '*.generated.js'
     strategy: 'ours'
+
+  # For Playwright VRT snapshots, prefer the incoming version from the feature branch
+  - paths: '**/*.spec.ts-snapshots/*.png'
+    strategy: 'theirs'

--- a/.github/workflows/conflict-resolver.yml
+++ b/.github/workflows/conflict-resolver.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           ref: ${{ env.SOURCE }}
           fetch-depth: 0
-          token: ${{ secrets.ARI_PAT || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT_TOKEN || secrets.ARI_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Validate branches
         id: validate_branches
@@ -118,11 +118,11 @@ jobs:
       - name: Trigger Gemini Orchestrator
         if: steps.validate_branches.outputs.skipped != 'true' && steps.resolve.outputs.unresolved-files == '' && env.PR_NUMBER && env.PR_NUMBER != '0'
         env:
-          GH_TOKEN: ${{ secrets.ARI_PAT || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PAT_TOKEN || secrets.ARI_PAT || secrets.GITHUB_TOKEN }}
           HEAD_SHA: ${{ steps.commit_push.outputs.resolved_sha }}
           BASE_SHA: ${{ steps.validate_branches.outputs.base_sha }}
         run: |
-          gh workflow run "Gemini Orchestrator" --ref "$SOURCE" -f pr_number="$PR_NUMBER" -f base_ref="$BASE_SHA" -f head_ref="$HEAD_SHA" -f base_branch="$TARGET"
+          gh workflow run "pr-orchestrator.yml" --ref "$SOURCE" -f pr_number="$PR_NUMBER" -f base_ref="$BASE_SHA" -f head_ref="$HEAD_SHA" -f base_branch="$TARGET"
 
       - name: Update comment on success
         if: steps.validate_branches.outputs.skipped != 'true' && success() && steps.resolve.outputs.unresolved-files == '' && env.PR_NUMBER && env.PR_NUMBER != '0'


### PR DESCRIPTION
- Added strategy to `.github/conflict-resolver.yml` to automatically resolve Playwright snapshots (`**/*.spec.ts-snapshots/*.png`) using 'theirs'.
- Updated `.github/workflows/conflict-resolver.yml` with:
    - Token fallback sequence `PAT_TOKEN || ARI_PAT || GITHUB_TOKEN` to resolve 403 Forbidden errors when pushing to protected branches.
    - Switched `gh workflow run` to use `pr-orchestrator.yml` filename instead of workflow name to avoid 'could not resolve to unique workflow' errors.

## Description

Please include a summary of the change and which issue is fixed.

Fixes # (issue)

## Change Type

- 🐛 Bug fix (non-breaking change fixing an issue)
- ✨ New feature (non-breaking change adding functionality)
- 💥 Breaking change (fix/feature causing existing functionality to break)
- 🏗️ Refactoring (code change that neither fixes bug nor adds feature)
- 📚 Documentation (changes only affecting documentation)
- 🎨 Styling (changes that do not affect functionality)

## Related Issues

Closes #(issue_number)
